### PR TITLE
KOGITO-684 Make icon button for parent-child navigation

### DIFF
--- a/packages/management-console/src/components/Organisms/ProcessDetails/ProcessDetails.tsx
+++ b/packages/management-console/src/components/Organisms/ProcessDetails/ProcessDetails.tsx
@@ -8,10 +8,12 @@ import {
   FormGroup,
   Text,
   TextVariants,
-  Title
+  Title,
+  Tooltip
 } from '@patternfly/react-core';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { LevelDownAltIcon, LevelUpAltIcon } from '@patternfly/react-icons';
 
 const ProcessDetails = ({ loading, data }) => {
   return (
@@ -73,18 +75,23 @@ const ProcessDetails = ({ loading, data }) => {
           </FormGroup>
           {data.ProcessInstances[0].parentProcessInstanceId ? (
             <FormGroup label="Parent Process" fieldId="parent">
-              <Text component={TextVariants.p}>
-                <Link
-                  to={
-                    '/ProcessInstances/' +
-                    data.ProcessInstances[0].parentProcessInstanceId
-                  }
+              <div>
+                <Tooltip
+                  content={data.ProcessInstances[0].parentProcessInstanceId}
                 >
-                  <Button variant="secondary">
+                  <Button
+                    component="a"
+                    href={
+                      '/ProcessInstances/' +
+                      data.ProcessInstances[0].parentProcessInstanceId
+                    }
+                    variant="link"
+                    icon={<LevelUpAltIcon />}
+                  >
                     {data.ProcessInstances[0].parentProcessInstanceId}
                   </Button>
-                </Link>
-              </Text>
+                </Tooltip>
+              </div>
             </FormGroup>
           ) : (
             ''
@@ -93,15 +100,19 @@ const ProcessDetails = ({ loading, data }) => {
             <FormGroup label="Sub Processes" fieldId="parent">
               {data.ProcessInstances[0].childProcessInstanceId.map(
                 (child, index) => (
-                  <Text
-                    component={TextVariants.p}
-                    key={child}
-                    style={{ marginTop: '5px' }}
-                  >
-                    <Link to={'/ProcessInstances/' + child}>
-                      <Button variant="secondary">{child}</Button>
-                    </Link>
-                  </Text>
+                  <div key={child}>
+                    <Tooltip content={child}>
+                      <Button
+                        component="a"
+                        href={'/ProcessInstances/' + child}
+                        key={child}
+                        variant="link"
+                        icon={<LevelDownAltIcon />}
+                      >
+                        {child}
+                      </Button>
+                    </Tooltip>
+                  </div>
                 )
               )}
             </FormGroup>

--- a/packages/management-console/src/components/Organisms/ProcessDetails/tests/__snapshots__/ProcessDetails.test.tsx.snap
+++ b/packages/management-console/src/components/Organisms/ProcessDetails/tests/__snapshots__/ProcessDetails.test.tsx.snap
@@ -78,19 +78,55 @@ exports[`Process Details component Snapshot tests 1`] = `
         fieldId="parent"
         label="Parent Process"
       >
-        <Text
-          component="p"
-        >
-          <Link
-            to="/ProcessInstances/e4448857-fa0c-403b-ad69-f0a353458b9d"
+        <div>
+          <Tooltip
+            appendTo={[Function]}
+            aria="describedby"
+            boundary="window"
+            className=""
+            content="e4448857-fa0c-403b-ad69-f0a353458b9d"
+            distance={15}
+            enableFlip={true}
+            entryDelay={500}
+            exitDelay={500}
+            flipBehavior={
+              Array [
+                "top",
+                "right",
+                "bottom",
+                "left",
+                "top",
+                "right",
+                "bottom",
+              ]
+            }
+            id=""
+            isAppLauncher={false}
+            isContentLeftAligned={false}
+            isVisible={false}
+            maxWidth="18.75rem"
+            position="top"
+            tippyProps={Object {}}
+            trigger="mouseenter focus"
+            zIndex={9999}
           >
             <Component
-              variant="secondary"
+              component="a"
+              href="/ProcessInstances/e4448857-fa0c-403b-ad69-f0a353458b9d"
+              icon={
+                <LevelUpAltIcon
+                  color="currentColor"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
+                />
+              }
+              variant="link"
             >
               e4448857-fa0c-403b-ad69-f0a353458b9d
             </Component>
-          </Link>
-        </Text>
+          </Tooltip>
+        </div>
       </FormGroup>
     </Form>
   </CardBody>


### PR DESCRIPTION
This changes the parent/sub process instance buttons to icon buttons with 2 different icons.
https://issues.redhat.com/browse/KOGITO-684
NOTE: I've put in the tooltip intended for displaying the parent or child's name, but I don't know if this information is available. @AjayJagan @cristianonicolai can you let me know and/or whether it's something I can add here easily or if someone else will need to do some work to show it?