### PR TITLE
KOGITO-1927 Debug logging activated for Jobs service

### DIFF
--- a/jobs-service/src/main/resources/application.properties
+++ b/jobs-service/src/main/resources/application.properties
@@ -16,7 +16,7 @@
 
 #Log Config
 quarkus.log.level=INFO
-quarkus.log.category."org.kie.kogito.jobs".level=DEBUG
+%dev.quarkus.log.category."org.kie.kogito.jobs".level=DEBUG
 
 ##Console
 quarkus.log.console.enable=true


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-1927

Changes the log level to DEBUG only on dev profile, like building with `"mvn clean compile quarkus:dev"`. For the normal build to generate the artifacts the log level will be set as INFO.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket