### PR TITLE
KOGITO-2726: changed parent to new kogito-build-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <parent>
     <groupId>org.kie.kogito</groupId>
-    <artifactId>kogito-runtimes</artifactId>
+    <artifactId>kogito-build-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>kogito-apps</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2726

This is followup of refactoring the kogito-bom as end user BOM from build requirements in parent

It depends on https://github.com/kiegroup/kogito-runtimes/pull/624