### PR TITLE
KOGITO-2678: Configure Kogito Services to enable/disable security at …

### DIFF
--- a/data-index/data-index-service/data-index-service-common/src/main/resources/META-INF/microprofile-config.properties
+++ b/data-index/data-index-service/data-index-service-common/src/main/resources/META-INF/microprofile-config.properties
@@ -63,11 +63,12 @@ mp.messaging.incoming.kogito-jobs-events.auto.offset.reset=earliest
 mp.messaging.incoming.kogito-jobs-events.isolation.level=read_committed
 
 #oidc
-quarkus.oidc.enabled=false
-quarkus.oidc.auth-server-url=none
+quarkus.oidc.enabled=true
+quarkus.oidc.tenant-enabled=false
 
 #oidc - keycloak
 %keycloak.quarkus.oidc.enabled=true
+%keycloak.quarkus.oidc.tenant-enabled=true
 %keycloak.quarkus.oidc.auth-server-url=http://localhost:8280/auth/realms/kogito
 %keycloak.quarkus.oidc.client-id=kogito-service
 %keycloak.quarkus.oidc.credentials.secret=secret
@@ -79,6 +80,8 @@ quarkus.oidc.auth-server-url=none
 %keycloak.quarkus.oidc.web-app-tenant.application-type=web-app
 
 # HTTP Security Configuration
+quarkus.http.auth.permission.authenticated.paths=/*
+quarkus.http.auth.permission.authenticated.policy=permit
 %keycloak.quarkus.http.auth.permission.authenticated.paths=/*
 %keycloak.quarkus.http.auth.permission.authenticated.policy=authenticated
 

--- a/data-index/data-index-service/data-index-service-infinispan/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-infinispan/src/test/resources/application.properties
@@ -70,9 +70,11 @@ quarkus.infinispan-client.sasl-mechanism=DIGEST-MD5
 kogito.persistence.type=infinispan
 
 quarkus.oidc.enabled=false
+quarkus.oidc.tenant-enabled=false
 
 # Keycloak oidc
 %keycloak-test.quarkus.oidc.enabled=true
+%keycloak-test.quarkus.oidc.tenant-enabled=true
 #%keycloak-test.quarkus.oidc.auth-server-url=http://localhost:8281/auth/realms/kogito
 %keycloak-test.quarkus.oidc.client-id=kogito-app
 %keycloak-test.quarkus.oidc.credentials.secret=secret

--- a/data-index/data-index-service/data-index-service-mongodb/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-mongodb/src/test/resources/application.properties
@@ -66,9 +66,11 @@ quarkus.mongodb.health.enabled=true
 quarkus.mongodb.metrics.enabled=true
 
 quarkus.oidc.enabled=false
+quarkus.oidc.tenant-enabled=false
 
 # Keycloak oidc
 %keycloak-test.quarkus.oidc.enabled=true
+%keycloak-test.quarkus.oidc.tenant-enabled=true
 #%keycloak-test.quarkus.oidc.auth-server-url=http://localhost:8281/auth/realms/kogito
 %keycloak-test.quarkus.oidc.client-id=kogito-app
 %keycloak-test.quarkus.oidc.credentials.secret=secret

--- a/jobs-service/src/main/resources/application.properties
+++ b/jobs-service/src/main/resources/application.properties
@@ -80,9 +80,12 @@ kogito.jobs-service.events-support=false
 %events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.topic=kogito-jobs-events
 %events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
-quarkus.oidc.enabled=false
+quarkus.oidc.enabled=true
+quarkus.oidc.tenant-enabled=false
+
 #enabled with the profile: 'keycloak' (-Dquarkus.profile=keycloak)
 %keycloak.quarkus.oidc.enabled=true
+%keycloak.quarkus.oidc.tenant-enabled=true
 %keycloak.quarkus.oidc.auth-server-url=http://localhost:8280/auth/realms/kogito
 %keycloak.quarkus.oidc.client-id=kogito-jobs-service
 %keycloak.quarkus.oidc.credentials.secret=secret
@@ -99,6 +102,7 @@ quarkus.oidc.enabled=false
 %events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
 %events-support-auth.quarkus.oidc.enabled=true
+%events-support-auth.quarkus.oidc.tenant-enabled=false
 %events-support-auth.quarkus.oidc.auth-server-url=http://localhost:8280/auth/realms/kogito
 %events-support-auth.quarkus.oidc.client-id=kogito-job-service
 %events-support-auth.quarkus.oidc.credentials.secret=secret

--- a/jobs-service/src/test/resources/application.properties
+++ b/jobs-service/src/test/resources/application.properties
@@ -34,7 +34,9 @@ kogito.jobs-service.loadJobFromCurrentTimeIntervalInMinutes=0
 kogito.jobs-service.forceExecuteExpiredJobs=false
 
 # Keycloak oidc
-quarkus.oidc.enabled=false
+quarkus.oidc.enabled=true
+quarkus.oidc.tenant-enabled=false
 %keycloak.quarkus.oidc.enabled=true
+%keycloak.quarkus.oidc.tenant-enabled=true
 %keycloak.quarkus.oidc.client-id=kogito-app
 %keycloak.quarkus.oidc.credentials.secret=secret


### PR DESCRIPTION
…runtime
https://issues.redhat.com/browse/KOGITO-2678
Change job and data-index services security configuration to be able to enable / disable security at runtime with quarkus.oidc.tenant-enabled property