### PR TITLE
KOGITO-3271 - PDPExplainer(Test) improvements

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainer.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeoutException;
 
 import org.kie.kogito.explainability.Config;
 import org.kie.kogito.explainability.global.GlobalExplainer;
-import org.kie.kogito.explainability.global.GlobalExplanationException;
 import org.kie.kogito.explainability.model.DataDistribution;
 import org.kie.kogito.explainability.model.FeatureDistribution;
 import org.kie.kogito.explainability.model.Output;

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainer.java
@@ -125,13 +125,14 @@ public class PartialDependencePlotExplainer implements GlobalExplainer<List<Part
      * @param predictionInputs a batch of inputs
      * @return a batch of outputs
      */
-    private List<PredictionOutput> getOutputs(PredictionProvider model, List<PredictionInput> predictionInputs) {
+    private List<PredictionOutput> getOutputs(PredictionProvider model, List<PredictionInput> predictionInputs)
+            throws InterruptedException, ExecutionException, TimeoutException {
         List<PredictionOutput> predictionOutputs;
         try {
             predictionOutputs = model.predictAsync(predictionInputs).get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             LOGGER.error("Impossible to obtain prediction {}", e.getMessage());
-            throw new GlobalExplanationException(e);
+            throw e;
         }
         return predictionOutputs;
     }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainer.java
@@ -16,8 +16,7 @@
 package org.kie.kogito.explainability.global.pdp;
 
 import java.security.SecureRandom;
-import java.util.Collection;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
@@ -33,7 +32,6 @@ import org.kie.kogito.explainability.model.PredictionInput;
 import org.kie.kogito.explainability.model.PredictionOutput;
 import org.kie.kogito.explainability.model.PredictionProvider;
 import org.kie.kogito.explainability.model.PredictionProviderMetadata;
-import org.kie.kogito.explainability.model.Type;
 import org.kie.kogito.explainability.utils.DataUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +77,7 @@ public class PartialDependencePlotExplainer implements GlobalExplainer<List<Part
     public List<PartialDependenceGraph> explain(PredictionProvider model, PredictionProviderMetadata metadata) throws InterruptedException, ExecutionException, TimeoutException {
         long start = System.currentTimeMillis();
 
-        List<PartialDependenceGraph> pdps = new LinkedList<>();
+        List<PartialDependenceGraph> pdps = new ArrayList<>();
         DataDistribution dataDistribution = metadata.getDataDistribution();
         int noOfFeatures = metadata.getInputShape().getFeatures().size();
 
@@ -101,7 +99,7 @@ public class PartialDependencePlotExplainer implements GlobalExplainer<List<Part
 
                 double[] marginalImpacts = new double[featureXSvalues.length];
                 for (int i = 0; i < featureXSvalues.length; i++) {
-                    List<PredictionInput> predictionInputs = new LinkedList<>();
+                    List<PredictionInput> predictionInputs = new ArrayList<>(seriesLength);
                     double[] inputs = new double[noOfFeatures];
                     inputs[featureIndex] = featureXSvalues[i];
                     for (int j = 0; j < seriesLength; j++) {
@@ -126,7 +124,7 @@ public class PartialDependencePlotExplainer implements GlobalExplainer<List<Part
                         Output output = predictionOutput.getOutputs().get(outputIndex);
                         // use numerical output when possible, otherwise only use the score
                         double v = output.getValue().asNumber();
-                        if (Double.isNaN(v)) {
+                        if (Double.isNaN(v)) { // check the output can be converted to a proper number
                             v = output.getScore();
                         }
                         marginalImpacts[i] += v / (double) seriesLength;

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
@@ -66,13 +66,13 @@ public class DataUtils {
         double d = getStdDev(data, m);
 
         // force desired standard deviation
-        double d1 = stdDeviation / d;
+        double d1 = d != 0 ? stdDeviation / d : stdDeviation; // avoid division by zero
         for (int i = 0; i < size; i++) {
             data[i] *= d1;
         }
 
         // get the new mean
-        double m1 = m * stdDeviation / d;
+        double m1 = d != 0 ? m * stdDeviation / d : m * stdDeviation; // avoid division by zero
 
         // force desired mean
         for (int i = 0; i < size; i++) {

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
@@ -72,7 +72,7 @@ public class DataUtils {
         }
 
         // get the new mean
-        double m1 = d != 0 ? m * stdDeviation / d : m * stdDeviation; // avoid division by zero
+        double m1 = d != 0 ? m * stdDeviation / d : m * stdDeviation;
 
         // force desired mean
         for (int i = 0; i < size; i++) {

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
@@ -62,21 +62,22 @@ public class DataUtils {
             data[i] = random.nextGaussian() * stdDeviation + mean;
         }
 
-        double m = getMean(data);
-        double d = getStdDev(data, m);
+        double generatedDataMean = getMean(data);
+        double generatedDataStdDev = getStdDev(data, generatedDataMean);
 
         // force desired standard deviation
-        double d1 = d != 0 ? stdDeviation / d : stdDeviation; // avoid division by zero
+        double newStdDeviation = generatedDataStdDev != 0 ? stdDeviation / generatedDataStdDev : stdDeviation; // avoid division by zero
         for (int i = 0; i < size; i++) {
-            data[i] *= d1;
+            data[i] *= newStdDeviation;
         }
 
         // get the new mean
-        double m1 = d != 0 ? m * stdDeviation / d : m * stdDeviation;
+        double newMean = generatedDataStdDev != 0 ? generatedDataMean * stdDeviation / generatedDataStdDev :
+                generatedDataMean * stdDeviation;
 
         // force desired mean
         for (int i = 0; i < size; i++) {
-            data[i] += mean - m1;
+            data[i] += mean - newMean;
         }
 
         return data;

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainerTest.java
@@ -74,7 +74,7 @@ class PartialDependencePlotExplainerTest {
     };
 
     @Test
-    void testPdpTextClassifier() throws Exception {
+    void testPdpNumericClassifier() throws Exception {
         PredictionProvider modelInfo = TestUtils.getSumSkipModel(0);
         List<PartialDependenceGraph> pdps = partialDependencePlotProvider.explain(modelInfo, metadata);
         assertNotNull(pdps);
@@ -94,10 +94,11 @@ class PartialDependencePlotExplainerTest {
     }
 
     private void assertGraph(PartialDependenceGraph pdp) {
-        for (int i = 1; i < pdp.getX().length; i++) {
-            assertNotEquals(Double.NaN, pdp.getX()[i]);
+        for (int i = 0; i < pdp.getX().length; i++) {
             assertNotEquals(Double.NaN, pdp.getY()[i]);
-            assertTrue(pdp.getX()[i] > pdp.getX()[i - 1]);
+            if (i > 0) {
+                assertTrue(pdp.getX()[i] > pdp.getX()[i - 1]);
+            }
         }
     }
 

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainerTest.java
@@ -87,7 +87,7 @@ class PartialDependencePlotExplainerTest {
         }
         // the first feature is always skipped by the model, so the predictions are not affected, hence PDP Y values are constant
         PartialDependenceGraph fixedFeatureGraph = pdps.get(0);
-        assertEquals(Arrays.stream(fixedFeatureGraph.getY()).distinct().count(), 1);
+        assertEquals(1, Arrays.stream(fixedFeatureGraph.getY()).distinct().count());
 
         // the other two instead change but in the same way, due the behaviour of FakeRandom in generating data/distributions
         assertArrayEquals(pdps.get(1).getY(), pdps.get(2).getY());

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainerTest.java
@@ -118,7 +118,7 @@ class PartialDependencePlotExplainerTest {
                     }
                 });
 
-        Assertions.assertThrows(GlobalExplanationException.class,
+        Assertions.assertThrows(TimeoutException.class,
                                 () -> partialDependencePlotProvider.explain(brokenProvider, metadata));
 
         Config.INSTANCE.setAsyncTimeout(Config.DEFAULT_ASYNC_TIMEOUT);

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/global/pdp/PartialDependencePlotExplainerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.kie.kogito.explainability.Config;
 import org.kie.kogito.explainability.FakeRandom;
 import org.kie.kogito.explainability.TestUtils;
+import org.kie.kogito.explainability.global.GlobalExplanationException;
 import org.kie.kogito.explainability.model.DataDistribution;
 import org.kie.kogito.explainability.model.Feature;
 import org.kie.kogito.explainability.model.FeatureFactory;
@@ -117,7 +118,7 @@ class PartialDependencePlotExplainerTest {
                     }
                 });
 
-        Assertions.assertThrows(TimeoutException.class,
+        Assertions.assertThrows(GlobalExplanationException.class,
                                 () -> partialDependencePlotProvider.explain(brokenProvider, metadata));
 
         Config.INSTANCE.setAsyncTimeout(Config.DEFAULT_ASYNC_TIMEOUT);


### PR DESCRIPTION
Fix to `PartialDependencePlotExplainer` to avoid problems with data having standard deviation = 0, also using numerical outputs when possible (not just their score).
Improved `PartialDependencePlotExplainerTest` by testing shape and expected PDP graph contents.

See https://issues.redhat.com/browse/KOGITO-3271

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket