### PR TITLE
KOGITO-3175 Jobs service health check fix (kafka + infinispan)

### DIFF
--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/InMemoryJobRepository.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/InMemoryJobRepository.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import io.vertx.core.Vertx;

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/InMemoryJobRepository.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/InMemoryJobRepository.java
@@ -27,15 +27,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import io.vertx.core.Vertx;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.eclipse.microprofile.reactive.streams.operators.ReactiveStreams;
 import org.kie.kogito.jobs.service.model.JobStatus;
-import org.kie.kogito.jobs.service.qualifier.Repository;
 import org.kie.kogito.jobs.service.model.job.JobDetails;
+import org.kie.kogito.jobs.service.qualifier.Repository;
 import org.kie.kogito.jobs.service.repository.ReactiveJobRepository;
 import org.kie.kogito.jobs.service.stream.JobStreams;
 import org.kie.kogito.jobs.service.utils.DateUtil;

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/JobRepositoryDelegate.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/JobRepositoryDelegate.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletionStage;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
@@ -30,8 +29,8 @@ import io.quarkus.arc.DefaultBean;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.kie.kogito.jobs.service.model.JobStatus;
-import org.kie.kogito.jobs.service.qualifier.Repository;
 import org.kie.kogito.jobs.service.model.job.JobDetails;
+import org.kie.kogito.jobs.service.qualifier.Repository;
 import org.kie.kogito.jobs.service.repository.ReactiveJobRepository;
 import org.kie.kogito.jobs.service.repository.infinispan.InfinispanConfiguration;
 import org.slf4j.Logger;

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/JobRepositoryDelegate.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/impl/JobRepositoryDelegate.java
@@ -26,6 +26,7 @@ import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import io.quarkus.arc.DefaultBean;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.kie.kogito.jobs.service.model.JobStatus;
@@ -36,7 +37,7 @@ import org.kie.kogito.jobs.service.repository.infinispan.InfinispanConfiguration
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Default
+@DefaultBean
 @ApplicationScoped
 public class JobRepositoryDelegate implements ReactiveJobRepository {
 
@@ -51,7 +52,8 @@ public class JobRepositoryDelegate implements ReactiveJobRepository {
     public JobRepositoryDelegate(@Any Instance<ReactiveJobRepository> instances,
                                  @ConfigProperty(name = InfinispanConfiguration.PERSISTENCE_CONFIG_KEY)
                                          Optional<String> persistence) {
-        delegate = instances.select(new Repository.Literal(persistence.orElse("in-memory"))).get();
+        delegate = instances.select(BaseReactiveJobRepository.class,
+                                    new Repository.Literal(persistence.orElse("in-memory"))).get();
         LOGGER.info("JobRepository selected {}", delegate.getClass());
     }
 

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanConfiguration.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanConfiguration.java
@@ -48,12 +48,11 @@ public class InfinispanConfiguration {
 
     @Produces
     @Readiness
-    public HealthCheck infinispanHealthCheck(@ConfigProperty(name = PERSISTENCE_CONFIG_KEY)
-                                                     Optional<String> persistence,
+    public HealthCheck infinispanHealthCheck(@ConfigProperty(name = PERSISTENCE_CONFIG_KEY) Optional<String> persistence,
                                              Instance<RemoteCacheManager> cacheManagerInstance) {
         return persistence
                 .filter("infinispan"::equals)
                 .<HealthCheck>map(p -> new InfinispanHealthCheck(cacheManagerInstance))
-                .orElseGet(() -> () -> HealthCheckResponse.up("Default persistence"));
+                .orElse(() -> HealthCheckResponse.up("In Memory Persistence"));
     }
 }

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanConfiguration.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanConfiguration.java
@@ -23,6 +23,8 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.kie.kogito.infinispan.health.InfinispanHealthCheck;
@@ -46,12 +48,12 @@ public class InfinispanConfiguration {
 
     @Produces
     @Readiness
-    public InfinispanHealthCheck infinispanHealthCheck(@ConfigProperty(name = PERSISTENCE_CONFIG_KEY)
-                                                               Optional<String> persistence,
-                                                       Instance<RemoteCacheManager> cacheManagerInstance) {
+    public HealthCheck infinispanHealthCheck(@ConfigProperty(name = PERSISTENCE_CONFIG_KEY)
+                                                     Optional<String> persistence,
+                                             Instance<RemoteCacheManager> cacheManagerInstance) {
         return persistence
                 .filter("infinispan"::equals)
-                .map(p -> new InfinispanHealthCheck(cacheManagerInstance))
-                .orElse(null);
+                .<HealthCheck>map(p -> new InfinispanHealthCheck(cacheManagerInstance))
+                .orElseGet(() -> () -> HealthCheckResponse.up("Default persistence"));
     }
 }

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanJobRepository.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanJobRepository.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import io.vertx.core.Vertx;

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanJobRepository.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/repository/infinispan/InfinispanJobRepository.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import io.vertx.core.Vertx;

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/stream/KafkaConfiguration.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/stream/KafkaConfiguration.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.kie.kogito.jobs.service.stream;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import io.quarkus.runtime.Startup;
+import io.quarkus.runtime.StartupEvent;
+import io.vertx.kafka.admin.NewTopic;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.kafka.admin.KafkaAdminClient;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.kie.kogito.jobs.service.stream.KafkaJobStreams.PUBLISH_EVENTS_CONFIG_KEY;
+
+@Startup
+@ApplicationScoped
+public class KafkaConfiguration {
+
+    @Inject
+    @Named("default-kafka-broker")
+    Instance<Map<String, Object>> defaultKafkaConfiguration;
+
+    @Inject
+    Vertx vertx;
+
+    @ConfigProperty(name = PUBLISH_EVENTS_CONFIG_KEY)
+    Optional<Boolean> enabled;
+
+    @ConfigProperty(name = "kogito.jobs-events-topic")
+    String topic;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConfiguration.class);
+
+    /**
+     * Verify if the needed Kafka topics used by the application already exists, in case they are not found create
+     * them. This should not be needed in case the infrastructure is already provisioned with all topics into Kafka.
+     * This avoids the health check issues for kafka where the topics are all checked.
+     * @param event Startup event
+     */
+    void topicConfiguration(@Observes StartupEvent event) {
+        LOGGER.info("Kafka topic configuration check.");
+        final Map<String, String> config = defaultKafkaConfiguration.get().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, el -> (String) el.getValue()));
+        enabled.map(e -> KafkaAdminClient.create(vertx, config))
+                .ifPresent(client -> client.listTopics()
+                        .subscribe()
+                        .with(t -> Optional.ofNullable(t.contains(topic))
+                                .map(match -> new NewTopic(topic, 1, (short) 1))
+                                .ifPresent(newTopic -> client.createTopics(Arrays.asList(newTopic))
+                                        .subscribe()
+                                        .with(r -> LOGGER.info("Created topic {}", topic)))));
+    }
+}

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/stream/KafkaJobStreams.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/stream/KafkaJobStreams.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 public class KafkaJobStreams {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaJobStreams.class);
-    private static final String PUBLISH_EVENTS_CONFIG_KEY = "kogito.jobs-service.events-support";
+    public static final String PUBLISH_EVENTS_CONFIG_KEY = "kogito.jobs-service.events-support";
 
     private ObjectMapper objectMapper;
 

--- a/jobs-service/src/main/resources/application.properties
+++ b/jobs-service/src/main/resources/application.properties
@@ -67,18 +67,23 @@ kogito.jobs-service.loadJobIntervalInMinutes=10
 kogito.jobs-service.loadJobFromCurrentTimeIntervalInMinutes=60
 kogito.jobs-service.forceExecuteExpiredJobs=true
 
+#Removing beans related to Kafka from CDI when eventing is not enabled
+quarkus.arc.exclude-types=io.smallrye.reactive.messaging.health.*,org.kie.kogito.jobs.service.stream.KafkaConfiguration
+
 #Configure Events Publishing on Job Service using profile
 #disabled by default
 kogito.jobs-service.events-support=false
+kogito.jobs-events-topic=kogito-jobs-events
 
 #enabled with the profile: 'events-support' (-Dquarkus.profile=events-support)
 %events-support.quarkus.kafka.health.enabled=true
-%events-support.quarkus.kafka.bootstrap-servers=localhost:9092
+%events-support.kafka.bootstrap-servers=localhost:9092
 %events-support.kogito.jobs-service.events-support=true
 %events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.connector=smallrye-kafka
 %events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.bootstrap.servers=localhost:9092
-%events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.topic=kogito-jobs-events
+%events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.topic=${kogito.jobs-events-topic}
 %events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+%events-support.quarkus.arc.exclude-types=
 
 quarkus.oidc.enabled=true
 quarkus.oidc.tenant-enabled=false
@@ -96,10 +101,13 @@ quarkus.oidc.tenant-enabled=false
 #Configure Events Publishing and security on Job Service using profile
 #enabled with the profile: 'events-support-auth' (-Dquarkus.profile=events-support-auth)
 %events-support-auth.kogito.jobs-service.events-support=true
+%events-support-auth.quarkus.kafka.health.enabled=true
+%events-support-auth.kafka.bootstrap-servers=localhost:9092
 %events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.connector=smallrye-kafka
 %events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.bootstrap.servers=localhost:9092
-%events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.topic=kogito-job-service-job-status-events-topic
+%events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.topic=${kogito.jobs-events-topic}
 %events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+%events-support-auth.quarkus.arc.exclude-types=
 
 %events-support-auth.quarkus.oidc.enabled=true
 %events-support-auth.quarkus.oidc.tenant-enabled=false
@@ -108,4 +116,4 @@ quarkus.oidc.tenant-enabled=false
 %events-support-auth.quarkus.oidc.credentials.secret=secret
 %events-support-auth.quarkus.http.auth.policy.role-policy1.roles-allowed=confidential
 %events-support-auth.quarkus.http.auth.permission.roles1.paths=/*
-%events-support-auth.quarkus.http.auth.permission.roles1.policy=role-policy1 
+%events-support-auth.quarkus.http.auth.permission.roles1.policy=role-policy1

--- a/jobs-service/src/main/resources/application.properties
+++ b/jobs-service/src/main/resources/application.properties
@@ -77,7 +77,7 @@ kogito.jobs-events-topic=kogito-jobs-events
 
 #enabled with the profile: 'events-support' (-Dquarkus.profile=events-support)
 %events-support.quarkus.kafka.health.enabled=true
-%events-support.kafka.bootstrap-servers=localhost:9092
+%events-support.kafka.bootstrap.servers=localhost:9092
 %events-support.kogito.jobs-service.events-support=true
 %events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.connector=smallrye-kafka
 %events-support.mp.messaging.outgoing.kogito-job-service-job-status-events.bootstrap.servers=localhost:9092
@@ -102,7 +102,7 @@ quarkus.oidc.tenant-enabled=false
 #enabled with the profile: 'events-support-auth' (-Dquarkus.profile=events-support-auth)
 %events-support-auth.kogito.jobs-service.events-support=true
 %events-support-auth.quarkus.kafka.health.enabled=true
-%events-support-auth.kafka.bootstrap-servers=localhost:9092
+%events-support-auth.kafka.bootstrap.servers=localhost:9092
 %events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.connector=smallrye-kafka
 %events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.bootstrap.servers=localhost:9092
 %events-support-auth.mp.messaging.outgoing.kogito-job-service-job-status-events.topic=${kogito.jobs-events-topic}

--- a/jobs-service/src/test/java/org/kie/kogito/jobs/service/stream/KafkaConfigurationTest.java
+++ b/jobs-service/src/test/java/org/kie/kogito/jobs/service/stream/KafkaConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.kie.kogito.jobs.service.stream;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.mutiny.core.Vertx;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.testcontainers.quarkus.KafkaQuarkusTestResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@QuarkusTest
+@QuarkusTestResource(KafkaQuarkusTestResource.class)
+class KafkaConfigurationIT {
+
+    private KafkaConfiguration tested;
+
+    private static final String TOPIC = UUID.randomUUID().toString();
+
+    @Inject
+    Vertx vertx;
+
+    @Inject
+    @Named("default-kafka-broker")
+    Instance<Map<String, Object>> defaultKafkaConfiguration;
+
+    @Test
+    void topicConfiguration() {
+        tested = new KafkaConfiguration(defaultKafkaConfiguration, vertx, Optional.of(Boolean.TRUE), TOPIC);
+        assertThat(tested.getAdminClient()).isNull();
+        tested.topicConfiguration(new StartupEvent());
+        assertThat(tested.getAdminClient()).isNotNull();
+        await().atMost(Duration.ofSeconds(4)).untilAsserted(
+                () -> assertThat(tested.getAdminClient().listTopicsAndAwait()).contains(TOPIC));
+        tested.getAdminClient().deleteTopicsAndAwait(Arrays.asList(TOPIC));
+    }
+
+    @Test
+    void topicConfigurationDisabledEvents() {
+        tested = new KafkaConfiguration(defaultKafkaConfiguration, vertx, Optional.of(Boolean.FALSE), TOPIC);
+        assertThat(tested.getAdminClient()).isNull();
+        tested.topicConfiguration(new StartupEvent());
+        assertThat(tested.getAdminClient()).isNull();
+    }
+}

--- a/jobs-service/src/test/resources/application.properties
+++ b/jobs-service/src/test/resources/application.properties
@@ -32,6 +32,7 @@ kogito.jobs-service.schedulerChunkInMinutes=10
 kogito.jobs-service.loadJobIntervalInMinutes=10
 kogito.jobs-service.loadJobFromCurrentTimeIntervalInMinutes=0
 kogito.jobs-service.forceExecuteExpiredJobs=false
+kogito.jobs-events-topic=kogito-jobs-events
 
 # Keycloak oidc
 quarkus.oidc.enabled=true


### PR DESCRIPTION
Fix for health checks:
- disabling kafka configurations when the profile is not enabled
- creating the topic for jobs in case it does not exist (in the best case the operator should provide beforehand the topic creation IMO)
- infinispan health check retuning ok in case it is not enabled
- bonus: fixed the exception being thrown on JobRepositoryDelegate

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket