### PR TITLE
KOGITO-2279 - Add trusty CI pipeline

### DIFF
--- a/.github/workflows/trustyCI.yml
+++ b/.github/workflows/trustyCI.yml
@@ -1,0 +1,23 @@
+name: Trusty experimental CI
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths:
+    - 'trusty/**'
+    - 'explainability-service/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    - name: Build kogito-runtimes
+      run: git clone https://github.com/kiegroup/kogito-runtimes.git /tmp/kogito-runtimes && mvn clean install -DskipTests -f /tmp/kogito-runtimes/pom.xml     
+    - name: Build trusty service
+      run: mvn -B package --file trusty/pom.xml
+    - name: Build explanability service
+      run: mvn -B package --file explainability-service/pom.xml 

--- a/.github/workflows/trustyCI.yml
+++ b/.github/workflows/trustyCI.yml
@@ -17,7 +17,5 @@ jobs:
         java-version: 1.11
     - name: Build kogito-runtimes
       run: git clone https://github.com/kiegroup/kogito-runtimes.git /tmp/kogito-runtimes && mvn clean install -DskipTests -f /tmp/kogito-runtimes/pom.xml     
-    - name: Build trusty service
-      run: mvn -B package --file trusty/pom.xml
-    - name: Build explanability service
-      run: mvn -B package --file explainability-service/pom.xml 
+    - name: Build kogito-apps with experimental flag
+      run: mvn -B package --file pom.xml -Pexperimental


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/KOGITO-2279

Hi, this PR adds the CI for the trusty services (flagged as experimental). The github action is run if and only if a pull request changes anything in the directories `trusty` and `explanability-service`. 

In my fork you can find some tests that I've made https://github.com/r00ta/kogito-apps/pulls :
1) the `trustyCI.yml` is already in my master branch
2) in the first pull request nothing has changed in the two modules mentioned above -> the CI is not run. 
3) in the second PR a file in the `trusty` module has changed -> the CI is run
4) in the third PR a file in the `explainability-service` has changed -> the CI is run. 

We propose to use this github action instead of a daily job running on jenkins. Since the trusty services are flagged as experimental, we just need a CI to run our tests in the PRs. This CI is going to be removed as soon as the `experimental` flag is removed from the trusty services. 

Looking forward your feedbacks :) 