### PR TITLE
[KOGITO-2868] Fix Data index configured to use Infinispan fails to start on OCP

### DIFF
--- a/data-index/data-index-service/pom.xml
+++ b/data-index/data-index-service/pom.xml
@@ -28,10 +28,6 @@
       <artifactId>persistence-commons-protobuf</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>data-index-storage-mongodb</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx</artifactId>
     </dependency>
@@ -73,6 +69,13 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+
+    <!-- Enable MongoDB for test only -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>data-index-storage-mongodb</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Move MongoDB module to test scope to disable MongoDB health check by `quarkus-smallrye-health` extension.
The property `quarkus.mongodb.health.enabled` is fixed at build time, it cannot be changed at runtime.
Move the MongoDB module to test scope and will figure out other option to switch persistence for data index.

https://issues.redhat.com/browse/KOGITO-2868
https://kie.zulipchat.com/#narrow/stream/232676-kogito/topic/Data.20index.20support.20for.20MonfoDB

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket