### PR TITLE
[KOGITO-1967] Add word break on long strings

### DIFF
--- a/packages/management-console/src/components/Organisms/ProcessDetails/ProcessDetails.tsx
+++ b/packages/management-console/src/components/Organisms/ProcessDetails/ProcessDetails.tsx
@@ -103,13 +103,19 @@ const ProcessDetails: React.FC<IOwnProps> = ({ data, from }) => {
             </Text>
           </FormGroup>
           <FormGroup label="Id" fieldId="id">
-            <Text component={TextVariants.p}>
+            <Text
+              component={TextVariants.p}
+              className="kogito-management-console--u-WordBreak"
+            >
               {data.ProcessInstances[0].id}
             </Text>
           </FormGroup>
           <FormGroup label="Endpoint" fieldId="endpoint">
             {data.ProcessInstances[0].endpoint ? (
-              <Text component={TextVariants.p}>
+              <Text
+                component={TextVariants.p}
+                className="kogito-management-console--u-WordBreak"
+              >
                 {data.ProcessInstances[0].endpoint}
               </Text>
             ) : (

--- a/packages/management-console/src/components/Organisms/ProcessDetails/tests/__snapshots__/ProcessDetails.test.tsx.snap
+++ b/packages/management-console/src/components/Organisms/ProcessDetails/tests/__snapshots__/ProcessDetails.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`Process Details component Snapshot tests 1`] = `
         label="Id"
       >
         <Text
+          className="kogito-management-console--u-WordBreak"
           component="p"
         />
       </FormGroup>
@@ -41,6 +42,7 @@ exports[`Process Details component Snapshot tests 1`] = `
         label="Endpoint"
       >
         <Text
+          className="kogito-management-console--u-WordBreak"
           component="p"
         >
           test

--- a/packages/management-console/src/components/Templates/DashboardComponent/Dashboard.css
+++ b/packages/management-console/src/components/Templates/DashboardComponent/Dashboard.css
@@ -1,3 +1,10 @@
 .kogito-management-console--dashboard-page {
   --pf-c-page__header-brand-link--c-brand--MaxHeight: 42px;
 }
+
+/* Utilities */
+
+/* apply WordBreak on content that might not break to fit into the container (e.g. URLs)  */
+.kogito-management-console--u-WordBreak {
+  word-break: break-all;
+}


### PR DESCRIPTION
KOGITO-1967 https://issues.redhat.com/browse/KOGITO-1967

A long string such as a URL or very long process instance ID might not wrap in certain cases, causing the content to overflow its container. This adds a utility class to be used in these cases. This fix applies it to the ID and Endpoint URL on the Process Instance Details page.
