### PR TITLE
KOGITO-1759: use card on domain landing page for text contrast 

### DIFF
--- a/packages/management-console/src/components/Templates/DomainExplorerLandingPage/DomainExplorerLandingPage.tsx
+++ b/packages/management-console/src/components/Templates/DomainExplorerLandingPage/DomainExplorerLandingPage.tsx
@@ -12,7 +12,9 @@ import {
   EmptyStateVariant,
   EmptyStateIcon,
   EmptyStateBody,
-  EmptyStateSecondaryActions
+  EmptyStateSecondaryActions,
+  Card,
+  CardBody
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { CubesIcon } from '@patternfly/react-icons';
@@ -36,47 +38,47 @@ const DomainExplorerLandingPage = () => {
 
   return (
     <>
-      <PageSection variant="light">
-        <PageTitleComponent title="Domain Explorer" />
-        <Breadcrumb>
-          <BreadcrumbItem>
-            <Link to={'/'}>Home</Link>
-          </BreadcrumbItem>
-          <BreadcrumbItem isActive>Domain Explorer</BreadcrumbItem>
-        </Breadcrumb>
-      </PageSection>
-      <PageSection>
-        <EmptyState variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={CubesIcon} />
+    <PageSection variant="light">
+      <PageTitleComponent title="Domain Explorer" />
+      <Breadcrumb>
+        <BreadcrumbItem>
+          <Link to={'/'}>Home</Link>
+        </BreadcrumbItem>
+        <BreadcrumbItem isActive>Domain Explorer</BreadcrumbItem>
+      </Breadcrumb>
+    </PageSection>
+    <PageSection>
+      <Card>
+        <CardBody>
+          <EmptyState variant={EmptyStateVariant.full}>
+            <EmptyStateIcon icon={CubesIcon} />
 
-          {availableDomains.length > 0 ? (
-            <>
-              <Title headingLevel="h5" size="lg">
-                Domains List
-              </Title>
-              <EmptyStateBody>
-                Select a domain from the below list to direct.
-              </EmptyStateBody>
-              <EmptyStateSecondaryActions>
-                {!getQuery.loading &&
-                  availableDomains.map((item, index) => {
+            {availableDomains.length > 0 ? (
+              <>
+                <Title headingLevel="h5" size="lg">
+                  Domains List
+                </Title>
+                <EmptyStateBody>Select a domain below</EmptyStateBody>
+                <EmptyStateSecondaryActions>
+                  {!getQuery.loading &&
+                    availableDomains.map((item, index) => {
                       return (
                         <Link to={`/DomainExplorer/${item.name}`} key={index}>
                           <Button variant="link">{item.name}</Button>
                         </Link>
                       );
-                  })}
-              </EmptyStateSecondaryActions>
-            </>
-          ) : (
-            <TextContent>
-              <Text component={TextVariants.h2}>
-                No domains available to select
-              </Text>
-            </TextContent>
-          )}
-        </EmptyState>
-      </PageSection>
+                    })}
+                </EmptyStateSecondaryActions>
+              </>
+            ) : (
+              <TextContent>
+                <Text component={TextVariants.h2}>No domains available</Text>
+              </TextContent>
+            )}
+          </EmptyState>
+        </CardBody>
+      </Card>
+    </PageSection>
     </>
   );
 };


### PR DESCRIPTION
This changes the wording on the landing page, and introduces a card to the landing page so that the empty state is not on a gray background, which causes contrast a11y problems.

Cherrypicked commit from 0.9.x PR