### PR TITLE
KOGITO-2941: Sonarcloud coverage report is not adding the react part

### DIFF
--- a/ui-packages/package.json
+++ b/ui-packages/package.json
@@ -11,7 +11,7 @@
     "build": "lerna run build --stream --",
     "build:fast": "lerna run build:fast --stream --",
     "build:prod": "lerna run build:prod --stream --",
-    "test": "lerna run test --stream --",
+    "test": "lerna run test:coverage --stream --",
     "cypress:run": "lerna run cypress:run --",
     "cypress:run-management-console": "cypress run --project ./packages/management-console",
     "cypress:run-task-console": "cypress run --project ./packages/task-console",


### PR DESCRIPTION
Related jira: https://issues.redhat.com/browse/KOGITO-2941
Adds the test coverage when test are executed in ui-packages 