### PR TITLE
KOGITO-2486 - add javadoc to the class StorageService

### DIFF
--- a/persistence-commons/persistence-commons-api/src/main/java/org/kie/kogito/persistence/api/Storage.java
+++ b/persistence-commons/persistence-commons-api/src/main/java/org/kie/kogito/persistence/api/Storage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates. 
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,25 +24,83 @@ import org.kie.kogito.persistence.api.query.Query;
 
 public interface Storage<K, V> {
 
+    /**
+     * Adds a listener on the create events.
+     *
+     * @param consumer The listener.
+     */
     void addObjectCreatedListener(Consumer<V> consumer);
 
+    /**
+     * Adds a listener on the update events.
+     *
+     * @param consumer The listener.
+     */
     void addObjectUpdatedListener(Consumer<V> consumer);
 
+    /**
+     * Adds a listener on the remove events.
+     *
+     * @param consumer The listener.
+     */
     void addObjectRemovedListener(Consumer<K> consumer);
 
+    /**
+     * Gets the `Query` object to query the storage.
+     *
+     * @return The `Query` instance.
+     */
     Query<V> query();
 
+    /**
+     * Gets an element by key. If the element is not present in the storage, then `null` is returned.
+     *
+     * @param key The key.
+     * @return The element.
+     */
     V get(K key);
 
+    /**
+     * Puts an element with a key. If an element with the same key is already present in the storage, then it is replaced.
+     *
+     * @param key   The key.
+     * @param value The value.
+     * @return The value.
+     */
     V put(K key, V value);
 
+    /**
+     * Removes an element by key. If the element is not present in the storage, then `null` is returned.
+     *
+     * @param key The key.
+     * @return The removed object.
+     */
     V remove(K key);
 
+    /**
+     * Checks whether the storage contains a key.
+     *
+     * @param key The key.
+     * @return `true` if the key is present in the storage, `false` otherwise.
+     */
     boolean containsKey(K key);
 
+    /**
+     * Gets the pair key-value entry set of the elements in the storage.
+     *
+     * @return The key-value pair set of the elements in the storage.
+     */
     Set<Map.Entry<K, V>> entrySet();
 
+    /**
+     * Erase all the elements in the storage.
+     */
     void clear();
 
+    /**
+     * Gets the root type for the storage.
+     *
+     * @return The root type for the storage.
+     */
     String getRootType();
 }


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/KOGITO-2486

Since some methods of the interface `StorageService` are not completely clear, I think it is good to document them a bit with the javadoc. 

It is good to have some documentation so that all the implementations (infinispan, mongo etc..) can handle the corner cases in the same way.

For example: what the method `get` should do when the key does not exist in the storage? The same question might be done for the method `put` when the key is already there. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket