### PR TITLE
KOGITO-3018: Separate logic to generate ports in Integration Tests

### DIFF
--- a/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/it/KogitoServiceRandomPortTestResource.java
+++ b/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/it/KogitoServiceRandomPortTestResource.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kie.kogito.it;
+
+import org.kie.kogito.it.utils.SocketUtils;
+import org.kie.kogito.resources.TestResource;
+import org.testcontainers.Testcontainers;
+
+public class KogitoServiceRandomPortTestResource implements TestResource {
+
+    public static final String NAME = "kogito-service";
+
+    private static final String KOGITO_SERVICE_URL = "kogito.service.url";
+
+    private int httpPort;
+
+    @Override
+    public String getResourceName() {
+        return NAME;
+    }
+
+    @Override
+    public void start() {
+        httpPort = SocketUtils.findAvailablePort();
+        //Container should have access the host port where the test is running
+        //It should be called be fore the container is instantiated
+        Testcontainers.exposeHostPorts(httpPort);
+        //the hostname for the container to access the host is "host.testcontainers.internal"
+        //https://www.testcontainers.org/features/networking/#exposing-host-ports-to-the-container
+        System.setProperty(KOGITO_SERVICE_URL, "http://host.testcontainers.internal:" + httpPort);
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public int getMappedPort() {
+        return httpPort;
+    }
+
+}

--- a/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/it/jobs/BaseProcessTimerIT.java
+++ b/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/it/jobs/BaseProcessTimerIT.java
@@ -15,20 +15,15 @@
  */
 package org.kie.kogito.it.jobs;
 
-import java.util.function.IntSupplier;
-
-import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.Testcontainers;
 
 import static io.restassured.RestAssured.given;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.with;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.kie.kogito.testcontainers.JobServiceContainer.KOGITO_SERVICE_PORT;
 
 public abstract class BaseProcessTimerIT {
 
@@ -36,19 +31,6 @@ public abstract class BaseProcessTimerIT {
     public static final String TIMERS_CYCLE = "timerscycle";
     public static final String TIMERS_ON_TASK = "timersOnTask";
     public static final String KOGITO_SERVICE_URL = "kogito.service.url";
-    static Integer httpPort;
-
-    public static void beforeAll(IntSupplier httpPortSupplier) {
-        httpPort = httpPortSupplier.getAsInt();
-        //Container should have access the host port where the test is running
-        //It should be called be fore the container is instantiated
-        Testcontainers.exposeHostPorts(httpPort);
-        //the hostname for the container to access the host is "host.testcontainers.internal"
-        //https://www.testcontainers.org/features/networking/#exposing-host-ports-to-the-container
-        System.setProperty(KOGITO_SERVICE_URL, "http://host.testcontainers.internal:" + httpPort);
-        System.setProperty(KOGITO_SERVICE_PORT, String.valueOf(httpPort));
-        RestAssured.port = httpPort;
-    }
 
     //Timers Tests
     @Test

--- a/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/it/utils/SocketUtils.java
+++ b/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/it/utils/SocketUtils.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kie.kogito.it.utils;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.security.SecureRandom;
+
+import javax.net.ServerSocketFactory;
+
+public final class SocketUtils {
+
+    private static final int PORT_RANGE_MIN = 1024;
+    private static final int PORT_RANGE_MAX = 65535;
+    private static final SecureRandom RND = new SecureRandom();
+
+    private SocketUtils() {
+
+    }
+
+    public static final int findAvailablePort() {
+        int portRange = PORT_RANGE_MAX - PORT_RANGE_MIN;
+        int candidatePort;
+        int searchCounter = 0;
+        do {
+            if (searchCounter > portRange) {
+                throw new IllegalStateException(String.format(
+                                                              "Could not find an available port in the range [%d, %d] after %d attempts",
+                                                              PORT_RANGE_MIN, PORT_RANGE_MAX, searchCounter));
+            }
+            candidatePort = findRandomPort(PORT_RANGE_MIN, PORT_RANGE_MAX);
+            searchCounter++;
+        } while (!isPortAvailable(candidatePort));
+
+        return candidatePort;
+    }
+
+    private static final int findRandomPort(int minPort, int maxPort) {
+        int portRange = maxPort - minPort;
+        return minPort + RND.nextInt(portRange + 1);
+    }
+
+    private static final boolean isPortAvailable(int port) {
+        try {
+            ServerSocket serverSocket = ServerSocketFactory.getDefault().createServerSocket(port, 1, InetAddress.getByName("localhost"));
+            serverSocket.close();
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+}

--- a/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/testcontainers/JobServiceContainer.java
+++ b/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/testcontainers/JobServiceContainer.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.kie.kogito.resources.TestResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -34,25 +33,14 @@ public class JobServiceContainer extends GenericContainer<JobServiceContainer> i
 
     public static final String NAME = "jobs-service";
     public static final int PORT = 8080;
-    public static final String KOGITO_SERVICE_PORT = "kogito.service.port";
     public static final String IMAGE = "container.image." + NAME;
     private static final Logger LOGGER = LoggerFactory.getLogger(JobServiceContainer.class);
 
     public JobServiceContainer() {
-        //allow access to the host using hostname "host.testcontainers.internal"
-        final Integer hostPort = Optional.ofNullable(System.getProperty(KOGITO_SERVICE_PORT))
-                .map(Integer::parseInt)
-                .orElse(PORT);
-        Testcontainers.exposeHostPorts(hostPort);
         addExposedPort(PORT);
         withLogConsumer(new Slf4jLogConsumer(LOGGER));
         waitingFor(Wait.forLogMessage(".*Listening on:.*", 1));
         setDockerImageName(getImageName());
-    }
-
-    private String getImageName() {
-        return Optional.ofNullable(System.getProperty(IMAGE)).filter(StringUtils::isNotBlank)
-                .orElseThrow(() -> new IllegalArgumentException(IMAGE + " property should be set in pom.xml"));
     }
 
     @Override
@@ -63,5 +51,10 @@ public class JobServiceContainer extends GenericContainer<JobServiceContainer> i
     @Override
     public String getResourceName() {
         return NAME;
+    }
+
+    private String getImageName() {
+        return Optional.ofNullable(System.getProperty(IMAGE)).filter(StringUtils::isNotBlank)
+                       .orElseThrow(() -> new IllegalArgumentException(IMAGE + " property should be set in pom.xml"));
     }
 }

--- a/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/it/jobs/ProcessTimerIT.java
+++ b/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/it/jobs/ProcessTimerIT.java
@@ -17,20 +17,14 @@ package org.kie.kogito.it.jobs;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
-import org.eclipse.microprofile.config.ConfigProvider;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kie.kogito.resources.JobServiceQuarkusTestResource;
+import org.kie.kogito.resources.KogitoServiceRandomPortQuarkusTestResource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @QuarkusTest
+@QuarkusTestResource(KogitoServiceRandomPortQuarkusTestResource.class)
 @QuarkusTestResource(JobServiceQuarkusTestResource.class)
 @ExtendWith(MockitoExtension.class)
 public class ProcessTimerIT extends BaseProcessTimerIT {
-
-    @BeforeAll
-    public static void beforeAll() {
-        beforeAll(() -> ConfigProvider.getConfig().getValue("quarkus.http.test-port",
-                                                            Integer.class));
-    }
 }

--- a/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/resources/KogitoServiceRandomPortQuarkusTestResource.java
+++ b/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/resources/KogitoServiceRandomPortQuarkusTestResource.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kie.kogito.resources;
+
+import org.kie.kogito.it.KogitoServiceRandomPortTestResource;
+
+public class KogitoServiceRandomPortQuarkusTestResource extends ConditionalQuarkusTestResource {
+
+    public static final String QUARKUS_SERVICE_HTTP_PORT = "quarkus.http.test-port";
+
+    public KogitoServiceRandomPortQuarkusTestResource() {
+        super(new KogitoServiceRandomPortTestResource());
+    }
+
+    @Override
+    protected String getKogitoProperty() {
+        return QUARKUS_SERVICE_HTTP_PORT;
+    }
+
+    @Override
+    protected String getKogitoPropertyValue() {
+        return String.valueOf(getTestResource().getMappedPort());
+    }
+
+}

--- a/integration-tests/integration-tests-springboot/src/test/java/org/kie/kogito/it/jobs/ProcessTimerIT.java
+++ b/integration-tests/integration-tests-springboot/src/test/java/org/kie/kogito/it/jobs/ProcessTimerIT.java
@@ -15,22 +15,26 @@
  */
 package org.kie.kogito.it.jobs;
 
-import org.junit.jupiter.api.BeforeAll;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
 import org.kie.kogito.KogitoApplication;
 import org.kie.kogito.resources.JobServiceSpringBootTestResource;
+import org.kie.kogito.resources.KogitoServiceRandomPortSpringBootTestResource;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.util.SocketUtils;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, classes = {KogitoApplication.class})
-@ContextConfiguration(initializers = JobServiceSpringBootTestResource.class)
+@ContextConfiguration(initializers = {KogitoServiceRandomPortSpringBootTestResource.class, JobServiceSpringBootTestResource.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class ProcessTimerIT extends BaseProcessTimerIT {
 
-    @BeforeAll
-    public static void beforeAll() {
-        beforeAll(() -> SocketUtils.findAvailableTcpPort());
-        System.setProperty("server.port", String.valueOf(httpPort));
+    @Value("${server.port}")
+    private int httpPort;
+
+    @BeforeEach
+    public void setup() {
+        RestAssured.port = httpPort;
     }
 }

--- a/integration-tests/integration-tests-springboot/src/test/java/org/kie/kogito/resources/KogitoServiceRandomPortSpringBootTestResource.java
+++ b/integration-tests/integration-tests-springboot/src/test/java/org/kie/kogito/resources/KogitoServiceRandomPortSpringBootTestResource.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.kie.kogito.resources;
+
+import org.kie.kogito.it.KogitoServiceRandomPortTestResource;
+
+public class KogitoServiceRandomPortSpringBootTestResource extends ConditionalSpringBootTestResource {
+
+    public static final String SPRINGBOOT_SERVICE_HTTP_PORT = "server.port";
+
+    public KogitoServiceRandomPortSpringBootTestResource() {
+        super(new KogitoServiceRandomPortTestResource());
+    }
+
+    @Override
+    protected String getKogitoProperty() {
+        return SPRINGBOOT_SERVICE_HTTP_PORT;
+    }
+
+    @Override
+    protected String getKogitoPropertyValue() {
+        return String.valueOf(getTestResource().getMappedPort());
+    }
+
+}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3018
Description:
Create initializers (test resources) to create random ports for the running kogito service apps in ITs. This approach will help to run ITs with multiple kogito apps (jobs service, data index, etc) because we move the logic from the jobs service test resource to an isolated initialized.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket