### PR TITLE
KOGITO-3262 - allow usage of hardly separable datasets

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/DatasetNotSeparableException.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/DatasetNotSeparableException.java
@@ -21,11 +21,11 @@ import org.kie.kogito.explainability.local.LocalExplanationException;
 import org.kie.kogito.explainability.model.Output;
 
 /**
- * Exception for when a dataset encoded for LIME is not (linearly) separable.
+ * Exception thrown when a dataset encoded for LIME is not (linearly) separable.
  */
-public class DatasetNotSeparableException extends LocalExplanationException {
+class DatasetNotSeparableException extends LocalExplanationException {
 
-    public DatasetNotSeparableException(Output output, Map<Double, Long> classBalance) {
+    DatasetNotSeparableException(Output output, Map<Double, Long> classBalance) {
         super("LIME dataset not separable for output '" + output.getName() + "' of type '" + output.getType() + "' with '"
                       + output.getValue() + "' (" + classBalance + ")");
     }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/DatasetNotSeparableException.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/DatasetNotSeparableException.java
@@ -23,9 +23,9 @@ import org.kie.kogito.explainability.model.Output;
 /**
  * Exception thrown when a dataset encoded for LIME is not (linearly) separable.
  */
-class DatasetNotSeparableException extends LocalExplanationException {
+public class DatasetNotSeparableException extends LocalExplanationException {
 
-    DatasetNotSeparableException(Output output, Map<Double, Long> classBalance) {
+    public DatasetNotSeparableException(Output output, Map<Double, Long> classBalance) {
         super("LIME dataset not separable for output '" + output.getName() + "' of type '" + output.getType() + "' with '"
                       + output.getValue() + "' (" + classBalance + ")");
     }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/LimeExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/LimeExplainer.java
@@ -244,8 +244,8 @@ public class LimeExplainer implements LocalExplainer<Map<String, Saliency>> {
                     throw new DatasetNotSeparableException(currentOutput, rawClassesBalance);
                 }
             } else {
-                LOGGER.warn("Using an hardly separable dataset for output '" + currentOutput.getName() + "' of type '" + currentOutput.getType() + "' with '"
-                                    + currentOutput.getValue() + "' (" + rawClassesBalance + ")");
+                LOGGER.warn("Using an hardly separable dataset for output '{}' of type '{}' with value '{}' ({})",
+                            currentOutput.getName(), currentOutput.getType(), currentOutput.getValue(), rawClassesBalance);
                 return new LimeInputs(rawClassesBalance.size() == 2, linearizedTargetInputFeatures, currentOutput, perturbedInputs, outputs);
             }
         } else {

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/LimeExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/LimeExplainer.java
@@ -260,7 +260,7 @@ public class LimeExplainer implements LocalExplainer<Map<String, Saliency>> {
             } else {
                 LOGGER.warn("Using an hardly separable dataset for output '{}' of type '{}' with value '{}' ({})",
                             currentOutput.getName(), currentOutput.getType(), currentOutput.getValue(), rawClassesBalance);
-                return new LimeInputs(rawClassesBalance.size() == 2, linearizedTargetInputFeatures, currentOutput, perturbedInputs, outputs);
+                return new LimeInputs(classification, linearizedTargetInputFeatures, currentOutput, perturbedInputs, outputs);
             }
         } else {
             return new LimeInputs(false, linearizedTargetInputFeatures, currentOutput, emptyList(), emptyList());

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/TestUtils.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/TestUtils.java
@@ -127,6 +127,17 @@ public class TestUtils {
         });
     }
 
+    public static PredictionProvider getFixedOutputClassifier() {
+        return inputs -> supplyAsync(() -> {
+            List<PredictionOutput> outputs = new LinkedList<>();
+            for (PredictionInput ignored : inputs) {
+                Output output = new Output("class", Type.BOOLEAN, new Value<>(false), 1d);
+                outputs.add(new PredictionOutput(List.of(output)));
+            }
+            return outputs;
+        });
+    }
+
     public static Feature getMockedNumericFeature() {
         return getMockedNumericFeature(1d);
     }


### PR DESCRIPTION
Currently `DatasetNotSeparableException` is thrown when the dataset of LIME perturbed inputs is not separable for a given `Output`, however this behviour prevents the generation of explanations for other `Outputs` not having the same issue.

This is especially inconvenient when there are fixed outputs that are always returned as part of a result (e.g. the DMN for fraud scoring seems to do that for blocked merchants).

This PR solves this by keeping the retrying mechanism to seek a separable dataset, but allowing the generation of a not (easily) separable dataset in the end which then will be normally fed into LIME, with a warning message. 
Such datasets are expected to generate poorly informative explanations (e.g. all scores equals or very close to zero).

See https://issues.redhat.com/browse/KOGITO-3262
See also related issue https://issues.redhat.com/browse/KOGITO-3259 and PR #439

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket