### PR TITLE
KOGITO-3266 - Correctly limit excessive perturbation size on Type.COMPOSITE

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/Type.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/Type.java
@@ -314,7 +314,8 @@ public enum Type {
             List<Feature> composite = getFeatures(value);
             List<Feature> newList = new ArrayList<>(List.copyOf(composite));
             if (!newList.isEmpty()) {
-                int[] indexesToBePerturbed = perturbationContext.getRandom().ints(0, composite.size()).distinct().limit(perturbationContext.getNoOfPerturbations()).toArray();
+                int[] indexesToBePerturbed = perturbationContext.getRandom().ints(0, composite.size())
+                        .distinct().limit(Math.min(perturbationContext.getNoOfPerturbations(), composite.size())).toArray();
                 for (int index : indexesToBePerturbed) {
                     Feature cf = composite.get(index);
                     Feature f = FeatureFactory.copyOf(cf, cf.getType().perturb(cf.getValue(), perturbationContext));

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/model/TypeTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/model/TypeTest.java
@@ -143,6 +143,18 @@ class TypeTest {
         assertNotEquals(value, perturbedValue);
     }
 
+    @Test
+    void testPerturbCompositeFeatureTooManyPerturbations() {
+        PerturbationContext perturbationContext = new PerturbationContext(new Random(), 1000);
+        List<Feature> features = new LinkedList<>();
+        features.add(new Feature("f1", Type.TEXT, new Value<>("foo bar")));
+        features.add(new Feature("f2", Type.NUMBER, new Value<>(1d)));
+        Value<?> value = new Value<>(features);
+        Feature f = new Feature("name", Type.COMPOSITE, value);
+        Value<?> perturbedValue = f.getType().perturb(f.getValue(), perturbationContext);
+        assertNotEquals(value, perturbedValue);
+    }
+
     @ParameterizedTest
     @EnumSource
     void testDrop(Type type) {


### PR DESCRIPTION
The `limit` call in `Type.Composite#perturb` should contain numbers smaller or equals to the streamed list size.

See https://issues.redhat.com/browse/KOGITO-3266

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket