### PR TITLE
KOGITO-1757: A11y clean up for process instance listing

### DIFF
--- a/packages/management-console/src/components/Molecules/DataListItemComponent/DataListItemComponent.tsx
+++ b/packages/management-console/src/components/Molecules/DataListItemComponent/DataListItemComponent.tsx
@@ -317,7 +317,7 @@ const DataListItemComponent: React.FC<IOwnProps> = ({
         modalContent={modalContent}
       />
       <DataListItem
-        aria-labelledby="kie-datalist-item"
+        aria-labelledby={'kie-datalist-item-' + processInstanceData.id}
         isExpanded={expanded.includes('kie-datalist-toggle')}
       >
         <DataListItemRow>
@@ -325,35 +325,38 @@ const DataListItemComponent: React.FC<IOwnProps> = ({
             <DataListToggle
               onClick={() => toggle('kie-datalist-toggle')}
               isExpanded={expanded.includes('kie-datalist-toggle')}
-              id="kie-datalist-toggle"
+              id={'kie-datalist-toggle-' + processInstanceData.id}
               aria-controls="kie-datalist-expand"
             />
           )}
           {processInstanceData.addons.includes('process-management') &&
-            processInstanceData.serviceUrl !== null ? (
-              <DataListCheck
-                aria-labelledby="width-kie-datalist-item"
-                name="width-kie-datalist-item"
-                checked={processInstanceData[isChecked]}
-                onChange={() => {
-                  onCheckBoxClick();
-                }}
-              />
-            ) : (
-              <DisablePopup
-                processInstanceData={processInstanceData}
-                component={
-                  <DataListCheck
-                    aria-labelledby="width-kie-datalist-item"
-                    name="width-kie-datalist-item"
-                    isDisabled={true}
-                  />
-                }
-              />
-            )}
+          processInstanceData.serviceUrl !== null ? (
+            <DataListCheck
+              aria-labelledby={'kie-datalist-item-' + processInstanceData.id}
+              checked={processInstanceData[isChecked]}
+              onChange={() => {
+                onCheckBoxClick();
+              }}
+            />
+          ) : (
+            <DisablePopup
+              processInstanceData={processInstanceData}
+              component={
+                <DataListCheck
+                  aria-labelledby={
+                    'kie-datalist-item-' + processInstanceData.id
+                  }
+                  isDisabled={true}
+                />
+              }
+            />
+          )}
           <DataListItemCells
             dataListCells={[
-              <DataListCell key={1}>
+              <DataListCell
+                key={1}
+                id={'kie-datalist-item-' + processInstanceData.id}
+              >
                 <Link to={'/Process/' + processInstanceData.id}>
                   <div>
                     <strong>
@@ -468,7 +471,7 @@ const DataListItemComponent: React.FC<IOwnProps> = ({
         </DataListItemRow>
         <DataListContent
           aria-label="Primary Content Details"
-          id="kie-datalist-expand1"
+          id={'kie-datalist-expand-' + processInstanceData.id}
           isHidden={!expanded.includes('kie-datalist-toggle')}
           className="kogito-management-console__embedded-list pf-m-compact"
         >

--- a/packages/management-console/src/components/Molecules/DataListItemComponent/tests/__snapshots__/DataListItemComponent.test.tsx.snap
+++ b/packages/management-console/src/components/Molecules/DataListItemComponent/tests/__snapshots__/DataListItemComponent.test.tsx.snap
@@ -79,16 +79,15 @@ exports[`DataListItem component tests Snapshot tests 1`] = `
     modalContent=""
   />
   <DataListItem
-    aria-labelledby="kie-datalist-item"
+    aria-labelledby="kie-datalist-item-c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e"
     isExpanded={false}
   >
     <DataListItemRow>
       <DisablePopup
         component={
           <DataListCheck
-            aria-labelledby="width-kie-datalist-item"
+            aria-labelledby="kie-datalist-item-c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e"
             isDisabled={true}
-            name="width-kie-datalist-item"
           />
         }
         processInstanceData={
@@ -149,7 +148,9 @@ exports[`DataListItem component tests Snapshot tests 1`] = `
       <DataListItemCells
         dataListCells={
           Array [
-            <DataListCell>
+            <DataListCell
+              id="kie-datalist-item-c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e"
+            >
               <Link
                 to="/Process/c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e"
               >
@@ -359,7 +360,7 @@ exports[`DataListItem component tests Snapshot tests 1`] = `
     <DataListContent
       aria-label="Primary Content Details"
       className="kogito-management-console__embedded-list pf-m-compact"
-      id="kie-datalist-expand1"
+      id="kie-datalist-expand-c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e"
       isHidden={true}
     >
       <Bullseye>

--- a/packages/management-console/src/components/Molecules/DataToolbarComponent/DataToolbarComponent.tsx
+++ b/packages/management-console/src/components/Molecules/DataToolbarComponent/DataToolbarComponent.tsx
@@ -463,7 +463,7 @@ const DataToolbarComponent: React.FC<IOwnProps> = ({
       </DataToolbarToggleGroup>
       <DataToolbarGroup variant="icon-button-group">
         <DataToolbarItem>
-          <Button variant="plain" onClick={onRefreshClick}>
+          <Button variant="plain" onClick={onRefreshClick} aria-label="Refresh list">
             <SyncIcon />
           </Button>
         </DataToolbarItem>

--- a/packages/management-console/src/components/Molecules/DataToolbarComponent/tests/__snapshots__/DataToolbarComponent.test.tsx.snap
+++ b/packages/management-console/src/components/Molecules/DataToolbarComponent/tests/__snapshots__/DataToolbarComponent.test.tsx.snap
@@ -216,6 +216,7 @@ exports[`DataToolbar component tests Snapshot tests 1`] = `
     >
       <DataToolbarItem>
         <Component
+          aria-label="Refresh list"
           onClick={[Function]}
           variant="plain"
         >


### PR DESCRIPTION
Creates unique ids for process instance list items to correct a11y errors.
Also adds an aria label to the refresh button.
