### PR TITLE
KOGITO-2190 Make pages OUIA:Page compliant

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -10,3 +10,4 @@ export {
 } from './src/components/Molecules/ServerUnavailable/ServerUnavailable';
 export { default as NoData } from './src/components/Molecules/NoData/NoData';
 export { default as ServerErrors } from './src/components/Molecules/ServerErrors/ServerErrors';
+export * from './src/utils/OuiaUtils'

--- a/packages/common/src/components/Templates/PageLayout/PageLayout.tsx
+++ b/packages/common/src/components/Templates/PageLayout/PageLayout.tsx
@@ -1,11 +1,12 @@
-import { Page, PageSidebar, PageHeader, Avatar } from '@patternfly/react-core';
-import React, { useState } from 'react';
+import { Page, PageSidebar, PageHeader, Avatar, InjectedOuiaProps, withOuiaContext } from '@patternfly/react-core';
+import React, { useState, useEffect } from 'react';
 import PageToolbar from '../../Molecules/PageToolbar/PageToolbar';
 import BrandLogo from '../../Atoms/BrandLogo/BrandLogo';
 import { aboutLogoContext } from '../../contexts';
 import './PageLayout.css';
 
 import userImage from '../../../static/avatar.svg';
+import { ouiaAttribute } from '../../../utils/OuiaUtils';
 
 interface IOwnProps {
   children: React.ReactNode;
@@ -15,12 +16,20 @@ interface IOwnProps {
   BrandClick: () => void;
 }
 
-const PageLayout: React.FC<IOwnProps> = (props: any) => {
+const PageLayout: React.FC<IOwnProps & InjectedOuiaProps> = ({
+  ouiaContext,
+  ...props
+}) => {
   const pageId = 'main-content-page-layout-default-nav';
   const [isNavOpen, setIsNavOpen] = useState(true);
   const onNavToggle = () => {
     setIsNavOpen(!isNavOpen);
   };
+
+  useEffect(() => {
+    // set OUIA:Page attribute
+    ouiaContext.isOuia && document.getElementById(pageId).setAttribute('data-ouia-main', 'true')
+  })
 
   const Header = (
     <PageHeader
@@ -40,11 +49,13 @@ const PageLayout: React.FC<IOwnProps> = (props: any) => {
       showNavToggle
       isNavOpen={isNavOpen}
       onNavToggle={onNavToggle}
+      {...ouiaAttribute(ouiaContext, "data-ouia-header","true")}
     />
   );
 
   const Sidebar = (
-    <PageSidebar nav={props.PageNav} isNavOpen={isNavOpen} theme="dark" />
+    <PageSidebar nav={props.PageNav} isNavOpen={isNavOpen} theme="dark"
+      {...ouiaAttribute(ouiaContext, "data-ouia-navigation", "true")}/>
   );
 
   return (
@@ -61,4 +72,4 @@ const PageLayout: React.FC<IOwnProps> = (props: any) => {
   );
 };
 
-export default PageLayout;
+export default withOuiaContext(PageLayout);

--- a/packages/common/src/utils/OuiaUtils.ts
+++ b/packages/common/src/utils/OuiaUtils.ts
@@ -1,0 +1,58 @@
+import { ReactElement } from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+
+/** 
+ * ugly workaround for the mount function in getWrapper to wait until component does all the hooks and effects
+ */
+const waitForComponentToPaint = async (wrapper: any) => {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    wrapper.update();
+  });
+};
+
+/**
+ * Wrapper used in snapshot testing to get rid of unnecessary wrappers of components.
+ * Not only OUIA wrappers, but also Routers, MockedProvider,...
+ * @param component The actual component with wrappers, e.g. <Router><MyGreatComponent /></Router>
+ * @param name name of the component to be extracted as string, e.g. 'MyGreatComponent'
+ */
+export const getWrapper = (component: ReactElement, name: string) => {
+  const wrapper = mount(component)
+  waitForComponentToPaint(wrapper)
+  return wrapper.find(name)
+}
+
+/**
+ * Function to set OUIA:Page Page Type and Page Object Id attributes in page body.
+ * @param ouiaContext OUIAContext of the component wrapped with patternfly's withOuiaContext function.
+ * @param type string value to be set as Page Type
+ * @param objectId string value to be set as Page Object Id
+ */
+export const ouiaPageTypeAndObjectId = (
+  ouiaContext,
+  type: string,
+  objectId?: string
+): (() => void) => {
+  if (!ouiaContext.isOuia) return;
+  document.body.setAttribute('data-ouia-page-type', type)
+  if (objectId) document.body.setAttribute('data-ouia-page-object-id', objectId)
+  return () => {
+    document.body.removeAttribute('data-ouia-page-type')
+    if (objectId) document.body.removeAttribute('data-ouia-page-object-id')
+  }
+};
+
+/**
+ * Function to set ouia attribute - only when OUIA is enabled.
+ * Usage:
+ * <div
+ *   {...ouiaAttribute(ouiaContext,'name','value')}
+ * @param ouiaContext OUIAContext of the component wrapped with patternfly's withOuiaContext function.
+ * @param name name of the attribute
+ * @param value value of the attribute
+ */
+export const ouiaAttribute = (ouiaContext, name: string, value: string) => {
+  return (ouiaContext.isOuia && {[name]:value})
+}

--- a/packages/management-console/src/components/Molecules/DataToolbarComponent/__mocks__/DataToolbarComponent.tsx
+++ b/packages/management-console/src/components/Molecules/DataToolbarComponent/__mocks__/DataToolbarComponent.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const DataToolbarComponent = (): React.ReactElement => {
+  return <></>
+};
+
+export default DataToolbarComponent;

--- a/packages/management-console/src/components/Molecules/ErrorComponent/ErrorComponent.tsx
+++ b/packages/management-console/src/components/Molecules/ErrorComponent/ErrorComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   PageSection,
   Bullseye,
@@ -7,12 +7,22 @@ import {
   EmptyStateVariant,
   Button,
   EmptyStateBody,
-  Title
+  Title,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { Redirect } from 'react-router';
+import { Redirect, RouteComponentProps } from 'react-router';
+import { ouiaPageTypeAndObjectId } from '@kogito-apps/common';
 
-const ErrorComponent = props => {
+interface LocationProps {
+  prev?: any,
+}
+
+const ErrorComponent: React.FC<RouteComponentProps<{}, {}, LocationProps> & InjectedOuiaProps> = ({
+  ouiaContext,
+  ...props
+}) => {
   let prevPath;
   if (props.location.state !== undefined) {
     prevPath = props.location.state.prev;
@@ -24,6 +34,9 @@ const ErrorComponent = props => {
   prevPath = tempPath.filter(item => item);
 
   const [isRedirect, setIsredirect] = useState(false);
+
+  useEffect(() => { return ouiaPageTypeAndObjectId(ouiaContext, "error") })
+
   const redirectHandler = () => {
     setIsredirect(true);
   };
@@ -52,4 +65,4 @@ const ErrorComponent = props => {
   );
 };
 
-export default ErrorComponent;
+export default withOuiaContext(ErrorComponent);

--- a/packages/management-console/src/components/Molecules/NoDataComponent/NoDataComponent.tsx
+++ b/packages/management-console/src/components/Molecules/NoDataComponent/NoDataComponent.tsx
@@ -7,12 +7,26 @@ import {
   EmptyStateVariant,
   Button,
   EmptyStateBody,
-  Title
+  Title,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { Redirect } from 'react-router';
+import { Redirect, RouteComponentProps } from 'react-router';
+import { ouiaPageTypeAndObjectId } from '@kogito-apps/common';
 
-const NoDataComponent = props => {
+interface LocationProps {
+  prev: any,
+  rememberedData: any,
+  title: string,
+  description: string,
+  buttonText: string
+}
+
+const NoDataComponent: React.FC<RouteComponentProps<{}, {}, LocationProps> &InjectedOuiaProps> = ({
+  ouiaContext,
+  ...props
+}) => {
   let prevPath;
   if (props.location.state !== undefined) {
     prevPath = props.location.state.prev;
@@ -33,6 +47,8 @@ const NoDataComponent = props => {
       props.history.push({ state: { ...props.location.state.rememberedData } });
     };
   });
+
+  useEffect(() => { return ouiaPageTypeAndObjectId(ouiaContext, "no-data") })
 
   let finalPath = '';
   prevPath.map(item => (finalPath = finalPath + `/${item}`));
@@ -72,4 +88,4 @@ const NoDataComponent = props => {
   );
 };
 
-export default NoDataComponent;
+export default withOuiaContext(NoDataComponent);

--- a/packages/management-console/src/components/Organisms/DataListComponent/__mocks__/DataListComponent.tsx
+++ b/packages/management-console/src/components/Organisms/DataListComponent/__mocks__/DataListComponent.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const DataListComponent = (): React.ReactElement => {
+  return <></>
+};
+
+export default DataListComponent;

--- a/packages/management-console/src/components/Templates/DataListContainer/DataListContainer.tsx
+++ b/packages/management-console/src/components/Templates/DataListContainer/DataListContainer.tsx
@@ -4,9 +4,14 @@ import {
   Card,
   Grid,
   GridItem,
-  PageSection
+  PageSection,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
-import { ServerErrors } from '@kogito-apps/common';
+import {
+  ServerErrors,
+  ouiaPageTypeAndObjectId
+} from '@kogito-apps/common';
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import PageTitleComponent from '../../Molecules/PageTitleComponent/PageTitleComponent';
@@ -24,7 +29,9 @@ import {
 import axios from 'axios';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
-const DataListContainer: React.FC<{}> = () => {
+const DataListContainer: React.FC<InjectedOuiaProps> = ({
+  ouiaContext
+}) => {
   const [defaultPageSize] = useState(10);
   const [initData, setInitData] = useState<any>({});
   const [checkedArray, setCheckedArray] = useState<any>(['ACTIVE']);
@@ -74,6 +81,8 @@ const DataListContainer: React.FC<{}> = () => {
   const handleAbortModalToggle = () => {
     setIsAbortModalOpen(!isAbortModalOpen);
   };
+
+  useEffect(() => { return ouiaPageTypeAndObjectId(ouiaContext, "process-instances") })
 
   const onFilterClick = async (arr = checkedArray) => {
     resetPagination();
@@ -380,4 +389,4 @@ const DataListContainer: React.FC<{}> = () => {
   );
 };
 
-export default DataListContainer;
+export default withOuiaContext(DataListContainer);

--- a/packages/management-console/src/components/Templates/DataListContainer/__mocks__/DataListContainer.tsx
+++ b/packages/management-console/src/components/Templates/DataListContainer/__mocks__/DataListContainer.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const DataListContainer = (): React.ReactElement => {
+  return <></>
+};
+
+export default DataListContainer;

--- a/packages/management-console/src/components/Templates/DataListContainer/tests/DataListContainer.test.tsx
+++ b/packages/management-console/src/components/Templates/DataListContainer/tests/DataListContainer.test.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import DataListContainer from '../DataListContainer';
+import { getWrapper } from '@kogito-apps/common';
+import { MemoryRouter as Router} from 'react-router-dom';
+import { MockedProvider } from '@apollo/react-testing';
+
+
+jest.mock('../../../Molecules/DataToolbarComponent/DataToolbarComponent');
+jest.mock('../../../Organisms/DataListComponent/DataListComponent');
 
 describe('DataListContainer component tests', () => {
   it('Snapshot tests', () => {
-    const wrapper = shallow(<DataListContainer />);
+    const wrapper = getWrapper(
+      <Router>
+        <MockedProvider>
+          <DataListContainer />
+        </MockedProvider>
+      </Router>
+      , 'DataListContainer');
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/management-console/src/components/Templates/DataListContainer/tests/__snapshots__/DataListContainer.test.tsx.snap
+++ b/packages/management-console/src/components/Templates/DataListContainer/tests/__snapshots__/DataListContainer.test.tsx.snap
@@ -1,7 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DataListContainer component tests Snapshot tests 1`] = `
-<Fragment>
+<DataListContainer
+  ouiaContext={
+    Object {
+      "isOuia": false,
+      "ouiaId": null,
+    }
+  }
+>
   <Modalbox
     abortedMessageObj={Object {}}
     checkedArray={
@@ -14,106 +21,525 @@ exports[`DataListContainer component tests Snapshot tests 1`] = `
     isAbortModalOpen={false}
     isModalOpen={false}
     isSingleAbort={false}
-  />
+  >
+    <Modal
+      actions={
+        Array [
+          <Unknown
+            onClick={[Function]}
+            variant="primary"
+          >
+            OK
+          </Unknown>,
+        ]
+      }
+      appendTo={
+        <body>
+          <div />
+        </body>
+      }
+      ariaDescribedById=""
+      className=""
+      header={
+        <Title
+          headingLevel="h1"
+          size="2xl"
+        />
+      }
+      hideTitle={false}
+      isFooterLeftAligned={false}
+      isLarge={false}
+      isOpen={false}
+      isSmall={true}
+      onClose={[Function]}
+      showClose={true}
+      title=""
+    >
+      <Portal
+        containerInfo={<div />}
+      >
+        <ModalContent
+          actions={
+            Array [
+              <Unknown
+                onClick={[Function]}
+                variant="primary"
+              >
+                OK
+              </Unknown>,
+            ]
+          }
+          ariaDescribedById=""
+          className=""
+          header={
+            <Title
+              headingLevel="h1"
+              size="2xl"
+            />
+          }
+          hideTitle={false}
+          id="pf-modal-0"
+          isFooterLeftAligned={false}
+          isLarge={false}
+          isOpen={false}
+          isSmall={true}
+          onClose={[Function]}
+          showClose={true}
+          title=""
+        />
+      </Portal>
+    </Modal>
+  </Modalbox>
   <PageSection
     variant="light"
   >
-    <PageTitleComponent
-      title="Process Instances"
-    />
-    <Component>
-      <BreadcrumbItem>
-        <Link
-          to="/"
-        >
-          Home
-        </Link>
-      </BreadcrumbItem>
-      <BreadcrumbItem
-        isActive={true}
+    <section
+      className="pf-c-page__main-section pf-m-light"
+    >
+      <PageTitleComponent
+        title="Process Instances"
       >
-        Process instances
-      </BreadcrumbItem>
-    </Component>
+        <Title
+          headingLevel="h1"
+          size="4xl"
+        >
+          <h1
+            className="pf-c-title pf-m-4xl"
+          >
+            Process Instances
+          </h1>
+        </Title>
+      </PageTitleComponent>
+      <Component>
+        <ComponentWithOuia
+          component={[Function]}
+          componentProps={
+            Object {
+              "children": Array [
+                <BreadcrumbItem>
+                  <Link
+                    to="/"
+                  >
+                    Home
+                  </Link>
+                </BreadcrumbItem>,
+                <BreadcrumbItem
+                  isActive={true}
+                >
+                  Process instances
+                </BreadcrumbItem>,
+              ],
+            }
+          }
+          consumerContext={
+            Object {
+              "isOuia": false,
+              "ouiaId": null,
+            }
+          }
+        >
+          <Breadcrumb
+            ouiaContext={
+              Object {
+                "isOuia": false,
+                "ouiaId": null,
+              }
+            }
+          >
+            <nav
+              aria-label="Breadcrumb"
+              className="pf-c-breadcrumb"
+            >
+              <ol
+                className="pf-c-breadcrumb__list"
+              >
+                <BreadcrumbItem>
+                  <li
+                    className="pf-c-breadcrumb__item"
+                  >
+                    <Link
+                      to="/"
+                    >
+                      <LinkAnchor
+                        href="/"
+                        navigate={[Function]}
+                      >
+                        <a
+                          href="/"
+                          onClick={[Function]}
+                        >
+                          Home
+                        </a>
+                      </LinkAnchor>
+                    </Link>
+                    <span
+                      className="pf-c-breadcrumb__item-divider"
+                    >
+                      <AngleRightIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                        title={null}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            transform=""
+                          />
+                        </svg>
+                      </AngleRightIcon>
+                    </span>
+                  </li>
+                </BreadcrumbItem>
+                <BreadcrumbItem
+                  isActive={true}
+                >
+                  <li
+                    className="pf-c-breadcrumb__item"
+                  >
+                    Process instances
+                  </li>
+                </BreadcrumbItem>
+              </ol>
+            </nav>
+          </Breadcrumb>
+        </ComponentWithOuia>
+      </Component>
+    </section>
   </PageSection>
   <PageSection>
-    <Grid
-      gutter="md"
+    <section
+      className="pf-c-page__main-section"
     >
-      <GridItem
-        span={12}
+      <Grid
+        gutter="md"
       >
-        <Card
-          className="dataList"
+        <div
+          className="pf-l-grid pf-m-gutter"
         >
-           
-          <DataToolbarComponent
-            abortedObj={Object {}}
-            checkedArray={
-              Array [
-                "ACTIVE",
-              ]
-            }
-            filterClick={[Function]}
-            filters={
-              Object {
-                "businessKey": Array [],
-                "status": Array [
-                  "ACTIVE",
-                ],
-              }
-            }
-            getProcessInstances={[Function]}
-            handleAbortAll={[Function]}
-            initData={Object {}}
-            isAllChecked={false}
-            searchWord=""
-            selectedNumber={0}
-            setAbortedObj={[Function]}
-            setCheckedArray={[Function]}
-            setFilters={[Function]}
-            setInitData={[Function]}
-            setIsAllChecked={[Function]}
-            setIsStatusSelected={[Function]}
-            setSearchWord={[Function]}
-            setSelectedNumber={[Function]}
-          />
-          <DataListComponent
-            abortedObj={Object {}}
-            checkedArray={
-              Array [
-                "ACTIVE",
-              ]
-            }
-            filters={
-              Object {
-                "businessKey": Array [],
-                "status": Array [
-                  "ACTIVE",
-                ],
-              }
-            }
-            initData={Object {}}
-            isFilterClicked={false}
-            isLoading={false}
-            pageSize={10}
-            selectedNumber={0}
-            setAbortedObj={[Function]}
-            setInitData={[Function]}
-            setIsAllChecked={[Function]}
-            setIsError={[Function]}
-            setSelectedNumber={[Function]}
-          />
-          <LoadMoreComponent
-            getMoreItems={[Function]}
-            isLoadingMore={false}
-            offset={10}
-            pageSize={10}
-            setOffset={[Function]}
-          />
-        </Card>
-      </GridItem>
-    </Grid>
+          <GridItem
+            span={12}
+          >
+            <div
+              className="pf-l-grid__item pf-m-12-col"
+            >
+              <Card
+                className="dataList"
+              >
+                <article
+                  className="pf-c-card dataList"
+                >
+                   
+                  <DataToolbarComponent
+                    abortedObj={Object {}}
+                    checkedArray={
+                      Array [
+                        "ACTIVE",
+                      ]
+                    }
+                    filterClick={[Function]}
+                    filters={
+                      Object {
+                        "businessKey": Array [],
+                        "status": Array [
+                          "ACTIVE",
+                        ],
+                      }
+                    }
+                    getProcessInstances={[Function]}
+                    handleAbortAll={[Function]}
+                    initData={Object {}}
+                    isAllChecked={false}
+                    searchWord=""
+                    selectedNumber={0}
+                    setAbortedObj={[Function]}
+                    setCheckedArray={[Function]}
+                    setFilters={[Function]}
+                    setInitData={[Function]}
+                    setIsAllChecked={[Function]}
+                    setIsStatusSelected={[Function]}
+                    setSearchWord={[Function]}
+                    setSelectedNumber={[Function]}
+                  />
+                  <DataListComponent
+                    abortedObj={Object {}}
+                    checkedArray={
+                      Array [
+                        "ACTIVE",
+                      ]
+                    }
+                    filters={
+                      Object {
+                        "businessKey": Array [],
+                        "status": Array [
+                          "ACTIVE",
+                        ],
+                      }
+                    }
+                    initData={Object {}}
+                    isFilterClicked={false}
+                    isLoading={false}
+                    pageSize={10}
+                    selectedNumber={0}
+                    setAbortedObj={[Function]}
+                    setInitData={[Function]}
+                    setIsAllChecked={[Function]}
+                    setIsError={[Function]}
+                    setSelectedNumber={[Function]}
+                  />
+                  <LoadMoreComponent
+                    getMoreItems={[Function]}
+                    isLoadingMore={false}
+                    offset={10}
+                    pageSize={10}
+                    setOffset={[Function]}
+                  >
+                    <DataList
+                      aria-label="Simple data list example"
+                    >
+                      <ul
+                        aria-label="Simple data list example"
+                        className="pf-c-data-list"
+                      >
+                        <DataListItem
+                          aria-labelledby="kie-datalist-item"
+                        >
+                          <li
+                            aria-labelledby="kie-datalist-item"
+                            className="pf-c-data-list__item"
+                            id=""
+                          >
+                            <DataListCell
+                              className="kogito-management-console__load-more"
+                              key=".0"
+                              rowid="kie-datalist-item"
+                            >
+                              <div
+                                className="pf-c-data-list__cell kogito-management-console__load-more"
+                                rowid="kie-datalist-item"
+                              >
+                                <Component
+                                  id="load10"
+                                  onClick={[Function]}
+                                  variant="secondary"
+                                >
+                                  <ComponentWithOuia
+                                    component={[Function]}
+                                    componentProps={
+                                      Object {
+                                        "children": "Load 10 more",
+                                        "id": "load10",
+                                        "onClick": [Function],
+                                        "variant": "secondary",
+                                      }
+                                    }
+                                    consumerContext={
+                                      Object {
+                                        "isOuia": false,
+                                        "ouiaId": null,
+                                      }
+                                    }
+                                  >
+                                    <Button
+                                      id="load10"
+                                      onClick={[Function]}
+                                      ouiaContext={
+                                        Object {
+                                          "isOuia": false,
+                                          "ouiaId": null,
+                                        }
+                                      }
+                                      variant="secondary"
+                                    >
+                                      <button
+                                        aria-disabled={null}
+                                        aria-label={null}
+                                        className="pf-c-button pf-m-secondary"
+                                        disabled={false}
+                                        id="load10"
+                                        onClick={[Function]}
+                                        tabIndex={null}
+                                        type="button"
+                                      >
+                                        Load 10 more
+                                      </button>
+                                    </Button>
+                                  </ComponentWithOuia>
+                                </Component>
+                                 
+                                <Component
+                                  id="load20"
+                                  onClick={[Function]}
+                                  variant="secondary"
+                                >
+                                  <ComponentWithOuia
+                                    component={[Function]}
+                                    componentProps={
+                                      Object {
+                                        "children": "Load 20 more",
+                                        "id": "load20",
+                                        "onClick": [Function],
+                                        "variant": "secondary",
+                                      }
+                                    }
+                                    consumerContext={
+                                      Object {
+                                        "isOuia": false,
+                                        "ouiaId": null,
+                                      }
+                                    }
+                                  >
+                                    <Button
+                                      id="load20"
+                                      onClick={[Function]}
+                                      ouiaContext={
+                                        Object {
+                                          "isOuia": false,
+                                          "ouiaId": null,
+                                        }
+                                      }
+                                      variant="secondary"
+                                    >
+                                      <button
+                                        aria-disabled={null}
+                                        aria-label={null}
+                                        className="pf-c-button pf-m-secondary"
+                                        disabled={false}
+                                        id="load20"
+                                        onClick={[Function]}
+                                        tabIndex={null}
+                                        type="button"
+                                      >
+                                        Load 20 more
+                                      </button>
+                                    </Button>
+                                  </ComponentWithOuia>
+                                </Component>
+                                 
+                                <Component
+                                  id="load50"
+                                  onClick={[Function]}
+                                  variant="secondary"
+                                >
+                                  <ComponentWithOuia
+                                    component={[Function]}
+                                    componentProps={
+                                      Object {
+                                        "children": "Load 50 more",
+                                        "id": "load50",
+                                        "onClick": [Function],
+                                        "variant": "secondary",
+                                      }
+                                    }
+                                    consumerContext={
+                                      Object {
+                                        "isOuia": false,
+                                        "ouiaId": null,
+                                      }
+                                    }
+                                  >
+                                    <Button
+                                      id="load50"
+                                      onClick={[Function]}
+                                      ouiaContext={
+                                        Object {
+                                          "isOuia": false,
+                                          "ouiaId": null,
+                                        }
+                                      }
+                                      variant="secondary"
+                                    >
+                                      <button
+                                        aria-disabled={null}
+                                        aria-label={null}
+                                        className="pf-c-button pf-m-secondary"
+                                        disabled={false}
+                                        id="load50"
+                                        onClick={[Function]}
+                                        tabIndex={null}
+                                        type="button"
+                                      >
+                                        Load 50 more
+                                      </button>
+                                    </Button>
+                                  </ComponentWithOuia>
+                                </Component>
+                                 
+                                <Component
+                                  id="load100"
+                                  onClick={[Function]}
+                                  variant="secondary"
+                                >
+                                  <ComponentWithOuia
+                                    component={[Function]}
+                                    componentProps={
+                                      Object {
+                                        "children": "Load 100 more",
+                                        "id": "load100",
+                                        "onClick": [Function],
+                                        "variant": "secondary",
+                                      }
+                                    }
+                                    consumerContext={
+                                      Object {
+                                        "isOuia": false,
+                                        "ouiaId": null,
+                                      }
+                                    }
+                                  >
+                                    <Button
+                                      id="load100"
+                                      onClick={[Function]}
+                                      ouiaContext={
+                                        Object {
+                                          "isOuia": false,
+                                          "ouiaId": null,
+                                        }
+                                      }
+                                      variant="secondary"
+                                    >
+                                      <button
+                                        aria-disabled={null}
+                                        aria-label={null}
+                                        className="pf-c-button pf-m-secondary"
+                                        disabled={false}
+                                        id="load100"
+                                        onClick={[Function]}
+                                        tabIndex={null}
+                                        type="button"
+                                      >
+                                        Load 100 more
+                                      </button>
+                                    </Button>
+                                  </ComponentWithOuia>
+                                </Component>
+                              </div>
+                            </DataListCell>
+                          </li>
+                        </DataListItem>
+                      </ul>
+                    </DataList>
+                  </LoadMoreComponent>
+                </article>
+              </Card>
+            </div>
+          </GridItem>
+        </div>
+      </Grid>
+    </section>
   </PageSection>
-</Fragment>
+</DataListContainer>
 `;

--- a/packages/management-console/src/components/Templates/DomainExplorerDashboard/DomainExplorerDashboard.tsx
+++ b/packages/management-console/src/components/Templates/DomainExplorerDashboard/DomainExplorerDashboard.tsx
@@ -8,12 +8,17 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   Card,
-  Bullseye
+  Bullseye,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
-import { ServerErrors } from '@kogito-apps/common';
+import {
+  ServerErrors,
+  ouiaPageTypeAndObjectId
+} from '@kogito-apps/common';
 import { FilterIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
-import { Redirect } from 'react-router';
+import { Redirect, RouteComponentProps } from 'react-router';
 import './DomainExplorerDashboard.css';
 import DomainExplorerColumnPicker from '../../Organisms/DomainExplorerColumnPicker/DomainExplorerColumnPicker';
 import DomainExplorerTable from '../../Organisms/DomainExplorerTable/DomainExplorerTable';
@@ -27,11 +32,23 @@ import {
   useGetColumnPickerAttributesQuery
 } from '../../../graphql/types';
 
-export interface IOwnProps {
-  domains: any;
+interface IOwnProps {
+  domains: any
 }
 
-const DomainExplorerDashboard = props => {
+interface MatchProps {
+  domainName: string
+}
+
+interface LocationProps {
+  parameters?: any[],
+  selected?: any[]
+}
+
+const DomainExplorerDashboard: React.FC<IOwnProps & RouteComponentProps<MatchProps, {}, LocationProps> & InjectedOuiaProps> = ({
+  ouiaContext,
+  ...props
+}) => {
   const rememberedParams =
     (props.location.state && props.location.state.parameters) || [];
   const rememberedSelections =
@@ -80,6 +97,8 @@ const DomainExplorerDashboard = props => {
       setColumnPickerType(domainName);
     }
   }, []);
+
+  useEffect(() => { return ouiaPageTypeAndObjectId(ouiaContext, "domain-explorer", domainName) })
 
   const getQuery = useGetQueryFieldsQuery();
   const getQueryTypes = useGetQueryTypesQuery();
@@ -289,4 +308,4 @@ const DomainExplorerDashboard = props => {
   );
 };
 
-export default React.memo(DomainExplorerDashboard);
+export default React.memo(withOuiaContext(DomainExplorerDashboard));

--- a/packages/management-console/src/components/Templates/DomainExplorerLandingPage/DomainExplorerLandingPage.tsx
+++ b/packages/management-console/src/components/Templates/DomainExplorerLandingPage/DomainExplorerLandingPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   TextContent,
   Text,
@@ -14,15 +14,20 @@ import {
   EmptyStateBody,
   EmptyStateSecondaryActions,
   Card,
-  CardBody
+  CardBody,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { CubesIcon } from '@patternfly/react-icons';
 import PageTitleComponent from '../../Molecules/PageTitleComponent/PageTitleComponent';
 
 import { useGetQueryFieldsQuery } from '../../../graphql/types';
+import { ouiaPageTypeAndObjectId } from '@kogito-apps/common';
 
-const DomainExplorerLandingPage = () => {
+const DomainExplorerLandingPage: React.FC<InjectedOuiaProps> = ({
+  ouiaContext
+}) => {
   const getQuery = useGetQueryFieldsQuery();
 
   let availableDomains =
@@ -35,6 +40,8 @@ const DomainExplorerLandingPage = () => {
         return item;
       }
     });
+
+  useEffect(() => { return ouiaPageTypeAndObjectId(ouiaContext, "domain-explorer") })
 
   return (
     <>
@@ -83,4 +90,4 @@ const DomainExplorerLandingPage = () => {
   );
 };
 
-export default DomainExplorerLandingPage;
+export default withOuiaContext(DomainExplorerLandingPage);

--- a/packages/management-console/src/components/Templates/PageLayoutComponent/PageLayoutComponent.tsx
+++ b/packages/management-console/src/components/Templates/PageLayoutComponent/PageLayoutComponent.tsx
@@ -1,10 +1,11 @@
-import { Nav, NavList, NavItem } from '@patternfly/react-core';
+import { Nav, NavList, NavItem, withOuiaContext, InjectedOuiaProps } from '@patternfly/react-core';
 import React from 'react';
-import { Redirect, Route, Link, Switch } from 'react-router-dom';
+import { Redirect, Route, Link, Switch} from 'react-router-dom';
 import {
   PageLayout,
   PageNotFound,
-  NoData
+  NoData,
+  ouiaAttribute
 } from '@kogito-apps/common';
 import DataListContainer from '../DataListContainer/DataListContainer';
 import ProcessDetailsPage from '../ProcessDetailsPage/ProcessDetailsPage';
@@ -14,18 +15,31 @@ import './PageLayoutComponent.css';
 import managementConsoleLogo from '../../../static/managementConsoleLogo.svg';
 
 import { useGetQueryFieldsQuery } from '../../../graphql/types';
+import {History, Location} from 'history'
 
-const PageLayoutComponent: React.FC<{}> = (props: any) => {
+interface IOwnProps {
+  location: Location,
+  history: History
+}
+
+const PageLayoutComponent: React.FC<IOwnProps & InjectedOuiaProps> = ({
+  ouiaContext,
+  ...props
+}) => {
   const { pathname } = props.location;
 
   const PageNav = (
     <Nav aria-label="Nav" theme="dark">
       <NavList>
         <NavItem isActive={pathname === '/ProcessInstances'}>
-          <Link to="/ProcessInstances">Process Instances</Link>
+          <Link to="/ProcessInstances"
+            {...ouiaAttribute(ouiaContext, "data-ouia-navigation-name", "process-instances")}
+          >Process Instances</Link>
         </NavItem>
         <NavItem isActive={pathname === '/DomainExplorer'}>
-          <Link to="/DomainExplorer">Domain Explorer</Link>
+          <Link to="/DomainExplorer"
+            {...ouiaAttribute(ouiaContext, "data-ouia-navigation-name", "domain-explorer")}
+          >Domain Explorer</Link>
         </NavItem>
       </NavList>
     </Nav>
@@ -37,7 +51,7 @@ const PageLayoutComponent: React.FC<{}> = (props: any) => {
 
   const getQuery = useGetQueryFieldsQuery();
   const availableDomains =
-    !getQuery.loading && getQuery.data.__type.fields.slice(2);
+    !getQuery.loading && getQuery.data && getQuery.data.__type.fields.slice(2);
   const domains = [];
   availableDomains && availableDomains.map(item => domains.push(item.name));
   return (
@@ -98,4 +112,4 @@ const PageLayoutComponent: React.FC<{}> = (props: any) => {
   );
 };
 
-export default PageLayoutComponent;
+export default withOuiaContext(PageLayoutComponent);

--- a/packages/management-console/src/components/Templates/PageLayoutComponent/tests/PageLayoutComponent.test.tsx
+++ b/packages/management-console/src/components/Templates/PageLayoutComponent/tests/PageLayoutComponent.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import PageLayoutComponent from '../PageLayoutComponent';
 import { MockedProvider } from '@apollo/react-testing';
+import { getWrapper } from '@kogito-apps/common'
+import { MemoryRouter as Router } from 'react-router-dom';
+
 
 const props: any = {
   location: {
@@ -11,13 +13,18 @@ const props: any = {
 
 const mocks = [];
 
+jest.mock('../../DataListContainer/DataListContainer.tsx');
+ 
 describe('PageLayoutComponent component tests', () => {
   it('snapshot testing', () => {
-    const wrapper = shallow(
-      <MockedProvider mocks={mocks}>
-        <PageLayoutComponent {...props} />
-      </MockedProvider>
-    );
-    expect(wrapper.find(PageLayoutComponent)).toMatchSnapshot();
+    const wrapper = getWrapper(
+      // keyLength set to zero to have stable snapshots
+      <Router keyLength={0}>
+        <MockedProvider mocks={mocks}>
+          <PageLayoutComponent {...props} />
+        </MockedProvider>
+      </Router>
+      , 'PageLayoutComponent');
+      expect(wrapper).toMatchSnapshot();
+    });
   });
-});

--- a/packages/management-console/src/components/Templates/PageLayoutComponent/tests/__snapshots__/PageLayoutComponent.test.tsx.snap
+++ b/packages/management-console/src/components/Templates/PageLayoutComponent/tests/__snapshots__/PageLayoutComponent.test.tsx.snap
@@ -7,5 +7,992 @@ exports[`PageLayoutComponent component tests snapshot testing 1`] = `
       "pathname": "/ProcessInstances",
     }
   }
-/>
+  ouiaContext={
+    Object {
+      "isOuia": false,
+      "ouiaId": null,
+    }
+  }
+>
+  <Component
+    BrandAltText="Management Console Logo"
+    BrandClick={[Function]}
+    BrandSrc="managementConsoleLogo.svg"
+    PageNav={
+      <Unknown
+        aria-label="Nav"
+        theme="dark"
+      >
+        <NavList
+          ariaLeftScroll="Scroll left"
+          ariaRightScroll="Scroll right"
+          className=""
+          variant="default"
+        >
+          <NavItem
+            isActive={true}
+          >
+            <Link
+              to="/ProcessInstances"
+            >
+              Process Instances
+            </Link>
+          </NavItem>
+          <NavItem
+            isActive={false}
+          >
+            <Link
+              to="/DomainExplorer"
+            >
+              Domain Explorer
+            </Link>
+          </NavItem>
+        </NavList>
+      </Unknown>
+    }
+  >
+    <ComponentWithOuia
+      component={[Function]}
+      componentProps={
+        Object {
+          "BrandAltText": "Management Console Logo",
+          "BrandClick": [Function],
+          "BrandSrc": "managementConsoleLogo.svg",
+          "PageNav": <Unknown
+            aria-label="Nav"
+            theme="dark"
+          >
+            <NavList
+              ariaLeftScroll="Scroll left"
+              ariaRightScroll="Scroll right"
+              className=""
+              variant="default"
+            >
+              <NavItem
+                isActive={true}
+              >
+                <Link
+                  to="/ProcessInstances"
+                >
+                  Process Instances
+                </Link>
+              </NavItem>
+              <NavItem
+                isActive={false}
+              >
+                <Link
+                  to="/DomainExplorer"
+                >
+                  Domain Explorer
+                </Link>
+              </NavItem>
+            </NavList>
+          </Unknown>,
+          "children": <Switch>
+            <Route
+              exact={true}
+              path="/"
+              render={[Function]}
+            />
+            <Route
+              component={[Function]}
+              exact={true}
+              path="/ProcessInstances"
+            />
+            <Route
+              component={[Function]}
+              exact={true}
+              path="/Process/:instanceID"
+            />
+            <Route
+              component={[Function]}
+              exact={true}
+              path="/DomainExplorer"
+            />
+            <Route
+              exact={true}
+              path="/DomainExplorer/:domainName"
+              render={[Function]}
+            />
+            <Route
+              path="/NoData"
+              render={[Function]}
+            />
+            <Route
+              path="*"
+              render={[Function]}
+            />
+          </Switch>,
+        }
+      }
+      consumerContext={
+        Object {
+          "isOuia": false,
+          "ouiaId": null,
+        }
+      }
+    >
+      <PageLayout
+        BrandAltText="Management Console Logo"
+        BrandClick={[Function]}
+        BrandSrc="managementConsoleLogo.svg"
+        PageNav={
+          <Unknown
+            aria-label="Nav"
+            theme="dark"
+          >
+            <NavList
+              ariaLeftScroll="Scroll left"
+              ariaRightScroll="Scroll right"
+              className=""
+              variant="default"
+            >
+              <NavItem
+                isActive={true}
+              >
+                <Link
+                  to="/ProcessInstances"
+                >
+                  Process Instances
+                </Link>
+              </NavItem>
+              <NavItem
+                isActive={false}
+              >
+                <Link
+                  to="/DomainExplorer"
+                >
+                  Domain Explorer
+                </Link>
+              </NavItem>
+            </NavList>
+          </Unknown>
+        }
+        ouiaContext={
+          Object {
+            "isOuia": false,
+            "ouiaId": null,
+          }
+        }
+      >
+        <Page
+          breadcrumb={null}
+          className="kogito-common--PageLayout"
+          defaultManagedSidebarIsOpen={true}
+          header={
+            <PageHeader
+              avatar={
+                <Avatar
+                  alt="Kogito Logo"
+                  src="avatar.svg"
+                />
+              }
+              isNavOpen={true}
+              logo={
+                <BrandLogo
+                  alt="Management Console Logo"
+                  brandClick={[Function]}
+                  src="managementConsoleLogo.svg"
+                />
+              }
+              onNavToggle={[Function]}
+              showNavToggle={true}
+              toolbar={
+                <Context.Provider
+                  value="managementConsoleLogo.svg"
+                >
+                  <PageToolbar />
+                </Context.Provider>
+              }
+            />
+          }
+          isManagedSidebar={false}
+          mainContainerId="main-content-page-layout-default-nav"
+          onPageResize={[Function]}
+          sidebar={
+            <PageSidebar
+              isNavOpen={true}
+              nav={
+                <Unknown
+                  aria-label="Nav"
+                  theme="dark"
+                >
+                  <NavList
+                    ariaLeftScroll="Scroll left"
+                    ariaRightScroll="Scroll right"
+                    className=""
+                    variant="default"
+                  >
+                    <NavItem
+                      isActive={true}
+                    >
+                      <Link
+                        to="/ProcessInstances"
+                      >
+                        Process Instances
+                      </Link>
+                    </NavItem>
+                    <NavItem
+                      isActive={false}
+                    >
+                      <Link
+                        to="/DomainExplorer"
+                      >
+                        Domain Explorer
+                      </Link>
+                    </NavItem>
+                  </NavList>
+                </Unknown>
+              }
+              theme="dark"
+            />
+          }
+          skipToContent={null}
+        >
+          <div
+            className="pf-c-page kogito-common--PageLayout"
+          >
+            <PageHeader
+              avatar={
+                <Avatar
+                  alt="Kogito Logo"
+                  src="avatar.svg"
+                />
+              }
+              isNavOpen={true}
+              logo={
+                <BrandLogo
+                  alt="Management Console Logo"
+                  brandClick={[Function]}
+                  src="managementConsoleLogo.svg"
+                />
+              }
+              onNavToggle={[Function]}
+              showNavToggle={true}
+              toolbar={
+                <Context.Provider
+                  value="managementConsoleLogo.svg"
+                >
+                  <PageToolbar />
+                </Context.Provider>
+              }
+            >
+              <header
+                className="pf-c-page__header"
+              >
+                <div
+                  className="pf-c-page__header-brand"
+                >
+                  <div
+                    className="pf-c-page__header-brand-toggle"
+                  >
+                    <Component
+                      aria-controls="page-sidebar"
+                      aria-expanded="true"
+                      aria-label="Global navigation"
+                      id="nav-toggle"
+                      onClick={[Function]}
+                      variant="plain"
+                    >
+                      <ComponentWithOuia
+                        component={[Function]}
+                        componentProps={
+                          Object {
+                            "aria-controls": "page-sidebar",
+                            "aria-expanded": "true",
+                            "aria-label": "Global navigation",
+                            "children": <BarsIcon
+                              color="currentColor"
+                              noVerticalAlign={false}
+                              size="sm"
+                              title={null}
+                            />,
+                            "id": "nav-toggle",
+                            "onClick": [Function],
+                            "variant": "plain",
+                          }
+                        }
+                        consumerContext={
+                          Object {
+                            "isOuia": false,
+                            "ouiaId": null,
+                          }
+                        }
+                      >
+                        <Button
+                          aria-controls="page-sidebar"
+                          aria-expanded="true"
+                          aria-label="Global navigation"
+                          id="nav-toggle"
+                          onClick={[Function]}
+                          ouiaContext={
+                            Object {
+                              "isOuia": false,
+                              "ouiaId": null,
+                            }
+                          }
+                          variant="plain"
+                        >
+                          <button
+                            aria-controls="page-sidebar"
+                            aria-disabled={null}
+                            aria-expanded="true"
+                            aria-label="Global navigation"
+                            className="pf-c-button pf-m-plain"
+                            disabled={false}
+                            id="nav-toggle"
+                            onClick={[Function]}
+                            tabIndex={null}
+                            type="button"
+                          >
+                            <BarsIcon
+                              color="currentColor"
+                              noVerticalAlign={false}
+                              size="sm"
+                              title={null}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-labelledby={null}
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.125em",
+                                  }
+                                }
+                                viewBox="0 0 448 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
+                                  transform=""
+                                />
+                              </svg>
+                            </BarsIcon>
+                          </button>
+                        </Button>
+                      </ComponentWithOuia>
+                    </Component>
+                  </div>
+                  <a
+                    className="pf-c-page__header-brand-link"
+                  >
+                    <BrandLogo
+                      alt="Management Console Logo"
+                      brandClick={[Function]}
+                      src="managementConsoleLogo.svg"
+                    >
+                      <Brand
+                        alt="Management Console Logo"
+                        onClick={[Function]}
+                        src="managementConsoleLogo.svg"
+                      >
+                        <img
+                          alt="Management Console Logo"
+                          className="pf-c-brand"
+                          onClick={[Function]}
+                          src="managementConsoleLogo.svg"
+                        />
+                      </Brand>
+                    </BrandLogo>
+                  </a>
+                </div>
+                <div
+                  className="pf-c-page__header-tools"
+                >
+                  <PageToolbar>
+                    <AboutModalBox
+                      handleModalToggleProp={[Function]}
+                      isOpenProp={false}
+                    >
+                      <AboutModal
+                        appendTo={null}
+                        backgroundImageSrc="kogitoAbout.png"
+                        brandImageAlt="Kogito Logo"
+                        brandImageSrc="managementConsoleLogo.svg"
+                        className=""
+                        isOpen={false}
+                        noAboutModalBoxContentContainer={false}
+                        onClose={[Function]}
+                        productName=""
+                        trademark="undefined is part of Kogito, an open source software released under the Apache Software License 2.0"
+                      >
+                        <Portal
+                          containerInfo={<div />}
+                        >
+                          <AboutModalContainer
+                            ariaDescribedById="pf-about-modal-content-0"
+                            ariaLabelledbyId="pf-about-modal-title-0"
+                            backgroundImageSrc="kogitoAbout.png"
+                            brandImageAlt="Kogito Logo"
+                            brandImageSrc="managementConsoleLogo.svg"
+                            className=""
+                            isOpen={false}
+                            noAboutModalBoxContentContainer={false}
+                            onClose={[Function]}
+                            productName=""
+                            trademark="undefined is part of Kogito, an open source software released under the Apache Software License 2.0"
+                          />
+                        </Portal>
+                      </AboutModal>
+                    </AboutModalBox>
+                    <Toolbar>
+                      <div
+                        className="pf-l-toolbar"
+                      >
+                        <ToolbarGroup>
+                          <div
+                            className="pf-l-toolbar__group"
+                          >
+                            <ToolbarItem
+                              className="pf-u-screen-reader pf-u-visible-on-md"
+                            >
+                              <div
+                                className="pf-l-toolbar__item pf-u-screen-reader pf-u-visible-on-md"
+                              >
+                                <Dropdown
+                                  dropdownItems={
+                                    Array [
+                                      <DropdownItem
+                                        onClick={[Function]}
+                                      >
+                                        About
+                                      </DropdownItem>,
+                                    ]
+                                  }
+                                  isOpen={false}
+                                  isPlain={true}
+                                  onSelect={[Function]}
+                                  position="right"
+                                  toggle={
+                                    <DropdownToggle
+                                      onToggle={[Function]}
+                                    >
+                                      Anonymous
+                                    </DropdownToggle>
+                                  }
+                                >
+                                  <Component
+                                    dropdownItems={
+                                      Array [
+                                        <DropdownItem
+                                          onClick={[Function]}
+                                        >
+                                          About
+                                        </DropdownItem>,
+                                      ]
+                                    }
+                                    isOpen={false}
+                                    isPlain={true}
+                                    position="right"
+                                    toggle={
+                                      <DropdownToggle
+                                        onToggle={[Function]}
+                                      >
+                                        Anonymous
+                                      </DropdownToggle>
+                                    }
+                                  >
+                                    <ComponentWithOuia
+                                      component={[Function]}
+                                      componentProps={
+                                        Object {
+                                          "dropdownItems": Array [
+                                            <DropdownItem
+                                              onClick={[Function]}
+                                            >
+                                              About
+                                            </DropdownItem>,
+                                          ],
+                                          "isOpen": false,
+                                          "isPlain": true,
+                                          "position": "right",
+                                          "toggle": <DropdownToggle
+                                            onToggle={[Function]}
+                                          >
+                                            Anonymous
+                                          </DropdownToggle>,
+                                        }
+                                      }
+                                      consumerContext={
+                                        Object {
+                                          "isOuia": false,
+                                          "ouiaId": null,
+                                        }
+                                      }
+                                    >
+                                      <DropdownWithContext
+                                        autoFocus={true}
+                                        className=""
+                                        direction="down"
+                                        dropdownItems={
+                                          Array [
+                                            <DropdownItem
+                                              onClick={[Function]}
+                                            >
+                                              About
+                                            </DropdownItem>,
+                                          ]
+                                        }
+                                        isGrouped={false}
+                                        isOpen={false}
+                                        isPlain={true}
+                                        onSelect={[Function]}
+                                        ouiaComponentType="Dropdown"
+                                        ouiaContext={
+                                          Object {
+                                            "isOuia": false,
+                                            "ouiaId": null,
+                                          }
+                                        }
+                                        position="right"
+                                        toggle={
+                                          <DropdownToggle
+                                            onToggle={[Function]}
+                                          >
+                                            Anonymous
+                                          </DropdownToggle>
+                                        }
+                                      >
+                                        <div
+                                          className="pf-c-dropdown pf-m-align-right"
+                                        >
+                                          <DropdownToggle
+                                            ariaHasPopup={true}
+                                            id="pf-toggle-id-0"
+                                            isOpen={false}
+                                            isPlain={true}
+                                            key=".0"
+                                            onEnter={[Function]}
+                                            onToggle={[Function]}
+                                            parentRef={
+                                              Object {
+                                                "current": <div
+                                                  class="pf-c-dropdown pf-m-align-right"
+                                                >
+                                                  <button
+                                                    aria-expanded="false"
+                                                    aria-haspopup="true"
+                                                    class="pf-c-dropdown__toggle pf-m-plain"
+                                                    id="pf-toggle-id-0"
+                                                    type="button"
+                                                  >
+                                                    <span
+                                                      class="pf-c-dropdown__toggle-text"
+                                                    >
+                                                      Anonymous
+                                                    </span>
+                                                    <svg
+                                                      aria-hidden="true"
+                                                      class="pf-c-dropdown__toggle-icon"
+                                                      fill="currentColor"
+                                                      height="1em"
+                                                      role="img"
+                                                      style="vertical-align: -0.125em;"
+                                                      viewBox="0 0 320 512"
+                                                      width="1em"
+                                                    >
+                                                      <path
+                                                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                        transform=""
+                                                      />
+                                                    </svg>
+                                                  </button>
+                                                </div>,
+                                              }
+                                            }
+                                          >
+                                            <Toggle
+                                              ariaHasPopup={true}
+                                              bubbleEvent={false}
+                                              className=""
+                                              id="pf-toggle-id-0"
+                                              isActive={false}
+                                              isDisabled={false}
+                                              isFocused={false}
+                                              isHovered={false}
+                                              isOpen={false}
+                                              isPlain={true}
+                                              isPrimary={false}
+                                              isSplitButton={false}
+                                              onEnter={[Function]}
+                                              onToggle={[Function]}
+                                              parentRef={
+                                                Object {
+                                                  "current": <div
+                                                    class="pf-c-dropdown pf-m-align-right"
+                                                  >
+                                                    <button
+                                                      aria-expanded="false"
+                                                      aria-haspopup="true"
+                                                      class="pf-c-dropdown__toggle pf-m-plain"
+                                                      id="pf-toggle-id-0"
+                                                      type="button"
+                                                    >
+                                                      <span
+                                                        class="pf-c-dropdown__toggle-text"
+                                                      >
+                                                        Anonymous
+                                                      </span>
+                                                      <svg
+                                                        aria-hidden="true"
+                                                        class="pf-c-dropdown__toggle-icon"
+                                                        fill="currentColor"
+                                                        height="1em"
+                                                        role="img"
+                                                        style="vertical-align: -0.125em;"
+                                                        viewBox="0 0 320 512"
+                                                        width="1em"
+                                                      >
+                                                        <path
+                                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                          transform=""
+                                                        />
+                                                      </svg>
+                                                    </button>
+                                                  </div>,
+                                                }
+                                              }
+                                            >
+                                              <button
+                                                aria-expanded={false}
+                                                aria-haspopup={true}
+                                                className="pf-c-dropdown__toggle pf-m-plain"
+                                                disabled={false}
+                                                id="pf-toggle-id-0"
+                                                onClick={[Function]}
+                                                onKeyDown={[Function]}
+                                                type="button"
+                                              >
+                                                <span
+                                                  className="pf-c-dropdown__toggle-text"
+                                                >
+                                                  Anonymous
+                                                </span>
+                                                <CaretDownIcon
+                                                  className="pf-c-dropdown__toggle-icon"
+                                                  color="currentColor"
+                                                  noVerticalAlign={false}
+                                                  size="sm"
+                                                  title={null}
+                                                >
+                                                  <svg
+                                                    aria-hidden={true}
+                                                    aria-labelledby={null}
+                                                    className="pf-c-dropdown__toggle-icon"
+                                                    fill="currentColor"
+                                                    height="1em"
+                                                    role="img"
+                                                    style={
+                                                      Object {
+                                                        "verticalAlign": "-0.125em",
+                                                      }
+                                                    }
+                                                    viewBox="0 0 320 512"
+                                                    width="1em"
+                                                  >
+                                                    <path
+                                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                      transform=""
+                                                    />
+                                                  </svg>
+                                                </CaretDownIcon>
+                                              </button>
+                                            </Toggle>
+                                          </DropdownToggle>
+                                        </div>
+                                      </DropdownWithContext>
+                                    </ComponentWithOuia>
+                                  </Component>
+                                </Dropdown>
+                              </div>
+                            </ToolbarItem>
+                          </div>
+                        </ToolbarGroup>
+                      </div>
+                    </Toolbar>
+                  </PageToolbar>
+                  <Avatar
+                    alt="Kogito Logo"
+                    src="avatar.svg"
+                  >
+                    <img
+                      alt="Kogito Logo"
+                      className="pf-c-avatar"
+                      src="avatar.svg"
+                    />
+                  </Avatar>
+                </div>
+              </header>
+            </PageHeader>
+            <PageSidebar
+              isNavOpen={true}
+              nav={
+                <Unknown
+                  aria-label="Nav"
+                  theme="dark"
+                >
+                  <NavList
+                    ariaLeftScroll="Scroll left"
+                    ariaRightScroll="Scroll right"
+                    className=""
+                    variant="default"
+                  >
+                    <NavItem
+                      isActive={true}
+                    >
+                      <Link
+                        to="/ProcessInstances"
+                      >
+                        Process Instances
+                      </Link>
+                    </NavItem>
+                    <NavItem
+                      isActive={false}
+                    >
+                      <Link
+                        to="/DomainExplorer"
+                      >
+                        Domain Explorer
+                      </Link>
+                    </NavItem>
+                  </NavList>
+                </Unknown>
+              }
+              theme="dark"
+            >
+              <div
+                className="pf-c-page__sidebar pf-m-dark pf-m-expanded"
+                id="page-sidebar"
+              >
+                <div
+                  className="pf-c-page__sidebar-body"
+                >
+                  <Component
+                    aria-label="Nav"
+                    theme="dark"
+                  >
+                    <ComponentWithOuia
+                      component={[Function]}
+                      componentProps={
+                        Object {
+                          "aria-label": "Nav",
+                          "children": <NavList
+                            ariaLeftScroll="Scroll left"
+                            ariaRightScroll="Scroll right"
+                            className=""
+                            variant="default"
+                          >
+                            <NavItem
+                              isActive={true}
+                            >
+                              <Link
+                                to="/ProcessInstances"
+                              >
+                                Process Instances
+                              </Link>
+                            </NavItem>
+                            <NavItem
+                              isActive={false}
+                            >
+                              <Link
+                                to="/DomainExplorer"
+                              >
+                                Domain Explorer
+                              </Link>
+                            </NavItem>
+                          </NavList>,
+                          "theme": "dark",
+                        }
+                      }
+                      consumerContext={
+                        Object {
+                          "isOuia": false,
+                          "ouiaId": null,
+                        }
+                      }
+                    >
+                      <Nav
+                        aria-label="Nav"
+                        className=""
+                        onSelect={[Function]}
+                        onToggle={[Function]}
+                        ouiaContext={
+                          Object {
+                            "isOuia": false,
+                            "ouiaId": null,
+                          }
+                        }
+                        theme="dark"
+                      >
+                        <nav
+                          aria-label="Nav"
+                          className="pf-c-nav pf-m-dark"
+                        >
+                          <NavList
+                            ariaLeftScroll="Scroll left"
+                            ariaRightScroll="Scroll right"
+                            className=""
+                            variant="default"
+                          >
+                            <ul
+                              className="pf-c-nav__list"
+                            >
+                              <NavItem
+                                isActive={true}
+                              >
+                                <li
+                                  className="pf-c-nav__item"
+                                >
+                                  <Link
+                                    aria-current="page"
+                                    className="pf-c-nav__link pf-m-current"
+                                    onClick={[Function]}
+                                    to="/ProcessInstances"
+                                  >
+                                    <LinkAnchor
+                                      aria-current="page"
+                                      className="pf-c-nav__link pf-m-current"
+                                      href="/ProcessInstances"
+                                      navigate={[Function]}
+                                      onClick={[Function]}
+                                    >
+                                      <a
+                                        aria-current="page"
+                                        className="pf-c-nav__link pf-m-current"
+                                        href="/ProcessInstances"
+                                        onClick={[Function]}
+                                      >
+                                        Process Instances
+                                      </a>
+                                    </LinkAnchor>
+                                  </Link>
+                                </li>
+                              </NavItem>
+                              <NavItem
+                                isActive={false}
+                              >
+                                <li
+                                  className="pf-c-nav__item"
+                                >
+                                  <Link
+                                    aria-current={null}
+                                    className="pf-c-nav__link"
+                                    onClick={[Function]}
+                                    to="/DomainExplorer"
+                                  >
+                                    <LinkAnchor
+                                      aria-current={null}
+                                      className="pf-c-nav__link"
+                                      href="/DomainExplorer"
+                                      navigate={[Function]}
+                                      onClick={[Function]}
+                                    >
+                                      <a
+                                        aria-current={null}
+                                        className="pf-c-nav__link"
+                                        href="/DomainExplorer"
+                                        onClick={[Function]}
+                                      >
+                                        Domain Explorer
+                                      </a>
+                                    </LinkAnchor>
+                                  </Link>
+                                </li>
+                              </NavItem>
+                            </ul>
+                          </NavList>
+                        </nav>
+                      </Nav>
+                    </ComponentWithOuia>
+                  </Component>
+                </div>
+              </div>
+            </PageSidebar>
+            <main
+              className="pf-c-page__main"
+              id="main-content-page-layout-default-nav"
+              tabIndex={-1}
+            >
+              <Switch>
+                <Route
+                  component={[Function]}
+                  computedMatch={
+                    Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/ProcessInstances",
+                      "url": "/ProcessInstances",
+                    }
+                  }
+                  exact={true}
+                  location={
+                    Object {
+                      "hash": "",
+                      "pathname": "/ProcessInstances",
+                      "search": "",
+                      "state": undefined,
+                    }
+                  }
+                  path="/ProcessInstances"
+                >
+                  <DataListContainer
+                    history={
+                      Object {
+                        "action": "REPLACE",
+                        "block": [Function],
+                        "canGo": [Function],
+                        "createHref": [Function],
+                        "entries": Array [
+                          Object {
+                            "hash": "",
+                            "pathname": "/ProcessInstances",
+                            "search": "",
+                            "state": undefined,
+                          },
+                        ],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "index": 0,
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/ProcessInstances",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      }
+                    }
+                    location={
+                      Object {
+                        "hash": "",
+                        "pathname": "/ProcessInstances",
+                        "search": "",
+                        "state": undefined,
+                      }
+                    }
+                    match={
+                      Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/ProcessInstances",
+                        "url": "/ProcessInstances",
+                      }
+                    }
+                  />
+                </Route>
+              </Switch>
+            </main>
+          </div>
+        </Page>
+      </PageLayout>
+    </ComponentWithOuia>
+  </Component>
+</PageLayoutComponent>
 `;

--- a/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
+++ b/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
@@ -12,11 +12,13 @@ import {
   SplitItem,
   OverflowMenu,
   OverflowMenuContent,
-  OverflowMenuGroup
+  OverflowMenuGroup,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
-import { ServerErrors } from '@kogito-apps/common';
+import { ServerErrors, ouiaPageTypeAndObjectId } from '@kogito-apps/common';
 import React, { useState, useEffect } from 'react';
-import { Link, Redirect } from 'react-router-dom';
+import { Link, Redirect, RouteComponentProps } from 'react-router-dom';
 import ProcessDetails from '../../Organisms/ProcessDetails/ProcessDetails';
 import ProcessDetailsProcessVariables from '../../Organisms/ProcessDetailsProcessVariables/ProcessDetailsProcessVariables';
 import ProcessDetailsTimeline from '../../Organisms/ProcessDetailsTimeline/ProcessDetailsTimeline';
@@ -36,7 +38,14 @@ import {
   modalToggle
 } from '../../../utils/Utils';
 
-const ProcessDetailsPage = props => {
+interface MatchProps {
+  instanceID: string
+}
+
+const ProcessDetailsPage: React.FC<RouteComponentProps<MatchProps, {}, {}> & InjectedOuiaProps> = ({
+  ouiaContext,
+  ...props
+}) => {
   const id = props.match.params.instanceID;
   const [isSkipModalOpen, setIsSkipModalOpen] = useState<boolean>(false);
   const [isRetryModalOpen, setIsRetryModalOpen] = useState<boolean>(false);
@@ -67,6 +76,8 @@ const ProcessDetailsPage = props => {
       props.history.push({ state: { ...props.location.state } });
     };
   });
+
+  useEffect(() => { return ouiaPageTypeAndObjectId(ouiaContext, "process-instances", id) })
 
   const abortButton = () => {
     if (
@@ -280,4 +291,4 @@ const ProcessDetailsPage = props => {
   );
 };
 
-export default ProcessDetailsPage;
+export default withOuiaContext(ProcessDetailsPage);

--- a/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/ProcessDetailsPage.test.tsx
+++ b/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/ProcessDetailsPage.test.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import ProcessDetailsPage from '../ProcessDetailsPage';
 import { MockedProvider } from '@apollo/react-testing';
 import gql from 'graphql-tag';
-import wait from 'waait';
+import { MemoryRouter } from 'react-router-dom';
+import { getWrapper } from '@kogito-apps/common';
+import * as H from 'history';
 
 const props = {
   match: {
-    params: '1232131'
-  }
+    params: { instanceID: '1232131' },
+    url: '',
+    isExact: false,
+    path: ''
+  },
+  location: H.createLocation(''),
+  history: H.createBrowserHistory()
 };
 
 const GET_PROCESS_INSTANCE = gql`
@@ -85,15 +91,14 @@ const mocks = [
 ];
 
 describe('Process Details Page component', () => {
-  it('Sample test case', async () => {
-    const wrapper = shallow(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <ProcessDetailsPage {...props} />
-      </MockedProvider>
-    );
-    await wait(0);
-    const p = wrapper.find('p');
-    expect(p.length).toEqual(0);
-    expect(wrapper.find(ProcessDetailsPage)).toMatchSnapshot();
+  it('Sample test case', () => {
+    const wrapper = getWrapper(
+      <MemoryRouter>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <ProcessDetailsPage {...props} />
+        </MockedProvider>
+      </MemoryRouter>
+    , 'ProcessDetailsPage');
+    expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/__snapshots__/ProcessDetailsPage.test.tsx.snap
+++ b/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/__snapshots__/ProcessDetailsPage.test.tsx.snap
@@ -2,10 +2,321 @@
 
 exports[`Process Details Page component Sample test case 1`] = `
 <ProcessDetailsPage
-  match={
+  history={
     Object {
-      "params": "1232131",
+      "action": "POP",
+      "block": [Function],
+      "createHref": [Function],
+      "go": [Function],
+      "goBack": [Function],
+      "goForward": [Function],
+      "length": 1,
+      "listen": [Function],
+      "location": Object {
+        "hash": "",
+        "pathname": "/",
+        "search": "",
+        "state": undefined,
+      },
+      "push": [Function],
+      "replace": [Function],
     }
   }
-/>
+  location={
+    Object {
+      "hash": "",
+      "pathname": "/",
+      "search": "",
+      "state": undefined,
+    }
+  }
+  match={
+    Object {
+      "isExact": false,
+      "params": Object {
+        "instanceID": "1232131",
+      },
+      "path": "",
+      "url": "",
+    }
+  }
+  ouiaContext={
+    Object {
+      "isOuia": false,
+      "ouiaId": null,
+    }
+  }
+>
+  <PageSection
+    variant="light"
+  >
+    <section
+      className="pf-c-page__main-section pf-m-light"
+    >
+      <Modalbox
+        completedMessageObj={Object {}}
+        handleModalToggle={[Function]}
+        isAbortModalOpen={false}
+        isModalOpen={false}
+        isSingleAbort={true}
+        modalTitle={
+          <React.Fragment>
+            <InfoCircleIcon
+              className="pf-u-mr-sm"
+              color="var(--pf-global--info-color--100)"
+              noVerticalAlign={false}
+              size="sm"
+              title={null}
+            />
+             
+            Abort operation
+             
+          </React.Fragment>
+        }
+      >
+        <Modal
+          actions={
+            Array [
+              <Unknown
+                onClick={[Function]}
+                variant="primary"
+              >
+                OK
+              </Unknown>,
+            ]
+          }
+          appendTo={
+            <body>
+              <div />
+              <div />
+            </body>
+          }
+          ariaDescribedById=""
+          className=""
+          header={
+            <Title
+              headingLevel="h1"
+              size="2xl"
+            >
+              <React.Fragment>
+                <InfoCircleIcon
+                  className="pf-u-mr-sm"
+                  color="var(--pf-global--info-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                  title={null}
+                />
+                 
+                Abort operation
+                 
+              </React.Fragment>
+            </Title>
+          }
+          hideTitle={false}
+          isFooterLeftAligned={false}
+          isLarge={false}
+          isOpen={false}
+          isSmall={true}
+          onClose={[Function]}
+          showClose={true}
+          title=""
+        >
+          <Portal
+            containerInfo={<div />}
+          >
+            <ModalContent
+              actions={
+                Array [
+                  <Unknown
+                    onClick={[Function]}
+                    variant="primary"
+                  >
+                    OK
+                  </Unknown>,
+                ]
+              }
+              ariaDescribedById=""
+              className=""
+              header={
+                <Title
+                  headingLevel="h1"
+                  size="2xl"
+                >
+                  <React.Fragment>
+                    <InfoCircleIcon
+                      className="pf-u-mr-sm"
+                      color="var(--pf-global--info-color--100)"
+                      noVerticalAlign={false}
+                      size="sm"
+                      title={null}
+                    />
+                     
+                    Abort operation
+                     
+                  </React.Fragment>
+                </Title>
+              }
+              hideTitle={false}
+              id="pf-modal-0"
+              isFooterLeftAligned={false}
+              isLarge={false}
+              isOpen={false}
+              isSmall={true}
+              onClose={[Function]}
+              showClose={true}
+              title=""
+            />
+          </Portal>
+        </Modal>
+      </Modalbox>
+      <Modalbox
+        modalContent=""
+      >
+        <Modal
+          actions={
+            Array [
+              <Unknown
+                variant="primary"
+              >
+                OK
+              </Unknown>,
+            ]
+          }
+          appendTo={
+            <body>
+              <div />
+              <div />
+            </body>
+          }
+          ariaDescribedById=""
+          className=""
+          header={
+            <Title
+              headingLevel="h1"
+              size="2xl"
+            />
+          }
+          hideTitle={false}
+          isFooterLeftAligned={false}
+          isLarge={false}
+          isOpen={false}
+          isSmall={true}
+          onClose={[Function]}
+          showClose={true}
+          title=""
+        >
+          <Portal
+            containerInfo={<div />}
+          >
+            <ModalContent
+              actions={
+                Array [
+                  <Unknown
+                    variant="primary"
+                  >
+                    OK
+                  </Unknown>,
+                ]
+              }
+              ariaDescribedById=""
+              className=""
+              header={
+                <Title
+                  headingLevel="h1"
+                  size="2xl"
+                />
+              }
+              hideTitle={false}
+              id="pf-modal-1"
+              isFooterLeftAligned={false}
+              isLarge={false}
+              isOpen={false}
+              isSmall={true}
+              onClose={[Function]}
+              showClose={true}
+              title=""
+            />
+          </Portal>
+        </Modal>
+      </Modalbox>
+      <PageTitleComponent
+        title="Process Details"
+      >
+        <Title
+          headingLevel="h1"
+          size="4xl"
+        >
+          <h1
+            className="pf-c-title pf-m-4xl"
+          >
+            Process Details
+          </h1>
+        </Title>
+      </PageTitleComponent>
+    </section>
+  </PageSection>
+  <PageSection>
+    <section
+      className="pf-c-page__main-section"
+    >
+      <Card>
+        <article
+          className="pf-c-card"
+        >
+          <Bullseye>
+            <div
+              className="pf-l-bullseye"
+            >
+              <EmptyStateSpinner
+                spinnerText="Loading process details..."
+              >
+                <EmptyState>
+                  <div
+                    className="pf-c-empty-state pf-m-lg"
+                  >
+                    <EmptyStateIcon
+                      component={[Function]}
+                      variant="container"
+                    >
+                      <div
+                        className="pf-c-empty-state__icon"
+                      >
+                        <Spinner>
+                          <span
+                            aria-valuetext="Loading..."
+                            className="pf-c-spinner pf-m-xl"
+                            role="progressbar"
+                          >
+                            <span
+                              className="pf-c-spinner__clipper"
+                            />
+                            <span
+                              className="pf-c-spinner__lead-ball"
+                            />
+                            <span
+                              className="pf-c-spinner__tail-ball"
+                            />
+                          </span>
+                        </Spinner>
+                      </div>
+                    </EmptyStateIcon>
+                    <Title
+                      size="lg"
+                    >
+                      <h1
+                        className="pf-c-title pf-m-lg"
+                      >
+                        Loading process details...
+                      </h1>
+                    </Title>
+                  </div>
+                </EmptyState>
+              </EmptyStateSpinner>
+            </div>
+          </Bullseye>
+        </article>
+      </Card>
+    </section>
+  </PageSection>
+</ProcessDetailsPage>
 `;

--- a/packages/management-console/webpack.common.js
+++ b/packages/management-console/webpack.common.js
@@ -29,7 +29,7 @@ module.exports = {
         test: /\.(tsx|ts)?$/,
         include: [
           path.resolve(__dirname, 'src'),
-          path.resolve('../../node_modules/@kogito-apps/common/src/components')
+          path.resolve('../../node_modules/@kogito-apps/common/src')
         ],
         use: [
           {

--- a/packages/task-console/src/components/Templates/DataListContainer/DataListContainer.tsx
+++ b/packages/task-console/src/components/Templates/DataListContainer/DataListContainer.tsx
@@ -4,7 +4,9 @@ import {
   Card,
   Grid,
   GridItem,
-  PageSection
+  PageSection,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
 import _ from 'lodash';
 import React, { useState, useEffect } from 'react';
@@ -15,8 +17,11 @@ import './DataList.css';
 import DataListComponent from '../../Organisms/DataListComponent/DataListComponent';
 import EmptyStateComponent from '../../Atoms/EmptyStateComponent/EmptyStateComponent';
 import { useGetUserTasksByStatesLazyQuery } from '../../../graphql/types';
+import { ouiaPageTypeAndObjectId } from '@kogito-apps/common';
 
-const DataListContainer: React.FC<{}> = () => {
+const DataListContainer: React.FC<InjectedOuiaProps> = ({
+  ouiaContext
+}) => {
   const [initData, setInitData] = useState<any>([]);
   const [checkedArray, setCheckedArray] = useState<any>(['Ready']);
   const [isLoading, setIsLoading] = useState(false);
@@ -40,6 +45,8 @@ const DataListContainer: React.FC<{}> = () => {
     setIsLoading(loading);
     setInitData(data);
   }, [data]);
+
+  useEffect(() => { return ouiaPageTypeAndObjectId(ouiaContext, "user-tasks") })
 
   return (
     <React.Fragment>
@@ -92,4 +99,4 @@ const DataListContainer: React.FC<{}> = () => {
   );
 };
 
-export default DataListContainer;
+export default withOuiaContext(DataListContainer);

--- a/packages/task-console/src/components/Templates/DataListContainerExpandable/DataListContainerExpandable.tsx
+++ b/packages/task-console/src/components/Templates/DataListContainerExpandable/DataListContainerExpandable.tsx
@@ -5,20 +5,27 @@ import {
   Grid,
   GridItem,
   PageSection,
-  Expandable
+  Expandable,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import PageTitleComponent from '../../Molecules/PageTitleComponent/PageTitleComponent';
 import './DataListExpandable.css';
 import DataListComponentByState from '../../Organisms/DataListComponentByState/DataListComponentByState';
+import { ouiaPageTypeAndObjectId } from '@kogito-apps/common';
 
-const DataListContainerExpandable: React.FC<{}> = () => {
+const DataListContainerExpandable: React.FC<InjectedOuiaProps> = ({
+  ouiaContext
+}) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const onToggle = () => {
     setIsExpanded(!isExpanded);
   };
+
+  useEffect(() => { return ouiaPageTypeAndObjectId(ouiaContext, "user-tasks") })
 
   return (
     <React.Fragment>
@@ -48,4 +55,4 @@ const DataListContainerExpandable: React.FC<{}> = () => {
   );
 };
 
-export default DataListContainerExpandable;
+export default withOuiaContext(DataListContainerExpandable);

--- a/packages/task-console/src/components/Templates/PageLayoutComponent/PageLayoutComponent.tsx
+++ b/packages/task-console/src/components/Templates/PageLayoutComponent/PageLayoutComponent.tsx
@@ -2,25 +2,38 @@ import React from 'react';
 import {
   Nav,
   NavList,
-  NavItem
+  NavItem,
+  InjectedOuiaProps,
+  withOuiaContext
 } from '@patternfly/react-core';
-import { PageLayout } from '@kogito-apps/common';
+import { PageLayout, ouiaAttribute } from '@kogito-apps/common';
 import { Redirect, Route, Link, Switch } from 'react-router-dom';
 import taskConsoleLogo from '../../../static/taskConsoleLogo.svg';
 import DataListContainerExpandable from "../DataListContainerExpandable/DataListContainerExpandable";
 import DataListContainer from "../DataListContainer/DataListContainer";
+import {Location, History} from 'history'
 
-const PageLayoutComponent = props => {
+interface IOwnProps {
+  location: Location,
+  history: History
+}
+const PageLayoutComponent: React.FC<IOwnProps & InjectedOuiaProps> = ({
+  ouiaContext,
+  ...props
+}) => {
   const { pathname } = props.location;
 
   const PageNav = (
     <Nav aria-label="Nav" theme="dark" css="">
       <NavList>
         <NavItem isActive={pathname === '/UserTasks'}>
-          <Link to="/UserTasks">User Tasks</Link>
+          <Link to="/UserTasks"
+            {...ouiaAttribute(ouiaContext, "data-ouia-navigation-name", "user-tasks")}
+          >User Tasks</Link>
         </NavItem>
         <NavItem isActive={pathname === '/UserTasksFilters'}>
-          <Link to="/UserTasksFilters">User tasks with filters</Link>
+          <Link to="/UserTasksFilters"
+            {...ouiaAttribute(ouiaContext, "data-ouia-navigation-name", "user-tasks-filters")}>User tasks with filters</Link>
         </NavItem>
       </NavList>
     </Nav>
@@ -51,4 +64,4 @@ const PageLayoutComponent = props => {
   );
 };
 
-export default PageLayoutComponent;
+export default withOuiaContext(PageLayoutComponent);

--- a/packages/task-console/webpack.common.js
+++ b/packages/task-console/webpack.common.js
@@ -14,7 +14,7 @@ module.exports = {
       {
         include: [
           path.resolve(__dirname, 'src'),
-          path.resolve('../../node_modules/@kogito-apps/common/src/components')
+          path.resolve('../../node_modules/@kogito-apps/common/src')
         ],
         test: /\.(tsx|ts)?$/,
         use: [


### PR DESCRIPTION
Hello, please review. This is an attempt to make management-console OUIA:Page compliant. The rules are straight-forward in this case:

There are following rules for OUIA:Page compliance (1):
* <body> element to have attributes:
  * data-ouia-page-type -> based on the page we're on (process-instances vs. domain-modeler)
  * data-ouia-page-object-id (OPTIONAL) -> in process details or for specific domain-name
  * data-ouia-page-action -> for pages that represent a certain action (optional when there's a single one) - we probably don't have such actions like 'edit', or similar
* page fragments identified by:
  * data-ouia-header="true" - For the header
  * data-ouia-footer="true" - For the footer
  * data-ouia-main="true" - For the main content pane
  * data-ouia-navigation="true" - For the main navigation pane
  * Header, Footer and Main MUST NOT ever be nested inside each other.
  * Navigation MAY live inside any of the other content areas but must appear only once.


(1) https://ouia.readthedocs.io/en/latest/README.html#specification-parts