### PR TITLE
KOGITO-2464 Process list show load more buttons when no results found

### DIFF
--- a/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/ProcessListTable.tsx
+++ b/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/ProcessListTable.tsx
@@ -15,6 +15,7 @@ import ProcessInstanceState = GraphQL.ProcessInstanceState;
 
 interface IOwnProps {
   setInitData: any;
+  setLimit: (limit: number) => void;
   initData: any;
   isLoading: boolean;
   setIsError: any;
@@ -32,6 +33,7 @@ interface IOwnProps {
 const ProcessListTable: React.FC<IOwnProps> = ({
   initData,
   setInitData,
+  setLimit,
   isLoading,
   setIsError,
   checkedArray,
@@ -67,6 +69,7 @@ const ProcessListTable: React.FC<IOwnProps> = ({
         instance.isChecked = false;
         instance.isOpen = false;
       });
+      setLimit(data.ProcessInstances.length);
     }
     setInitData(data);
   }, [data]);

--- a/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/tests/ProcessListTable.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/tests/ProcessListTable.test.tsx
@@ -314,6 +314,7 @@ const mocks3 = [
 
 const props1 = {
   setInitData: jest.fn(),
+  setLimit: jest.fn(),
   isLoading: false,
   setIsError: jest.fn(),
   setIsLoading: jest.fn(),
@@ -337,6 +338,7 @@ const props1 = {
 
 const props2 = {
   setInitData: jest.fn(),
+  setLimit: jest.fn(),
   isLoading: false,
   setIsError: jest.fn(),
   setIsLoading: jest.fn(),
@@ -360,6 +362,7 @@ const props2 = {
 
 const props3 = {
   setInitData: jest.fn(),
+  setLimit: jest.fn(),
   isLoading: false,
   setIsError: jest.fn(),
   setIsLoading: jest.fn(),

--- a/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/tests/__snapshots__/ProcessListTable.test.tsx.snap
+++ b/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/tests/__snapshots__/ProcessListTable.test.tsx.snap
@@ -246,6 +246,21 @@ exports[`ProcessListTable component tests Snapshot testing initial empty data 1`
     }
   }
   setIsLoading={[MockFunction]}
+  setLimit={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          1,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
   setSelectedNumber={[MockFunction]}
 >
   <DataList
@@ -555,6 +570,21 @@ exports[`ProcessListTable component tests Snapshot testing with no data 1`] = `
     }
   }
   setIsLoading={[MockFunction]}
+  setLimit={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          0,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
   setSelectedNumber={[MockFunction]}
 >
   <DataList
@@ -1004,6 +1034,21 @@ exports[`ProcessListTable component tests Snapshot testing with success data 1`]
     }
   }
   setIsLoading={[MockFunction]}
+  setLimit={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          1,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
   setSelectedNumber={[MockFunction]}
 >
   <DataList
@@ -3073,6 +3118,21 @@ exports[`ProcessListTable component tests Snapshot testing with wrong query para
     }
   }
   setIsLoading={[MockFunction]}
+  setLimit={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          0,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
   setSelectedNumber={[MockFunction]}
 >
   <withRouter(ServerErrors)

--- a/ui-packages/packages/management-console/src/components/Templates/ProcessListPage/ProcessListPage.tsx
+++ b/ui-packages/packages/management-console/src/components/Templates/ProcessListPage/ProcessListPage.tsx
@@ -42,7 +42,7 @@ const ProcessListPage: React.FC<InjectedOuiaProps> = ({ ouiaContext }) => {
   const [titleType, setTitleType] = useState('');
   const [modalTitle, setModalTitle] = useState('');
   const [limit, setLimit] = useState(defaultPageSize);
-  const [offset, setOffset] = useState(10);
+  const [offset, setOffset] = useState(0);
   const [pageSize, setPageSize] = useState(defaultPageSize);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [filters, setFilters] = useState({
@@ -322,6 +322,7 @@ const ProcessListPage: React.FC<InjectedOuiaProps> = ({ ouiaContext }) => {
                 <ProcessListTable
                   initData={initData}
                   setInitData={setInitData}
+                  setLimit={setLimit}
                   isLoading={isLoading}
                   setIsError={setIsError}
                   checkedArray={checkedArray}

--- a/ui-packages/packages/management-console/src/components/Templates/ProcessListPage/tests/__snapshots__/ProcessListPage.test.tsx.snap
+++ b/ui-packages/packages/management-console/src/components/Templates/ProcessListPage/tests/__snapshots__/ProcessListPage.test.tsx.snap
@@ -298,12 +298,13 @@ exports[`ProcessListPage component tests Snapshot tests 1`] = `
                     setInitData={[Function]}
                     setIsAllChecked={[Function]}
                     setIsError={[Function]}
+                    setLimit={[Function]}
                     setSelectedNumber={[Function]}
                   />
                   <LoadMore
                     getMoreItems={[Function]}
                     isLoadingMore={false}
-                    offset={10}
+                    offset={0}
                     pageSize={10}
                     setOffset={[Function]}
                   >


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2464

Adds setLimit call on first query used to control how many items were loaded last time and to know if load more buttons have to be displayed. also set initial offset value to 0, to make pagination work propertly