### PR TITLE
KOGITO-3238 Remove prepare script and rely on regular npm script for GWT editors

### DIFF
--- a/ui-packages/package.json
+++ b/ui-packages/package.json
@@ -8,7 +8,6 @@
   ],
   "scripts": {
     "init": "lerna bootstrap",
-    "prepare": "yarn workspace @kogito-apps/trusty run prepare",
     "build": "lerna run build --stream --",
     "build:fast": "lerna run build:fast --stream --",
     "build:prod": "lerna run build:prod --stream --",

--- a/ui-packages/packages/trusty/README.md
+++ b/ui-packages/packages/trusty/README.md
@@ -6,6 +6,15 @@ To install dependencies you need to have yarn installed globally and run in the 
 ```
 yarn install
 ```
+
+### Install GWT editors
+
+To install the GWT editors to view DMN models you need to run the following in the terminal before running the project:
+
+```
+yarn run copy-embedded-editor
+```
+
 ### Run the project
 
 Compile and run the project in development mode with:

--- a/ui-packages/packages/trusty/package.json
+++ b/ui-packages/packages/trusty/package.json
@@ -24,12 +24,11 @@
   },
   "scripts": {
     "start": "webpack-dev-server --hot --color --progress --info=true --config webpack.dev.js",
-    "build:prod": "yarn run lint && webpack --config webpack.prod.js",
+    "build:prod": "yarn copy-embedded-editor && yarn lint && webpack --config webpack.prod.js",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "test:coverage": "yarn test --coverage",
     "test:watch": "jest --watch",
     "lint": "tslint -c ./tslint.json --project . './src/**/*.ts{,x}'",
-    "prepare": "yarn run copy-embedded-editor",
     "copy-embedded-editor": "mvn clean compile -B -nsu",
     "mock-server": "json-server --watch api-mock/db.js --routes api-mock/routes.json --port 1336 --delay 1000 --id executionId --middlewares api-mock/filterSingular.js"
   },


### PR DESCRIPTION
[Link to jira ticket](https://issues.redhat.com/browse/KOGITO-3238)

This PR removes the `prepare` script installing GWT editors because it gets executed on `yarn install` but also after `yarn add`, which seems unnecessary.