### PR TITLE
KOGITO-2807 - activate quarkus health addon in trusty services

### DIFF
--- a/explainability-service/pom.xml
+++ b/explainability-service/pom.xml
@@ -19,8 +19,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
-      <scope>test</scope>
+      <artifactId>quarkus-smallrye-health</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -29,6 +28,12 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-openapi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/trusty/trusty-service/pom.xml
+++ b/trusty/trusty-service/pom.xml
@@ -33,6 +33,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>trusty-storage-infinispan</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-2807

Activate the quarkus health addon so that the operator can check the status of the trusty services properly.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket