### PR TITLE
KOGITO-3233: ProtobufMonitorServiceTest test is randomly failing

### DIFF
--- a/persistence-commons/persistence-commons-protobuf/src/test/java/org/kie/kogito/persistence/protobuf/ProtobufMonitorServiceTest.java
+++ b/persistence-commons/persistence-commons-protobuf/src/test/java/org/kie/kogito/persistence/protobuf/ProtobufMonitorServiceTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -60,15 +59,14 @@ class ProtobufMonitorServiceTest {
 
             protobufMonitorService.monitor = true;
             protobufMonitorService.protoFiles = Optional.of(dir.toAbsolutePath().toString());
-            protobufMonitorService.onFolderWatch = path ->
-                    CompletableFuture.runAsync(() -> {
-                        try {
-                            Files.write(file2, "test".getBytes());
-                            Files.write(file1, "test".getBytes());
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    });
+            protobufMonitorService.onFolderWatch = path -> {
+                try {
+                    Files.write(file2, "test".getBytes());
+                    Files.write(file1, "test".getBytes());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            };
             protobufMonitorService.startMonitoring();
 
             latch.await(1, TimeUnit.MINUTES);
@@ -89,8 +87,8 @@ class ProtobufMonitorServiceTest {
         try {
             dir = Files.createTempDirectory(this.getClass().getName());
             Files.createFile(dir.resolve("kogito-application.proto"));
-            Files.createFile(dir.resolve("test1.proto"));
-            CountDownLatch latch = new CountDownLatch(2);
+            Files.createFile(dir.resolve("test1.proto")); // valid proto file
+            CountDownLatch latch = new CountDownLatch(2); // should only register test1 and test2 proto files
             Path proto = dir.resolve("proto");
             doAnswer(args -> {
                 latch.countDown();
@@ -99,16 +97,15 @@ class ProtobufMonitorServiceTest {
 
             protobufMonitorService.monitor = true;
             protobufMonitorService.protoFiles = Optional.of(dir.toAbsolutePath().toString());
-            protobufMonitorService.onFolderWatch = path ->
-                    CompletableFuture.runAsync(() -> {
-                        try {
-                            Path sub = Files.createDirectory(proto);
-                            Files.createFile(sub.resolve("test2.txt"));
-                            Files.createFile(sub.resolve("test2.proto"));
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    });
+            protobufMonitorService.onFolderWatch = path -> {
+                try {
+                    Path sub = Files.createDirectory(proto);
+                    Files.createFile(sub.resolve("test2.txt"));
+                    Files.createFile(sub.resolve("test2.proto")); // valid proto file
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            };
             protobufMonitorService.startMonitoring();
 
             latch.await(1, TimeUnit.MINUTES);


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3233
Description: The test ProtobufMonitorServiceTest.testAddingSubFolderAfterStart is randomly failing in the pipeline.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket