### PR TITLE
KOGITO-2928 - fix wrong explainability-service parent

### DIFF
--- a/explainability/explainability-service/pom.xml
+++ b/explainability/explainability-service/pom.xml
@@ -3,7 +3,7 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>kogito-apps</artifactId>
+    <artifactId>explainability</artifactId>
     <groupId>org.kie.kogito</groupId>
     <version>8.0.0-SNAPSHOT</version>
   </parent>


### PR DESCRIPTION
Move ´explainability-service´ parent to ´explainability´.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket