### PR TITLE
KOGITO-3017 fail maven build when yarn.lock updated during build

### DIFF
--- a/ui-packages/pom.xml
+++ b/ui-packages/pom.xml
@@ -147,7 +147,7 @@
                 </goals>
                 <configuration>
                   <npmRegistryURL>${env.NPM_REGISTRY_URL}</npmRegistryURL>
-                  <arguments>install --fetch-retry-mintimeout=100000 --fetch-retries=10</arguments>
+                  <arguments>install --fetch-retry-mintimeout=100000 --fetch-retries=10 --frozen-lockfile</arguments>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
Merge after #380.

Goal here is for the PR check to fail when the yarn.lock is updated during the build - that signals that the author forgot to commit the yarn.lock together with the changes.

This should not affect developers experience significantly - it's just during the maven build of ui-packages.