### PR TITLE
KOGITO-1894: Bump extension to Quarkus 1.4.0.CR1 (or later)

### DIFF
--- a/data-index/pom.xml
+++ b/data-index/pom.xml
@@ -18,16 +18,4 @@
     <module>data-index-service</module>
   </modules>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.kie.kogito</groupId>
-        <artifactId>kogito-quarkus-bom</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
 </project>


### PR DESCRIPTION
keep data-index on 1.3.1.Final