### PR TITLE
KOGITO-2939 Time sensitive snapshot in task-console

### DIFF
--- a/ui-packages/packages/task-console/src/components/Molecules/TaskListItem/tests/TaskListItem.test.tsx
+++ b/ui-packages/packages/task-console/src/components/Molecules/TaskListItem/tests/TaskListItem.test.tsx
@@ -25,6 +25,8 @@ import TaskConsoleContext, {
 
 import UserTaskInstance = GraphQL.UserTaskInstance;
 
+Date.now = jest.fn(() => 1595109600000); // UTC 2020-07-19 00:00:00
+
 const userTaskInstance: UserTaskInstance = {
   id: '45a73767-5da3-49bf-9c40-d533c3e77ef3',
   description: null,


### PR DESCRIPTION
failing test without mocked date.