### PR TITLE
KOGITO-1313: Override netty version to avoid BufferOverflow in infinispan client

### DIFF
--- a/data-index/data-index-service/pom.xml
+++ b/data-index/data-index-service/pom.xml
@@ -153,7 +153,8 @@
           </excludes>
           <systemPropertyVariables>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-            <infinispan.version>${version.org.infinispan.image}</infinispan.version>
+            <infinispan.version>${version.org.infinispan}</infinispan.version>
+            <infinispan.image.version>${version.org.infinispan.image}</infinispan.image.version>
             <keycloak.version>${version.org.keycloak.image}</keycloak.version>
           </systemPropertyVariables>
         </configuration>

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/InfinispanServerTestResource.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/InfinispanServerTestResource.java
@@ -29,14 +29,14 @@ import org.testcontainers.containers.wait.strategy.Wait;
 
 public class InfinispanServerTestResource implements QuarkusTestResourceLifecycleManager {
 
-    private static final String INFINISPAN_VERSION = System.getProperty("infinispan.version");
+    private static final String INFINISPAN_VERSION = System.getProperty("infinispan.image.version");
     private static final Logger LOGGER = LoggerFactory.getLogger(InfinispanServerTestResource.class);
     private GenericContainer infinispan;
 
     @Override
     public Map<String, String> start() {
         if (INFINISPAN_VERSION == null) {
-            throw new RuntimeException("Please define a valid Infinispan image version in system property infinispan.version");
+            throw new RuntimeException("Please define a valid Infinispan image version in system property infinispan.image.version");
         }
         LOGGER.info("Using Infinispan image version: {}", INFINISPAN_VERSION);
         infinispan = new FixedHostPortGenericContainer("quay.io/infinispan/server:" + INFINISPAN_VERSION)

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/service/NativeIndexingServiceIT.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/service/NativeIndexingServiceIT.java
@@ -16,9 +16,9 @@
 
 package org.kie.kogito.index.service;
 
-import io.quarkus.test.junit.SubstrateTest;
+import io.quarkus.test.junit.NativeImageTest;
 
-@SubstrateTest
+@NativeImageTest
 public class NativeIndexingServiceIT extends IndexingServiceTest {
 
     // Execute the same tests but in native mode.


### PR DESCRIPTION
depends on https://github.com/kiegroup/kogito-runtimes/pull/346