### PR TITLE
KOGITO-2973: Set default container images in TestResources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,13 @@
     <version.maven-remote-resources-plugin>1.7.0</version.maven-remote-resources-plugin>
 
     <version.org.infinispan>10.1.5.Final</version.org.infinispan>
-    <version.org.infinispan.image>10.1.5.Final</version.org.infinispan.image>
     <version.org.infinispan.protostream>4.3.2.Final</version.org.infinispan.protostream>
 
+    <version.org.keycloak>11.0.0</version.org.keycloak>
+
     <!-- containers used for testing -->
-    <container.image.infinispan>quay.io/infinispan/server:${version.org.infinispan.image}</container.image.infinispan>
-    <container.image.keycloak>quay.io/keycloak/keycloak:${version.org.keycloak.image}</container.image.keycloak>
+    <container.image.infinispan>quay.io/infinispan/server:${version.org.infinispan}</container.image.infinispan>
+    <container.image.keycloak>quay.io/keycloak/keycloak:${version.org.keycloak}</container.image.keycloak>
     <container.image.jobs-service>org.kie.kogito/jobs-service:${project.version}</container.image.jobs-service>
   </properties>
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-2973
Description: The images for containers are set at pom level. However, when running the tests via IDE, these images are not injected. This task is about to default the images.
When running the tests via maven, it won't make any change. But when running the tests via IDE, it will continue working as expected.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket