### PR TITLE
KOGITO-3053 Upgrade kogito-apps to Quarkus 1.7

### DIFF
--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanJobRepository.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanJobRepository.java
@@ -91,7 +91,7 @@ public class InfinispanJobRepository extends BaseReactiveJobRepository implement
     public PublisherBuilder<JobDetails> findAll() {
         return ReactiveStreams
                 .fromIterable(queryFactory.from(JobDetails.class)
-                                      .build()
+                                      .<JobDetails>build()
                                       .list());
     }
 
@@ -102,12 +102,12 @@ public class InfinispanJobRepository extends BaseReactiveJobRepository implement
                                                     .in(Arrays.stream(status)
                                                                 .map(JobStatus::name)
                                                                 .collect(Collectors.toList()))
-                                                    .build()
+                                                    .<JobDetails>build()
                                                     .list());
     }
 
     public PublisherBuilder<JobDetails> findByStatusBetweenDatesOrderByPriority(ZonedDateTime from, ZonedDateTime to,
-                                                                                  JobStatus... status) {
+                                                                                JobStatus... status) {
         return ReactiveStreams.fromIterable(queryFactory.from(JobDetails.class)
                                                     .having("status")
                                                     .in(Arrays.stream(status)
@@ -118,7 +118,7 @@ public class InfinispanJobRepository extends BaseReactiveJobRepository implement
                                                     .between(DateUtil.zonedDateTimeToInstant(from),
                                                              DateUtil.zonedDateTimeToInstant(to))
                                                     .orderBy("priority", SortOrder.DESC)
-                                                    .build()
+                                                    .<JobDetails>build()
                                                     .list());
     }
 }

--- a/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/cache/JsonDataFormatMarshaller.java
+++ b/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/cache/JsonDataFormatMarshaller.java
@@ -44,7 +44,7 @@ public class JsonDataFormatMarshaller extends AbstractMarshaller {
         String json = object.toString();
         LOGGER.debug("Serializing JSON: \n{}", json);
         byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
-        return new ByteBufferImpl(bytes, 0, bytes.length);
+        return ByteBufferImpl.create(bytes, 0, bytes.length);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
   <description>Kogito Apps</description>
 
   <properties>
-    <version.io.quarkus>1.6.0.Final</version.io.quarkus>
     <version.frontend.plugin>1.9.1</version.frontend.plugin>
     <version.node>v12.16.2</version.node>
     <version.npm>6.10.3</version.npm>
@@ -24,9 +23,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <version.maven-remote-resources-plugin>1.7.0</version.maven-remote-resources-plugin>
 
-    <version.org.infinispan>10.1.5.Final</version.org.infinispan>
     <version.org.infinispan.image>10.1.5.Final</version.org.infinispan.image>
-    <version.org.infinispan.protostream>4.3.2.Final</version.org.infinispan.protostream>
 
     <!-- containers used for testing -->
     <container.image.infinispan>quay.io/infinispan/server:${version.org.infinispan.image}</container.image.infinispan>


### PR DESCRIPTION
With this upgrade, we move to Infinispan client 11 but running againt version 10.
I created a followup story to handle just the Infinispan migration, see [KOGITO-3118](https://issues.redhat.com/browse/KOGITO-3118)