### PR TITLE
KOGITO-1299: 0.9.x-added fallback UI when server unavailable

### DIFF
--- a/management-console/src/main/java/org/kie/kogito/mgmt/VertxRouter.java
+++ b/management-console/src/main/java/org/kie/kogito/mgmt/VertxRouter.java
@@ -41,6 +41,7 @@ public class VertxRouter {
     void setupRouter(@Observes Router router) {
         router.route("/").handler(ctx -> ctx.response().putHeader("location", "/ProcessInstances/").setStatusCode(302).end());
         router.route("/ProcessInstances*").handler(ctx -> handle(ctx));
+        router.route("/Process*").handler(ctx -> handle(ctx));
         router.route("/DomainExplorer*").handler(ctx -> handle(ctx));
         router.route().handler(StaticHandler.create());
     }

--- a/management-console/src/test/java/org/kie/kogito/mgmt/VertxRouterTest.java
+++ b/management-console/src/test/java/org/kie/kogito/mgmt/VertxRouterTest.java
@@ -14,7 +14,7 @@ public class VertxRouterTest {
                 .then()
                 .statusCode(200);
 
-        given().when().get("/ProcessInstances/a1e139d5-4e77-48c9-84ae-34578e904e5a")
+        given().when().get("/Process/a1e139d5-4e77-48c9-84ae-34578e904e5a")
                 .then()
                 .statusCode(200);
 

--- a/packages/management-console/src/components/Molecules/DataListItemComponent/DataListItemComponent.tsx
+++ b/packages/management-console/src/components/Molecules/DataListItemComponent/DataListItemComponent.tsx
@@ -85,6 +85,8 @@ const DataListItemComponent: React.FC<IOwnProps> = ({
     fetchPolicy: 'network-only'
   });
 
+  const currentPage = { prev: location.pathname}
+  window.localStorage.setItem('state', JSON.stringify(currentPage))
   const setTitle = (titleStatus, titleText) => {
     switch (titleStatus) {
       case 'success':
@@ -526,7 +528,7 @@ const DataListItemComponent: React.FC<IOwnProps> = ({
           <DataListItemCells
             dataListCells={[
               <DataListCell key={1}>
-                <Link to={'/ProcessInstances/' + processInstanceData.id}>
+                <Link to={'/Process/' + processInstanceData.id}>
                   <div>
                     <strong>
                       <ProcessDescriptor

--- a/packages/management-console/src/components/Molecules/DataListItemComponent/tests/__snapshots__/DataListItemComponent.test.tsx.snap
+++ b/packages/management-console/src/components/Molecules/DataListItemComponent/tests/__snapshots__/DataListItemComponent.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`DataListItem component tests Snapshot tests 1`] = `
           Array [
             <DataListCell>
               <Link
-                to="/ProcessInstances/c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e"
+                to="/Process/c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e"
               >
                 <div>
                   <strong>

--- a/packages/management-console/src/components/Molecules/NoServerComponent/NoServerComponent.tsx
+++ b/packages/management-console/src/components/Molecules/NoServerComponent/NoServerComponent.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import {
+  PageSection,
+  Bullseye,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Button,
+  EmptyStateBody,
+  Title,
+  Page,
+  SkipToContent,
+  PageSidebar,
+  PageHeader,
+  Nav,
+  NavList,
+  NavItem,
+  Brand,
+} from '@patternfly/react-core';
+import {
+  ExclamationCircleIcon
+} from '@patternfly/react-icons';
+import { BrowserRouter as Router, Link } from 'react-router-dom';
+import Avatar from '../../Atoms/AvatarComponent/AvatarComponent';
+import PageToolbarComponent from '../../Organisms/PageToolbarComponent/PageToolbarComponent';
+import managementConsoleLogo from '../../../static/managementConsoleLogo.svg';
+
+const NoServerComponent = (props) => {
+  const [isNavOpen, setIsNavOpen] = useState(true);
+  const onNavToggle = () => {
+    setIsNavOpen(!isNavOpen);
+  };
+
+  const Header = (
+    <PageHeader
+      logo={<Brand
+        src={managementConsoleLogo}
+        alt="Management Console Logo"
+      />}
+      toolbar={<PageToolbarComponent />}
+      avatar={<Avatar />}
+      showNavToggle
+      isNavOpen={isNavOpen}
+      onNavToggle={onNavToggle}
+    />
+  );
+
+  const PageNav = (
+    <Nav aria-label="Nav" theme="dark">
+      <NavList>
+        <NavItem>
+          <Link to="/ProcessInstances">Process Instances</Link>
+        </NavItem>
+        <NavItem>
+          <Link to="/DomainExplorer">Domain Explorer</Link>
+        </NavItem>
+      </NavList>
+    </Nav>
+  );
+  const Sidebar = (
+    <PageSidebar nav={PageNav} isNavOpen={isNavOpen} theme="dark" />
+  );
+
+  const pageId = 'main-content-page-layout-default-nav';
+  const PageSkipToContent = (
+    <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
+  );
+
+  return (
+    <>
+    <Router>
+    <Page
+        header={Header}
+        skipToContent={PageSkipToContent}
+        mainContainerId={pageId}
+        sidebar={Sidebar}
+        isManagedSidebar
+        className="kogito-management-console--dashboard-page"
+      >
+      <PageSection variant="light">
+        <Bullseye>
+          <EmptyState variant={EmptyStateVariant.full}>
+            <EmptyStateIcon
+              icon={ExclamationCircleIcon}
+              size="md"
+              color="var(--pf-global--danger-color--100)" />
+            <Title headingLevel="h1" size="4xl">Error connecting server</Title>
+            <EmptyStateBody>
+              The management console could not access the server to display content.
+            </EmptyStateBody>
+            <EmptyStateBody>
+              Try reloading the page, or contact your administrator for more information.
+            </EmptyStateBody>
+            <Button variant="primary" onClick={() => window.location.reload()}>
+              Refresh
+              </Button>
+          </EmptyState>
+        </Bullseye>
+      </PageSection>
+    </Page>
+    </Router>
+    </>
+  );
+};
+
+export default NoServerComponent;

--- a/packages/management-console/src/components/Molecules/ServerErrorsComponent/ServerErrorsComponent.css
+++ b/packages/management-console/src/components/Molecules/ServerErrorsComponent/ServerErrorsComponent.css
@@ -1,0 +1,4 @@
+.kogito-management-console--Server-Errors__text-color {
+    color: var(--pf-global--primary-color--100);
+    cursor: pointer
+}

--- a/packages/management-console/src/components/Molecules/ServerErrorsComponent/ServerErrorsComponent.tsx
+++ b/packages/management-console/src/components/Molecules/ServerErrorsComponent/ServerErrorsComponent.tsx
@@ -1,0 +1,51 @@
+import React,{useState} from 'react';
+
+import {
+    PageSection,
+    Bullseye,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateVariant,
+    Button,
+    EmptyStateBody,
+    Title,
+    Popover,
+    ClipboardCopy,
+    ClipboardCopyVariant
+} from '@patternfly/react-core';
+import {
+    ExclamationCircleIcon
+} from '@patternfly/react-icons';
+import './ServerErrorsComponent.css';
+import {useHistory} from 'react-router-dom';
+
+const ServerErrorsComponent = (props) => {
+    const [displayError, setDisplayError] = useState(false)
+    const history = useHistory();
+    
+    return (
+        <PageSection variant="light">
+            <Bullseye>
+                <EmptyState variant={EmptyStateVariant.full}>
+                    <EmptyStateIcon
+                        icon={ExclamationCircleIcon}
+                        size="md"
+                        color="var(--pf-global--danger-color--100)" />
+                    <Title headingLevel="h1" size="4xl">Error fetching data</Title>
+                    <EmptyStateBody>
+                        An error occurred while accessing data. <Button variant="link" isInline onClick={() => setDisplayError(!displayError)}>See more details</Button>
+                    </EmptyStateBody>
+                    {displayError &&<EmptyStateBody>
+                        <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} isExpanded={true} className="pf-u-text-align-left">{JSON.stringify(props.message)}</ClipboardCopy>             
+                    </EmptyStateBody>}
+                    <Button variant="primary" onClick={() => history.goBack()}>
+                        Go back
+              </Button>
+                </EmptyState>
+            </Bullseye>
+
+        </PageSection>
+    )
+}
+
+export default ServerErrorsComponent;

--- a/packages/management-console/src/components/Organisms/DomainExplorerColumnPicker/DomainExplorerColumnPicker.tsx
+++ b/packages/management-console/src/components/Organisms/DomainExplorerColumnPicker/DomainExplorerColumnPicker.tsx
@@ -23,6 +23,7 @@ export interface IOwnProps {
   setSelected: any;
   data: any;
   getPicker: any;
+  setError: any
 }
 
 const DomainExplorerColumnPicker: React.FC<IOwnProps> = ({
@@ -37,6 +38,7 @@ const DomainExplorerColumnPicker: React.FC<IOwnProps> = ({
   setSelected,
   data,
   getPicker,
+  setError
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [tempDomain, setTempDomain] = useState('');
@@ -122,7 +124,8 @@ const DomainExplorerColumnPicker: React.FC<IOwnProps> = ({
             }
           });
       } catch (error) {
-        return error;
+        setError(error)
+        // return error;
       }
     } else {
       setDisplayTable(false);

--- a/packages/management-console/src/components/Organisms/DomainExplorerTable/DomainExplorerTable.tsx
+++ b/packages/management-console/src/components/Organisms/DomainExplorerTable/DomainExplorerTable.tsx
@@ -39,6 +39,8 @@ import ProcessDescriptor from '../../Molecules/ProcessDescriptor/ProcessDescript
 const DomainExplorerTable = ({ columnFilters, tableLoading, displayTable }) => {
   const [columns, setColumns] = useState([]);
   const [rows, setRows] = useState([]);
+  const currentPage = { prev: location.pathname}
+  window.localStorage.setItem('state', JSON.stringify(currentPage))
 
   const stateIcon = (state) => {
     switch (state) {
@@ -155,7 +157,7 @@ const DomainExplorerTable = ({ columnFilters, tableLoading, displayTable }) => {
                 const ele = {
                   title: (
                     <>
-                     <Link to={'/ProcessInstances/' + tempObj.id}>
+                     <Link to={'/Process/' + tempObj.id}>
                     <strong>
                       <ProcessDescriptor processInstanceData={tempObj}/>
                       </strong>

--- a/packages/management-console/src/components/Organisms/ProcessDetails/ProcessDetails.tsx
+++ b/packages/management-console/src/components/Organisms/ProcessDetails/ProcessDetails.tsx
@@ -27,8 +27,9 @@ import ProcessDescriptor from '../../Molecules/ProcessDescriptor/ProcessDescript
 
 interface IOwnProps {
   data: any;
+  from: any;
 }
-const ProcessDetails: React.FC<IOwnProps> = ({ data }) => {
+const ProcessDetails: React.FC<IOwnProps> = ({ data, from }) => {
   const stateIconCreator = state => {
     switch (state) {
       case ProcessInstanceState.Active:
@@ -139,10 +140,11 @@ const ProcessDetails: React.FC<IOwnProps> = ({ data }) => {
             <FormGroup label="Parent Process" fieldId="parent">
               <div>
                 <Link
-                  to={
-                    '/ProcessInstances/' +
-                    data.ProcessInstances[0].parentProcessInstance.id
-                  }
+                  to={{
+                   pathname: '/Process/' +
+                    data.ProcessInstances[0].parentProcessInstance.id,
+                   state: from
+                  }}
                 >
                   <Tooltip
                     content={data.ProcessInstances[0].parentProcessInstance.id}
@@ -165,7 +167,7 @@ const ProcessDetails: React.FC<IOwnProps> = ({ data }) => {
               {data.ProcessInstances[0].childProcessInstances.map(
                 (child, index) => (
                   <div key={child.id}>
-                    <Link to={'/ProcessInstances/' + child.id}>
+                    <Link to={{pathname:'/Process/' + child.id,state: from}}>
                       <Tooltip content={child.id}>
                         <Button variant="link" icon={<LevelDownAltIcon />}>
                           <ProcessDescriptor processInstanceData={child} />

--- a/packages/management-console/src/components/Organisms/ProcessDetails/tests/ProcessDetails.test.tsx
+++ b/packages/management-console/src/components/Organisms/ProcessDetails/tests/ProcessDetails.test.tsx
@@ -22,6 +22,7 @@ const props = {
       }
     ]
   },
+  from: {prev: ''},
   loading: true,
   childLoading: true,
   parentLoading: true,
@@ -60,6 +61,7 @@ const props2 = {
       }
     ]
   },
+  from: {},
   childLoading: true,
   parentLoading: true,
   parentResult: {

--- a/packages/management-console/src/components/Organisms/ProcessDetails/tests/__snapshots__/ProcessDetails.test.tsx.snap
+++ b/packages/management-console/src/components/Organisms/ProcessDetails/tests/__snapshots__/ProcessDetails.test.tsx.snap
@@ -108,7 +108,14 @@ exports[`Process Details component Snapshot tests 1`] = `
       >
         <div>
           <Link
-            to="/ProcessInstances/"
+            to={
+              Object {
+                "pathname": "/Process/",
+                "state": Object {
+                  "prev": "",
+                },
+              }
+            }
           >
             <Tooltip
               appendTo={[Function]}
@@ -172,7 +179,14 @@ exports[`Process Details component Snapshot tests 1`] = `
           key=""
         >
           <Link
-            to="/ProcessInstances/"
+            to={
+              Object {
+                "pathname": "/Process/",
+                "state": Object {
+                  "prev": "",
+                },
+              }
+            }
           >
             <Tooltip
               appendTo={[Function]}

--- a/packages/management-console/src/components/Templates/DashboardComponent/Dashboard.tsx
+++ b/packages/management-console/src/components/Templates/DashboardComponent/Dashboard.tsx
@@ -85,7 +85,7 @@ const Dashboard: React.FC<{}> = (props: any) => {
           <Route exact path="/ProcessInstances" component={DataListContainer} />
           <Route
             exact
-            path="/ProcessInstances/:instanceID"
+            path="/Process/:instanceID"
             component={ProcessDetailsPage}
           />
           <Route

--- a/packages/management-console/src/components/Templates/DomainExplorerDashboard/DomainExplorerDashboard.tsx
+++ b/packages/management-console/src/components/Templates/DomainExplorerDashboard/DomainExplorerDashboard.tsx
@@ -18,6 +18,7 @@ import DomainExplorerColumnPicker from '../../Organisms/DomainExplorerColumnPick
 import DomainExplorerTable from '../../Organisms/DomainExplorerTable/DomainExplorerTable';
 import PageTitleComponent from '../../Molecules/PageTitleComponent/PageTitleComponent';
 import SpinnerComponent from '../../Atoms/SpinnerComponent/SpinnerComponent';
+import ServerErrorsComponent from '../../Molecules/ServerErrorsComponent/ServerErrorsComponent';
 
 import {
   useGetQueryTypesQuery,
@@ -52,6 +53,7 @@ const DomainExplorerDashboard = props => {
   const [tableLoading, setTableLoading] = useState(true);
   const [displayTable, setDisplayTable] = useState(false);
   const [selected, setSelected] = useState([]);
+  const [error, setError] = useState()
   const [parameters, setParameters] = useState([
     { metadata: [{ processInstances: ['id','processName', 'state', 'start', 'lastUpdate','businessKey'] }] }
   ]);
@@ -175,6 +177,7 @@ const DomainExplorerDashboard = props => {
                   setSelected={setSelected}
                   data={data}
                   getPicker={getPicker}
+                  setError={setError}
                 />
               )}
             </DataToolbarGroup>
@@ -218,6 +221,7 @@ const DomainExplorerDashboard = props => {
           })}
         </Breadcrumb>
       </PageSection>
+      {!error ? (
       <PageSection>
         {renderToolbar()}
 
@@ -234,7 +238,7 @@ const DomainExplorerDashboard = props => {
               </Bullseye>
             </Card>
           )}
-      </PageSection>
+      </PageSection>): (<ServerErrorsComponent message={error} />) }
     </>
   );
 };


### PR DESCRIPTION
Added fallback UI to display when management console is not connected with data-index
Added UI to display graphql errors
Fixed bugs on breadcrumb on Domain Explorer page
Fixed bug of redirecting directing back to proper page when process details has no data to display