### PR TITLE
KOGITO-2465: Management Console version showing as DEV instead of 0.11.0

### DIFF
--- a/management-console/pom.xml
+++ b/management-console/pom.xml
@@ -214,7 +214,7 @@
                   <npmRegistryURL>${env.NPM_REGISTRY_URL}</npmRegistryURL>
                   <arguments>run build:prod</arguments>
                   <environmentVariables>
-                    <KOGITO_MANAGEMENTCONSOLE_VERSION>${project.version}</KOGITO_MANAGEMENTCONSOLE_VERSION>
+                    <KOGITO_APP_VERSION>${project.version}</KOGITO_APP_VERSION>
                 </environmentVariables>
                 </configuration>
               </execution>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2465

Changed the name of the property that fills the about page version 