### PR TITLE
KOGITO 2474 - refactoring InfinispanServerTestResource

### DIFF
--- a/data-index/data-index-service/pom.xml
+++ b/data-index/data-index-service/pom.xml
@@ -78,11 +78,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-infinispan-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -121,6 +116,11 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-kafka-client</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>persistence-commons-infinispan</artifactId>
+      <type>test-jar</type>
     </dependency>
   </dependencies>
   <build>

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/DataIndexInfinispanServerTestResource.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/DataIndexInfinispanServerTestResource.java
@@ -1,0 +1,14 @@
+package org.kie.kogito.index;
+
+import org.kie.kogito.persistence.infinispan.InfinispanServerTestResource;
+
+public class DataIndexInfinispanServerTestResource extends InfinispanServerTestResource {
+
+    @Override
+    public boolean shouldCleanCache(String cacheName) {
+        return cacheName.equals("processinstances")
+                || cacheName.endsWith("_domain")
+                || cacheName.equals("jobs")
+                || cacheName.equals("usertaskinstances");
+    }
+}

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/cache/QueryIT.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/cache/QueryIT.java
@@ -26,8 +26,8 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.index.DataIndexInfinispanServerTestResource;
 import org.kie.kogito.index.DataIndexStorageService;
-import org.kie.kogito.index.InfinispanServerTestResource;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.kie.kogito.persistence.api.query.AttributeFilter;
 
@@ -51,7 +51,7 @@ import static org.kie.kogito.persistence.api.query.QueryFilterFactory.lessThanEq
 import static org.kie.kogito.persistence.api.query.QueryFilterFactory.notNull;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanServerTestResource.class)
+@QuarkusTestResource(DataIndexInfinispanServerTestResource.class)
 public class QueryIT {
 
     @Inject

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/cache/StorageIT.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/cache/StorageIT.java
@@ -25,8 +25,8 @@ import javax.inject.Inject;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.index.DataIndexInfinispanServerTestResource;
 import org.kie.kogito.index.DataIndexStorageService;
-import org.kie.kogito.index.InfinispanServerTestResource;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.kie.kogito.index.model.ProcessInstanceState;
 import org.kie.kogito.persistence.api.Storage;
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.kie.kogito.index.TestUtils.getProcessInstance;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanServerTestResource.class)
+@QuarkusTestResource(DataIndexInfinispanServerTestResource.class)
 public class StorageIT {
 
     @Inject

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/graphql/WebSocketSubscriptionIT.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/graphql/WebSocketSubscriptionIT.java
@@ -34,7 +34,7 @@ import io.vertx.core.http.WebSocket;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.handler.graphql.ApolloWSMessageType;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.index.InfinispanServerTestResource;
+import org.kie.kogito.index.DataIndexInfinispanServerTestResource;
 import org.kie.kogito.index.TestUtils;
 import org.kie.kogito.index.event.KogitoJobCloudEvent;
 import org.kie.kogito.index.event.KogitoProcessCloudEvent;
@@ -56,7 +56,7 @@ import static org.kie.kogito.index.TestUtils.getTravelsProtoBufferFile;
 import static org.kie.kogito.index.TestUtils.getUserTaskCloudEvent;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanServerTestResource.class)
+@QuarkusTestResource(DataIndexInfinispanServerTestResource.class)
 public class WebSocketSubscriptionIT {
 
     @Inject

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/graphql/query/GraphQLQueryOrderByIT.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/graphql/query/GraphQLQueryOrderByIT.java
@@ -34,7 +34,7 @@ import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.index.InfinispanServerTestResource;
+import org.kie.kogito.index.DataIndexInfinispanServerTestResource;
 import org.kie.kogito.index.graphql.GraphQLSchemaManager;
 import org.kie.kogito.persistence.protobuf.ProtobufService;
 
@@ -44,7 +44,7 @@ import static org.hamcrest.CoreMatchers.isA;
 import static org.kie.kogito.index.TestUtils.getTravelsProtoBufferFile;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanServerTestResource.class)
