### PR TITLE
FAI-237 - multiple seed non-deterministic tests

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/LimeExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/LimeExplainer.java
@@ -213,7 +213,7 @@ public class LimeExplainer implements LocalExplainer<Saliency> {
         // as per LIME paper, the dataset size should be at least |features|^2
         double perturbedDataSize = Math.max(noOfSamples, Math.pow(2, noOfFeatures));
         for (int i = 0; i < perturbedDataSize; i++) {
-            perturbedInputs.add(DataUtils.perturbFeatures(predictionInput, noOfSamples, noOfPerturbations));
+            perturbedInputs.add(DataUtils.perturbFeatures(predictionInput, noOfPerturbations));
         }
         return perturbedInputs;
     }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
@@ -44,7 +44,9 @@ import org.kie.kogito.explainability.model.Type;
  */
 public class DataUtils {
 
-    private final static Random random = new Random();
+    private DataUtils() {}
+
+    private static final Random random = new Random();
 
     public static void setSeed(long seed) {
         random.setSeed(seed);
@@ -156,11 +158,10 @@ public class DataUtils {
      * Which feature will be perturbed is non deterministic.
      *
      * @param input             the input whose features need to be perturbed
-     * @param noOfSamples       the no. of samples that need to be generated when perturbing numeric features
      * @param noOfPerturbations the no. of features to be perturbed
      * @return a new input with perturbed features
      */
-    public static PredictionInput perturbFeatures(PredictionInput input, int noOfSamples, int noOfPerturbations) {
+    public static PredictionInput perturbFeatures(PredictionInput input, int noOfPerturbations) {
         List<Feature> originalFeatures = input.getFeatures();
         List<Feature> newFeatures = new ArrayList<>(originalFeatures);
         PredictionInput perturbedInput = new PredictionInput(newFeatures);
@@ -353,7 +354,6 @@ public class DataUtils {
                 break;
             case CATEGORICAL:
                 if (names.contains(featureName)) {
-                    String category = feature.getValue().asString();
                     f = FeatureFactory.newCategoricalFeature(featureName, "");
                 }
                 break;

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
@@ -17,7 +17,6 @@ package org.kie.kogito.explainability.utils;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
@@ -29,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 
@@ -44,7 +44,7 @@ import org.kie.kogito.explainability.model.Type;
  */
 public class DataUtils {
 
-    private final static SecureRandom random = new SecureRandom();
+    private final static Random random = new Random();
 
     public static void setSeed(long seed) {
         random.setSeed(seed);

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/ExplainabilityMetrics.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/ExplainabilityMetrics.java
@@ -36,8 +36,14 @@ import org.kie.kogito.explainability.model.Type;
 public class ExplainabilityMetrics {
 
     /**
-     * Measure the explainability of an explanation as per paper "Towards Quantification of Explainability in Explainable
-     * Artificial Intelligence Methods" by Islam et al.
+     * Drop in confidence score threshold for impact score calculation.
+     * Confidence scores below {@code originalScore * CONFIDENCE_DROP_RATIO} are considered impactful for a model.
+     */
+    private static final double CONFIDENCE_DROP_RATIO = 0.2d;
+
+    /**
+     * Measure the explainability of an explanation.
+     * See paper: "Towards Quantification of Explainability in Explainable Artificial Intelligence Methods" by Islam et al.
      *
      * @param inputCognitiveChunks  the no. of cognitive chunks (pieces of information) required to generate the
      *                              explanation (e.g. the no. of explanation inputs)
@@ -53,13 +59,15 @@ public class ExplainabilityMetrics {
     /**
      * Calculate the impact of dropping the most important features (given by {@link Saliency#getTopFeatures(int)} from the input.
      * Highly important features would have rather high impact.
+     * See paper: Qiu Lin, Zhong, et al. "Do Explanations Reflect Decisions? A Machine-centric Strategy to Quantify the
+     * Performance of Explainability Algorithms." 2019.
      *
      * @param model       the model to be explained
      * @param prediction  a prediction
      * @param topFeatures the list of important features that should be dropped
      * @return the saliency impact
      */
-    public static double saliencyImpact(PredictionProvider model, Prediction prediction, List<FeatureImportance> topFeatures) {
+    public static double impactScore(PredictionProvider model, Prediction prediction, List<FeatureImportance> topFeatures) {
         List<String> importantFeatureNames = topFeatures.stream().map(f -> f.getFeature().getName()).collect(Collectors.toList());
 
         List<Feature> newFeatures = new LinkedList<>();
@@ -75,21 +83,15 @@ public class ExplainabilityMetrics {
         for (int i = 0; i < size; i++) {
             Output original = prediction.getOutput().getOutputs().get(i);
             Output modified = predictionOutput.getOutputs().get(i);
-            impact += 0.5 * DataUtils.euclideanDistance(new double[]{original.getScore()}, new double[]{modified.getScore()});
-            String x = original.getValue().asString();
-            String y = modified.getValue().asString();
-            if (x.length() == y.length()) {
-                impact += DataUtils.hammingDistance(x, y);
-            } else {
-                impact += 1d;
-            }
+            impact += (!original.getValue().asString().equals(modified.getValue().asString())
+                    || modified.getScore() < original.getScore() * CONFIDENCE_DROP_RATIO) ? 1d : 0d;
         }
         return impact / size;
     }
 
     /**
      * Calculate fidelity (accuracy) of boolean classification outputs using saliency predictor function = sign(sum(saliency.scores))
-     * see papers:
+     * See papers:
      * - Guidotti Riccardo, et al. "A survey of methods for explaining black box models." ACM computing surveys (2018).
      * - Bodria, Francesco, et al. "Explainability Methods for Natural Language Processing: Applications to Sentiment Analysis (Discussion Paper)."
      *

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/ExplainabilityMetrics.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/ExplainabilityMetrics.java
@@ -41,6 +41,8 @@ public class ExplainabilityMetrics {
      */
     private static final double CONFIDENCE_DROP_RATIO = 0.2d;
 
+    private ExplainabilityMetrics() {}
+
     /**
      * Measure the explainability of an explanation.
      * See paper: "Towards Quantification of Explainability in Explainable Artificial Intelligence Methods" by Islam et al.

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/TestUtils.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/TestUtils.java
@@ -15,7 +15,6 @@
  */
 package org.kie.kogito.explainability;
 
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,12 +31,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestUtils {
-
-    private final static SecureRandom random = new SecureRandom();
-
-    static {
-        random.setSeed(4);
-    }
 
     public static PredictionProvider getFeaturePassModel(int featureIndex) {
         return inputs -> {

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/lime/DummyModelsLimeExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/lime/DummyModelsLimeExplainerTest.java
@@ -17,9 +17,7 @@ package org.kie.kogito.explainability.local.lime;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.explainability.TestUtils;
 import org.kie.kogito.explainability.model.Feature;
@@ -33,128 +31,125 @@ import org.kie.kogito.explainability.model.Saliency;
 import org.kie.kogito.explainability.utils.DataUtils;
 import org.kie.kogito.explainability.utils.ExplainabilityMetrics;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DummyModelsLimeExplainerTest {
 
-    @BeforeAll
-    static void setUpBefore() {
-        DataUtils.setSeed(4);
-    }
-
     @Test
     void testMapOneFeatureToOutputRegression() {
-        int idx = 1;
-        List<Feature> features = new LinkedList<>();
-        features.add(FeatureFactory.newNumericalFeature("f1", 100));
-        features.add(FeatureFactory.newNumericalFeature("f2", 20));
-        features.add(FeatureFactory.newNumericalFeature("f3", 0.1));
-        PredictionInput input = new PredictionInput(features);
-        PredictionProvider model = TestUtils.getFeaturePassModel(idx);
-        List<PredictionOutput> outputs = model.predict(List.of(input));
-        Prediction prediction = new Prediction(input, outputs.get(0));
+        for (int seed = 0; seed < 5; seed++) {
+            DataUtils.setSeed(seed);
+            int idx = 1;
+            List<Feature> features = new LinkedList<>();
+            features.add(FeatureFactory.newNumericalFeature("f1", 100));
+            features.add(FeatureFactory.newNumericalFeature("f2", 20));
+            features.add(FeatureFactory.newNumericalFeature("f3", 0.1));
+            PredictionInput input = new PredictionInput(features);
+            PredictionProvider model = TestUtils.getFeaturePassModel(idx);
+            List<PredictionOutput> outputs = model.predict(List.of(input));
+            Prediction prediction = new Prediction(input, outputs.get(0));
 
-        LimeExplainer limeExplainer = new LimeExplainer(100, 1);
-        Saliency saliency = limeExplainer.explain(prediction, model);
+            LimeExplainer limeExplainer = new LimeExplainer(100, 1);
+            Saliency saliency = limeExplainer.explain(prediction, model);
 
-        assertNotNull(saliency);
-        List<FeatureImportance> topFeatures = saliency.getTopFeatures(3);
-        assertEquals(topFeatures.get(0).getFeature().getName(), features.get(idx).getName());
-        assertTrue(topFeatures.get(1).getScore() < topFeatures.get(0).getScore() / 2);
-        assertTrue(topFeatures.get(2).getScore() < topFeatures.get(0).getScore() / 2);
-        double v = ExplainabilityMetrics.saliencyImpact(model, prediction, saliency.getTopFeatures(1));
-        assertThat(v).isGreaterThan(0);
+            assertNotNull(saliency);
+            List<FeatureImportance> topFeatures = saliency.getTopFeatures(3);
+            assertEquals(3, topFeatures.size());
+            assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
+        }
     }
 
     @Test
     void testUnusedFeatureRegression() {
-        int idx = 2;
-        List<Feature> features = new LinkedList<>();
-        features.add(FeatureFactory.newNumericalFeature("f1", 100));
-        features.add(FeatureFactory.newNumericalFeature("f2", 20));
-        features.add(FeatureFactory.newNumericalFeature("f3", 10));
-        PredictionProvider model = TestUtils.getSumSkipModel(idx);
-        PredictionInput input = new PredictionInput(features);
-        List<PredictionOutput> outputs = model.predict(List.of(input));
-        Prediction prediction = new Prediction(input, outputs.get(0));
-        LimeExplainer limeExplainer = new LimeExplainer(1000, 1);
-        Saliency saliency = limeExplainer.explain(prediction, model);
+        for (int seed = 0; seed < 5; seed++) {
+            DataUtils.setSeed(seed);
+            int idx = 2;
+            List<Feature> features = new LinkedList<>();
+            features.add(FeatureFactory.newNumericalFeature("f1", 100));
+            features.add(FeatureFactory.newNumericalFeature("f2", 20));
+            features.add(FeatureFactory.newNumericalFeature("f3", 10));
+            PredictionProvider model = TestUtils.getSumSkipModel(idx);
+            PredictionInput input = new PredictionInput(features);
+            List<PredictionOutput> outputs = model.predict(List.of(input));
+            Prediction prediction = new Prediction(input, outputs.get(0));
+            LimeExplainer limeExplainer = new LimeExplainer(1000, 1);
+            Saliency saliency = limeExplainer.explain(prediction, model);
 
-        assertNotNull(saliency);
-        List<FeatureImportance> perFeatureImportance = saliency.getPerFeatureImportance();
-
-        perFeatureImportance.sort((t1, t2) -> (int) (t2.getScore() - t1.getScore()));
-        assertTrue(perFeatureImportance.get(0).getScore() > 0);
-        assertTrue(perFeatureImportance.get(1).getScore() > 0);
-        assertEquals(features.get(idx).getName(), perFeatureImportance.get(2).getFeature().getName());
-        double v = ExplainabilityMetrics.saliencyImpact(model, prediction, saliency.getTopFeatures(1));
-        assertThat(v).isGreaterThan(0);
+            assertNotNull(saliency);
+            List<FeatureImportance> topFeatures = saliency.getTopFeatures(3);
+            assertEquals(3, topFeatures.size());
+            assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
+        }
     }
 
     @Test
     void testMapOneFeatureToOutputClassification() {
-        int idx = 1;
-        List<Feature> features = new LinkedList<>();
-        features.add(FeatureFactory.newNumericalFeature("f1", 1));
-        features.add(FeatureFactory.newNumericalFeature("f2", 2));
-        features.add(FeatureFactory.newNumericalFeature("f3", 3));
-        PredictionInput input = new PredictionInput(features);
-        PredictionProvider model = TestUtils.getEvenFeatureModel(idx);
-        List<PredictionOutput> outputs = model.predict(List.of(input));
-        Prediction prediction = new Prediction(input, outputs.get(0));
+        for (int seed = 0; seed < 5; seed++) {
+            DataUtils.setSeed(seed);
+            int idx = 1;
+            List<Feature> features = new LinkedList<>();
+            features.add(FeatureFactory.newNumericalFeature("f1", 1));
+            features.add(FeatureFactory.newNumericalFeature("f2", 1));
+            features.add(FeatureFactory.newNumericalFeature("f3", 3));
+            PredictionInput input = new PredictionInput(features);
+            PredictionProvider model = TestUtils.getEvenFeatureModel(idx);
+            List<PredictionOutput> outputs = model.predict(List.of(input));
+            Prediction prediction = new Prediction(input, outputs.get(0));
 
-        LimeExplainer limeExplainer = new LimeExplainer(100, 1);
-        Saliency saliency = limeExplainer.explain(prediction, model);
+            LimeExplainer limeExplainer = new LimeExplainer(1000, 1);
+            Saliency saliency = limeExplainer.explain(prediction, model);
 
-        assertNotNull(saliency);
-        List<FeatureImportance> topFeatures = saliency.getPositiveFeatures(1);
-        assertFalse(topFeatures.isEmpty());
-        assertEquals(features.get(idx).getName(), topFeatures.get(0).getFeature().getName());
+            assertNotNull(saliency);
+            List<FeatureImportance> topFeatures = saliency.getTopFeatures(3);
+            assertEquals(3, topFeatures.size());
+            assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
+        }
     }
 
     @Test
     void testTextSpamClassification() {
-        List<Feature> features = new LinkedList<>();
-        features.add(FeatureFactory.newTextFeature("f1", "we go here and there"));
-        features.add(FeatureFactory.newTextFeature("f2", "please give me some money"));
-        features.add(FeatureFactory.newTextFeature("f3", "dear friend, please reply"));
-        PredictionInput input = new PredictionInput(features);
-        PredictionProvider model = TestUtils.getDummyTextClassifier();
-        List<PredictionOutput> outputs = model.predict(List.of(input));
-        Prediction prediction = new Prediction(input, outputs.get(0));
+        for (int seed = 0; seed < 5; seed++) {
+            DataUtils.setSeed(seed);
+            List<Feature> features = new LinkedList<>();
+            features.add(FeatureFactory.newTextFeature("f1", "we go here and there"));
+            features.add(FeatureFactory.newTextFeature("f2", "please give me some money"));
+            features.add(FeatureFactory.newTextFeature("f3", "dear friend, please reply"));
+            PredictionInput input = new PredictionInput(features);
+            PredictionProvider model = TestUtils.getDummyTextClassifier();
+            List<PredictionOutput> outputs = model.predict(List.of(input));
+            Prediction prediction = new Prediction(input, outputs.get(0));
 
-        LimeExplainer limeExplainer = new LimeExplainer(1000, 1);
-        Saliency saliency = limeExplainer.explain(prediction, model);
+            LimeExplainer limeExplainer = new LimeExplainer(1000, 1);
+            Saliency saliency = limeExplainer.explain(prediction, model);
 
-        assertNotNull(saliency);
-        List<FeatureImportance> topFeatures = saliency.getPositiveFeatures(1);
-        assertEquals("money (f2)", topFeatures.get(0).getFeature().getName());
-        double v = ExplainabilityMetrics.saliencyImpact(model, prediction, saliency.getTopFeatures(1));
-        assertThat(v).isGreaterThan(0);
+            assertNotNull(saliency);
+            List<FeatureImportance> topFeatures = saliency.getTopFeatures(3);
+            assertEquals(3, topFeatures.size());
+            assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
+        }
     }
 
     @Test
     void testUnusedFeatureClassification() {
-        int idx = 2;
-        List<Feature> features = new LinkedList<>();
-        features.add(FeatureFactory.newNumericalFeature("f1", 6));
-        features.add(FeatureFactory.newNumericalFeature("f2", 3));
-        features.add(FeatureFactory.newNumericalFeature("f3", 5));
-        PredictionProvider model = TestUtils.getEvenSumModel(idx);
-        PredictionInput input = new PredictionInput(features);
-        List<PredictionOutput> outputs = model.predict(List.of(input));
-        Prediction prediction = new Prediction(input, outputs.get(0));
-        LimeExplainer limeExplainer = new LimeExplainer(1000, 1);
-        Saliency saliency = limeExplainer.explain(prediction, model);
+        for (int seed = 0; seed < 5; seed++) {
+            DataUtils.setSeed(seed);
+            int idx = 2;
+            List<Feature> features = new LinkedList<>();
+            features.add(FeatureFactory.newNumericalFeature("f1", 6));
+            features.add(FeatureFactory.newNumericalFeature("f2", 3));
+            features.add(FeatureFactory.newNumericalFeature("f3", 5));
+            PredictionProvider model = TestUtils.getEvenSumModel(idx);
+            PredictionInput input = new PredictionInput(features);
+            List<PredictionOutput> outputs = model.predict(List.of(input));
+            Prediction prediction = new Prediction(input, outputs.get(0));
+            LimeExplainer limeExplainer = new LimeExplainer(1000, 1);
+            Saliency saliency = limeExplainer.explain(prediction, model);
 
-        assertNotNull(saliency);
-        List<FeatureImportance> perFeatureImportance = saliency.getNegativeFeatures(3);
-        assertFalse(perFeatureImportance.stream().map(fi -> fi.getFeature().getName()).collect(Collectors.toList()).contains(features.get(idx).getName()));
-        double v = ExplainabilityMetrics.saliencyImpact(model, prediction, saliency.getNegativeFeatures(2));
-        assertThat(v).isGreaterThan(0);
+            assertNotNull(saliency);
+            List<FeatureImportance> topFeatures = saliency.getTopFeatures(3);
+            assertEquals(3, topFeatures.size());
+            assertEquals(1d, ExplainabilityMetrics.impactScore(model, prediction, topFeatures));
+        }
     }
 }

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/lime/LimeExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/lime/LimeExplainerTest.java
@@ -19,7 +19,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.explainability.TestUtils;
 import org.kie.kogito.explainability.local.LocalExplanationException;
@@ -36,33 +35,34 @@ import static org.mockito.Mockito.mock;
 
 class LimeExplainerTest {
 
-    @BeforeAll
-    static void setUpBefore() {
-        DataUtils.setSeed(4);
-    }
-
     @Test
     void testEmptyPrediction() {
-        LimeExplainer limeExplainer = new LimeExplainer(10, 1);
-        PredictionOutput output = mock(PredictionOutput.class);
-        PredictionInput input = mock(PredictionInput.class);
-        Prediction prediction = new Prediction(input, output);
-        PredictionProvider model = mock(PredictionProvider.class);
-        Assertions.assertThrows(LocalExplanationException.class, () -> limeExplainer.explain(prediction, model));
+        for (int seed = 0; seed < 5; seed++) {
+            DataUtils.setSeed(seed);
+            LimeExplainer limeExplainer = new LimeExplainer(10, 1);
+            PredictionOutput output = mock(PredictionOutput.class);
+            PredictionInput input = mock(PredictionInput.class);
+            Prediction prediction = new Prediction(input, output);
+            PredictionProvider model = mock(PredictionProvider.class);
+            Assertions.assertThrows(LocalExplanationException.class, () -> limeExplainer.explain(prediction, model));
+        }
     }
 
     @Test
     void testNonEmptyInput() {
-        LimeExplainer limeExplainer = new LimeExplainer(10, 1);
-        PredictionOutput output = mock(PredictionOutput.class);
-        List<Feature> features = new LinkedList<>();
-        for (int i = 0; i < 4; i++) {
-            features.add(TestUtils.getMockedNumericFeature());
+        for (int seed = 0; seed < 5; seed++) {
+            DataUtils.setSeed(seed);
+            LimeExplainer limeExplainer = new LimeExplainer(10, 1);
+            PredictionOutput output = mock(PredictionOutput.class);
+            List<Feature> features = new LinkedList<>();
+            for (int i = 0; i < 4; i++) {
+                features.add(TestUtils.getMockedNumericFeature());
+            }
+            PredictionInput input = new PredictionInput(features);
+            Prediction prediction = new Prediction(input, output);
+            PredictionProvider model = mock(PredictionProvider.class);
+            Saliency saliency = limeExplainer.explain(prediction, model);
+            assertNotNull(saliency);
         }
-        PredictionInput input = new PredictionInput(features);
-        Prediction prediction = new Prediction(input, output);
-        PredictionProvider model = mock(PredictionProvider.class);
-        Saliency saliency = limeExplainer.explain(prediction, model);
-        assertNotNull(saliency);
     }
 }

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/DataUtilsTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/DataUtilsTest.java
@@ -196,7 +196,7 @@ class DataUtilsTest {
     }
 
     private void assertPerturbDropNumeric(PredictionInput input, int noOfPerturbations) {
-        PredictionInput perturbedInput = DataUtils.perturbFeatures(input, 10, noOfPerturbations);
+        PredictionInput perturbedInput = DataUtils.perturbFeatures(input, noOfPerturbations);
         int changedFeatures = 0;
         for (int i = 0; i < input.getFeatures().size(); i++) {
             double v = input.getFeatures().get(i).getValue().asNumber();
@@ -209,7 +209,7 @@ class DataUtilsTest {
     }
 
     private void assertPerturbDropString(PredictionInput input, int noOfPerturbations) {
-        PredictionInput perturbedInput = DataUtils.perturbFeatures(input, 10, noOfPerturbations);
+        PredictionInput perturbedInput = DataUtils.perturbFeatures(input, noOfPerturbations);
         int changedFeatures = 0;
         for (int i = 0; i < input.getFeatures().size(); i++) {
             String v = input.getFeatures().get(i).getValue().asString();

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/LinearModelTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/LinearModelTest.java
@@ -15,7 +15,6 @@
  */
 package org.kie.kogito.explainability.utils;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.stream.DoubleStream;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class LinearModelTest {
 


### PR DESCRIPTION
This PR enforces different seeds to tests that involve non deterministic behaviour caused by randomly generated data.
It also contains an improvement to the `impact` calculation and refactored `DummyModelsLimeExplainerTest` to be consistent across the (dummy) models.
See https://issues.redhat.com/browse/FAI-237.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket