### PR TITLE
KOGITO-3099 fixed a bug which breaks navigation from process details to process list page

### DIFF
--- a/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
+++ b/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
@@ -12,7 +12,7 @@ import {
   SplitItem,
   OverflowMenu,
   OverflowMenuContent,
-  OverflowMenuGroup,
+  OverflowMenuGroup
 } from '@patternfly/react-core';
 import {
   ServerErrors,
@@ -20,7 +20,8 @@ import {
   ItemDescriptor,
   KogitoSpinner,
   GraphQL,
-  componentOuiaProps, OUIAProps
+  componentOuiaProps,
+  OUIAProps
 } from '@kogito-apps/common';
 import React, { useState, useEffect } from 'react';
 import { Link, Redirect, RouteComponentProps } from 'react-router-dom';
@@ -43,13 +44,13 @@ enum TitleType {
 }
 
 const ProcessDetailsPage: React.FC<RouteComponentProps<MatchProps, {}, {}> &
-  OUIAProps> = ({ ouiaId,ouiaSafe , ...props }) => {
+  OUIAProps> = ({ ouiaId, ouiaSafe, ...props }) => {
   const id = props.match.params.instanceID;
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [modalTitle, setModalTitle] = useState<string>('');
   const [titleType, setTitleType] = useState<string>('');
   const [modalContent, setModalContent] = useState<string>('');
-  const currentPage = JSON.parse(window.localStorage.getItem('state'));
+  let currentPage = JSON.parse(window.localStorage.getItem('state'));
 
   const { loading, error, data } = GraphQL.useGetProcessInstanceByIdQuery({
     variables: { id }
@@ -65,7 +66,7 @@ const ProcessDetailsPage: React.FC<RouteComponentProps<MatchProps, {}, {}> &
   });
 
   useEffect(() => {
-    return ouiaPageTypeAndObjectId( 'process-instances', id);
+    return ouiaPageTypeAndObjectId('process-instances', id);
   });
 
   const onShowMessage = (
@@ -123,6 +124,7 @@ const ProcessDetailsPage: React.FC<RouteComponentProps<MatchProps, {}, {}> &
     const result = data.ProcessInstances;
     /* istanbul ignore else */
     if (currentPage) {
+      currentPage = { ...currentPage, ...props.location.state };
       const tempPath = currentPage.prev.split('/');
       prevPath = tempPath.filter(item => item);
       BreadCrumb.push(...prevPath);
@@ -218,7 +220,7 @@ const ProcessDetailsPage: React.FC<RouteComponentProps<MatchProps, {}, {}> &
           </PageSection>
           <PageSection>
             {!loading ? (
-              <Grid hasGutter md={1}span={12} lg={6} xl={4}>
+              <Grid hasGutter md={1} span={12} lg={6} xl={4}>
                 <GridItem span={12}>
                   <Split
                     hasGutter={true}

--- a/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/__snapshots__/ProcessDetailsPage.test.tsx.snap
+++ b/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/__snapshots__/ProcessDetailsPage.test.tsx.snap
@@ -573,6 +573,14 @@ exports[`Process Details Page component tests snapshot testing in Active state 1
                   }
                   from={
                     Object {
+                      "filters": Object {
+                        "businessKey": Array [
+                          "tra",
+                        ],
+                        "status": Array [
+                          "ACTIVE",
+                        ],
+                      },
                       "prev": "/ProcessInstances/8035b580-6ae4-4aa8-9ec0-e18e19809e0b",
                     }
                   }
@@ -1151,6 +1159,14 @@ exports[`Process Details Page component tests snapshot testing in Error state 1`
                   }
                   from={
                     Object {
+                      "filters": Object {
+                        "businessKey": Array [
+                          "tra",
+                        ],
+                        "status": Array [
+                          "ACTIVE",
+                        ],
+                      },
                       "prev": "/ProcessInstances/8035b580-6ae4-4aa8-9ec0-e18e19809e0b",
                     }
                   }
@@ -1729,6 +1745,14 @@ exports[`Process Details Page component tests snapshot testing in Suspended stat
                   }
                   from={
                     Object {
+                      "filters": Object {
+                        "businessKey": Array [
+                          "tra",
+                        ],
+                        "status": Array [
+                          "ACTIVE",
+                        ],
+                      },
                       "prev": "/ProcessInstances/8035b580-6ae4-4aa8-9ec0-e18e19809e0b",
                     }
                   }


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Description: This pr fixes a bug which breaks the application when navigating from process details page to process list page. The bug appears when we go to the details page of a parent process , navigate to a child process(present in the process details section) and then navigate to process list page.

JIRA : https://issues.redhat.com/browse/KOGITO-3099