### PR TITLE
KOGITO-2163 add utils methods for testing and OUIA

### DIFF
--- a/packages/common/src/utils/OuiaUtils.ts
+++ b/packages/common/src/utils/OuiaUtils.ts
@@ -1,27 +1,49 @@
 import { ReactElement } from 'react';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
+import wait from 'waait';
 import { act } from 'react-dom/test-utils';
 
-/** 
- * ugly workaround for the mount function in getWrapper to wait until component does all the hooks and effects
+/**
+ * Wrapper used in asynchronous snapshot tests to wait for the asynchronous action to complete and get rid
+ * of unnecessary wrappers of components in resulting snapshots.
+ *
+ * For use with MockedProvider mainly.
+ *
+ * Typical usage:
+ * it('test case', async () => {
+ *   const wrapper = await getWrapperAsync(
+ *     <MockedProvider>
+ *       <MyComponent />
+ *     </MockedProvider>
+ *     , 'MyComponent')
+ *   expect(wrapper).toMatchSnapshot()
+ * })
+ *
+ * @param component The actual component with wrappers, e.g. <MockedProvider mocks=mockedData><MyGreatComponent /></MockedProvider>
+ * @param name name of the component to be extracted as string, e.g. 'MyGreatComponent'
  */
-const waitForComponentToPaint = async (wrapper: any) => {
+export const getWrapperAsync = async (component: ReactElement, name: string): Promise<ReactWrapper> => {
+  const wrapper = mount(component);
+  // tslint:disable-next-line: await-promise
   await act(async () => {
-    await new Promise(resolve => setTimeout(resolve, 0));
-    wrapper.update();
-  });
-};
+    await wait(0)
+  })
+  const promise: Promise<ReactWrapper> = new Promise(resolve => { resolve(wrapper.update().find(name)) })
+  return promise
+}
 
 /**
  * Wrapper used in snapshot testing to get rid of unnecessary wrappers of components.
- * Not only OUIA wrappers, but also Routers, MockedProvider,...
+ * Not only OUIA wrappers, but also Routers,...
+ *
+ * Not for use with Apollo's MockedProvider, use getWrapperAsync instead
+ *
  * @param component The actual component with wrappers, e.g. <Router><MyGreatComponent /></Router>
  * @param name name of the component to be extracted as string, e.g. 'MyGreatComponent'
  */
-export const getWrapper = (component: ReactElement, name: string) => {
-  const wrapper = mount(component)
-  waitForComponentToPaint(wrapper)
-  return wrapper.find(name)
+export const getWrapper = (component: ReactElement, name: string): ReactWrapper => {
+  const wrapper = mount(component);
+  return wrapper.update().find(name)
 }
 
 /**
@@ -49,10 +71,65 @@ export const ouiaPageTypeAndObjectId = (
  * Usage:
  * <div
  *   {...ouiaAttribute(ouiaContext,'name','value')}
+ * />
  * @param ouiaContext OUIAContext of the component wrapped with patternfly's withOuiaContext function.
  * @param name name of the attribute
  * @param value value of the attribute
  */
 export const ouiaAttribute = (ouiaContext, name: string, value: string) => {
-  return (ouiaContext.isOuia && {[name]:value})
+  return (ouiaContext.isOuia && { [name]: value })
+}
+
+/**
+ * Function to set OUIA attributes on the component. For use in components that extends on InjectedOUIAProps
+ * and are wrapped by withOuiaContext() into Higher-order component.
+ *
+ * Typical usage:
+ * const MyComponent:React.FC<InjectedOuiaProps> = ({
+ *   ouiaContext,
+ *   ouiaId
+ * }) => {
+ * return
+ *   <OtherComponent {...componentOuiaProps(ouiaContext, ouiaId, 'MyComponent', !isLoading())} >
+ *   .
+ *   .
+ *   .
+ *   </OtherComponent>
+ * }
+ *
+ * @param ouiaContext ouiaContext provided by the higher-order component wrapper
+ * @param ouiaId id that is being passed to this component via the context (not to be set explicitly)
+ * @param ouiaType type of the component - typically a string explicitly provided to this function call
+ * @param isSafe boolean value indicating if the component is safe = is not doing any loading action.
+ */
+export const componentOuiaProps = (
+  ouiaContext,
+  ouiaId,
+  ouiaType,
+  isSafe?
+) => {
+  return ouiaContext.isOuia && {
+    'data-ouia-component-type': ouiaType,
+    'data-ouia-component-id': ouiaId || ouiaContext.ouiaId,
+    'data-ouia-safe': (isSafe) ? true : false
+  }
+};
+
+/**
+ * Function to set an data-ouia-component-id attribute if OUIA is enabled (either by default or in browser local storage `ouia:enabled`=true)
+ *
+ * Typical usage:
+ * <MyComponent>
+ *   <Button {...attributeOuiaId(ouiaContext, 'button-1')} />
+ *   <Button {...attributeOuiaId(ouiaContext, 'button-2')} />
+ * </MyComponent>
+ *
+ * @param ouiaContext ouiaContext provided by the higher-order component wrapper
+ * @param ouiaId id string value to be set as an id
+ */
+export const attributeOuiaId = (
+  ouiaContext,
+  ouiaId: string
+) => {
+  return ouiaAttribute(ouiaContext, 'ouiaId', ouiaId)
 }


### PR DESCRIPTION
Hello,

I had to distill the utils functions from the #236 so that they're available to everyone already.

It would be ideal for this to be merged asap and other PRs adapted to this, mainly in terms of writing snapshot tests.

This introduces two wrapper providing functions `getWrapper` and `getWrapperAsync` which are to be used instead of `mount` in all places.
After I submit the other changes from #236 `shallow` wrapper won't be possible to use anymore, so it is also encourage not to use that, but stick to the `getWrapper*` functions instead.

@AjayJagan @Sara4994 @yzhao583 @cristianonicolai @srambach 

Please mark others that I might have missed.