+@QuarkusTestResource(DataIndexInfinispanServerTestResource.class)
 public class GraphQLQueryOrderByIT {
 
     @Inject

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/messaging/ReactiveMessagingEventConsumerKafkaIT.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/messaging/ReactiveMessagingEventConsumerKafkaIT.java
@@ -33,7 +33,7 @@ import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.index.InfinispanServerTestResource;
+import org.kie.kogito.index.DataIndexInfinispanServerTestResource;
 import org.kie.kogito.index.KafkaTestResource;
 import org.kie.kogito.persistence.protobuf.ProtobufService;
 
@@ -45,7 +45,7 @@ import static org.kie.kogito.index.TestUtils.getTravelsProtoBufferFile;
 import static org.kie.kogito.index.TestUtils.readFileContent;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanServerTestResource.class)
+@QuarkusTestResource(DataIndexInfinispanServerTestResource.class)
 @QuarkusTestResource(KafkaTestResource.class)
 public class ReactiveMessagingEventConsumerKafkaIT {
 

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/service/IndexingServiceIT.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/service/IndexingServiceIT.java
@@ -34,7 +34,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.index.InfinispanServerTestResource;
+import org.kie.kogito.index.DataIndexInfinispanServerTestResource;
 import org.kie.kogito.index.event.KogitoJobCloudEvent;
 import org.kie.kogito.index.event.KogitoProcessCloudEvent;
 import org.kie.kogito.index.event.KogitoUserTaskCloudEvent;
@@ -65,7 +65,7 @@ import static org.kie.kogito.index.model.ProcessInstanceState.COMPLETED;
 import static org.kie.kogito.index.model.ProcessInstanceState.ERROR;
 
 @QuarkusTest
-@QuarkusTestResource(InfinispanServerTestResource.class)
+@QuarkusTestResource(DataIndexInfinispanServerTestResource.class)
 public class IndexingServiceIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexingServiceIT.class);

--- a/data-index/data-index-service/src/test/java/org/kie/kogito/index/service/KeycloakIntegrationIndexingServiceIT.java
+++ b/data-index/data-index-service/src/test/java/org/kie/kogito/index/service/KeycloakIntegrationIndexingServiceIT.java
@@ -21,14 +21,14 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 import org.keycloak.representations.AccessTokenResponse;
-import org.kie.kogito.index.InfinispanServerTestResource;
+import org.kie.kogito.index.DataIndexInfinispanServerTestResource;
 import org.kie.kogito.index.KeycloakServerTestResource;
 
 import static io.restassured.RestAssured.given;
 
 @QuarkusTest
 @QuarkusTestResource(KeycloakServerTestResource.class)
-@QuarkusTestResource(InfinispanServerTestResource.class)
+@QuarkusTestResource(DataIndexInfinispanServerTestResource.class)
 public class KeycloakIntegrationIndexingServiceIT {
 
     private static final String KEYCLOAK_SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8281/auth");

--- a/persistence-commons/persistence-commons-api/src/main/java/org/kie/kogito/persistence/api/Storage.java
+++ b/persistence-commons/persistence-commons-api/src/main/java/org/kie/kogito/persistence/api/Storage.java
@@ -32,11 +32,11 @@ public interface Storage<K, V> {
 
     Query<V> query();
 
-    V get(Object key);
+    V get(K key);
 
     V put(K key, V value);
 
-    V remove(Object key);
+    V remove(K key);
 
     boolean containsKey(K key);
 

--- a/persistence-commons/persistence-commons-infinispan/pom.xml
+++ b/persistence-commons/persistence-commons-infinispan/pom.xml
@@ -48,5 +48,31 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/persistence-commons/persistence-commons-infinispan/src/test/java/org/kie/kogito/persistence/infinispan/QuarkusTestResourceWithCleanupLifecycleManager.java
+++ b/persistence-commons/persistence-commons-infinispan/src/test/java/org/kie/kogito/persistence/infinispan/QuarkusTestResourceWithCleanupLifecycleManager.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.kie.kogito.index;
+package org.kie.kogito.persistence.infinispan;
 
 import java.util.Arrays;
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-2474

This PR moves the InfinispanServerTestResource to the `persistence-commons-infinispan` module, so that multiple modules can use this utility class (in particular, this is going to be needed by the trusty service in the next days).

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket