### PR TITLE
KOGITO-2465: Management Console version showing as DEV instead of 0.1…

### DIFF
--- a/packages/common/src/components/Molecules/AboutModalBox/tests/AboutModalBox.test.tsx
+++ b/packages/common/src/components/Molecules/AboutModalBox/tests/AboutModalBox.test.tsx
@@ -8,6 +8,7 @@ const props = {
 };
 describe('AboutModal component tests', () => {
   it('snapshot testing', () => {
+    process.env.KOGITO_APP_VERSION='1.2.3-MOCKED-VERSION';
     const wrapper = shallow(<AboutModal {...props} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/packages/common/src/components/Molecules/AboutModalBox/tests/__snapshots__/AboutModalBox.test.tsx.snap
+++ b/packages/common/src/components/Molecules/AboutModalBox/tests/__snapshots__/AboutModalBox.test.tsx.snap
@@ -27,7 +27,9 @@ exports[`AboutModal component tests snapshot testing 1`] = `
       </TextListItem>
       <TextListItem
         component="dd"
-      />
+      >
+        1.2.3-MOCKED-VERSION
+      </TextListItem>
       <TextListItem
         component="dt"
       >


### PR DESCRIPTION
…1.0 Fixing test snapshot
https://issues.redhat.com/browse/KOGITO-2465

Fix AboutModalBox test includiing the prop value