### PR TITLE
A11y clean up for process instance details page (#158)

### DIFF
--- a/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.css
+++ b/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.css
@@ -1,0 +1,3 @@
+.kogito-management-console--details__title small {
+    --pf-c-content--small--Color: var(--pf-global--Color--100);
+}

--- a/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
+++ b/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
@@ -275,7 +275,11 @@ const ProcessDetailsPage = ({ match }) => {
                     className="pf-u-align-items-center"
                   >
                     <SplitItem isFilled={true}>
-                      <Title headingLevel="h1" size="4xl">
+                    <Title
+                        headingLevel="h2"
+                        size="4xl"
+                        className="kogito-management-console--details__title"
+                      >
                         <ProcessDescriptor
                           processInstanceData={data.ProcessInstances[0]}
                         />


### PR DESCRIPTION
Fixes a heading level and the contrast of small text in the title.
Cherrypicked commit from 0.9.x PR