### PR TITLE
KOGITO-3277: Hide the panel when no milestone

### DIFF
--- a/ui-packages/packages/management-console/server/MockData/graphql.js
+++ b/ui-packages/packages/management-console/server/MockData/graphql.js
@@ -480,6 +480,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -595,6 +596,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -652,6 +654,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -708,6 +711,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -813,6 +817,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'fc1b6535-d557-40df-82c8-b425b9dc531b',
@@ -930,6 +935,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -1175,6 +1181,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -1280,6 +1287,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -1336,6 +1344,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21eaccd',
@@ -1398,6 +1407,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21eajabbcc',
@@ -1460,6 +1470,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -1516,6 +1527,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -1622,6 +1634,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: '2d962eef-45b8-48a9-ad4e-9cde0ad6af88abc',
@@ -1685,6 +1698,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: []
   },
   {
@@ -1793,6 +1807,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -1911,6 +1926,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2029,6 +2045,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2147,6 +2164,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2265,6 +2283,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2383,6 +2402,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2501,6 +2521,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2619,6 +2640,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2737,6 +2759,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2855,6 +2878,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -2973,6 +2997,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
@@ -3091,6 +3116,7 @@ module.exports ={ ProcessInstanceData : [
         type: 'StartNode'
       }
     ],
+    milestones: [],
     childProcessInstances: [
       {
         id: 'c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',

--- a/ui-packages/packages/management-console/src/components/Organisms/ProcessDetailsMilestones/tests/ProcessDetailsMilestones.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Organisms/ProcessDetailsMilestones/tests/ProcessDetailsMilestones.test.tsx
@@ -45,7 +45,7 @@ describe('Process details page milestones panel', () => {
       },
       {
         id: '27107f38-d888-4edf-9a4f-11b9e6d75m88',
-        name: 'Milestone 3: Order delivered and closed',
+        name: 'Milestone 3: Order delivered and closed with customer sign off',
         status: MilestoneStatus['Available'],
         __typename: 'Milestones'
       }
@@ -73,7 +73,7 @@ describe('Process details page milestones panel', () => {
       },
       {
         id: '27107f38-d888-4edf-9a4f-11b9e6d75i86',
-        name: 'Manager decision and sign off',
+        name: 'Milestone 3: Order delivered and closed with customer sign off',
         status: MilestoneStatus['Completed'],
         __typename: 'Milestones'
       },

--- a/ui-packages/packages/management-console/src/components/Organisms/ProcessDetailsMilestones/tests/__snapshots__/ProcessDetailsMilestones.test.tsx.snap
+++ b/ui-packages/packages/management-console/src/components/Organisms/ProcessDetailsMilestones/tests/__snapshots__/ProcessDetailsMilestones.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Process details page milestones panel Snapshot test with default props 
       Object {
         "__typename": "Milestones",
         "id": "27107f38-d888-4edf-9a4f-11b9e6d75m88",
-        "name": "Milestone 3: Order delivered and closed",
+        "name": "Milestone 3: Order delivered and closed with customer sign off",
         "status": "AVAILABLE",
       },
       Object {
@@ -132,38 +132,47 @@ exports[`Process details page milestones panel Snapshot test with default props 
                   </Label>
                 </p>
               </Text>
-              <Text
-                component="p"
+              <Tooltip
+                content="Milestone 3: Order delivered and closed with customer sign off"
                 key="2"
               >
-                <p
-                  className=""
-                  data-pf-content={true}
+                <Text
+                  component="p"
                 >
-                  Milestone 3: Order delivered and closed
-                   
-                  <Label
-                    icon={<InfoCircleIcon />}
+                  <p
+                    className=""
+                    data-pf-content={true}
                   >
                     <span
-                      className="pf-c-label"
+                      className="kogito-management-console--milestones__nameTextEllipses"
+                    >
+                      Milestone 3: Order delivered and closed with customer sign off
+                    </span>
+                     
+                    <Label
+                      icon={<InfoCircleIcon />}
                     >
                       <span
-                        className="pf-c-label__content"
+                        className="pf-c-label"
                       >
                         <span
-                          className="pf-c-label__icon"
+                          className="pf-c-label__content"
                         >
-                          <InfoCircleIcon>
-                            <MockedComponent />
-                          </InfoCircleIcon>
+                          <span
+                            className="pf-c-label__icon"
+                          >
+                            <InfoCircleIcon>
+                              <MockedComponent />
+                            </InfoCircleIcon>
+                          </span>
+                          Available
                         </span>
-                        Available
                       </span>
-                    </span>
-                  </Label>
-                </p>
-              </Text>
+                    </Label>
+                  </p>
+                </Text>
+                 
+              </Tooltip>
               <Text
                 component="blockquote"
                 key="3"
@@ -237,7 +246,7 @@ exports[`Process details page milestones panel test assertions 1`] = `
       Object {
         "__typename": "Milestones",
         "id": "27107f38-d888-4edf-9a4f-11b9e6d75i86",
-        "name": "Manager decision and sign off",
+        "name": "Milestone 3: Order delivered and closed with customer sign off",
         "status": "COMPLETED",
       },
       Object {
@@ -414,39 +423,48 @@ exports[`Process details page milestones panel test assertions 1`] = `
                   </Label>
                 </p>
               </Text>
-              <Text
-                component="blockquote"
+              <Tooltip
+                content="Milestone 3: Order delivered and closed with customer sign off"
                 key="4"
               >
-                <blockquote
-                  className=""
-                  data-pf-content={true}
+                <Text
+                  component="blockquote"
                 >
-                  Manager decision and sign off
-                   
-                  <Label
-                    color="green"
-                    icon={<InfoCircleIcon />}
+                  <blockquote
+                    className=""
+                    data-pf-content={true}
                   >
                     <span
-                      className="pf-c-label pf-m-green"
+                      className="kogito-management-console--milestones__nameTextEllipses"
+                    >
+                      Milestone 3: Order delivered and closed with customer sign off
+                    </span>
+                     
+                    <Label
+                      color="green"
+                      icon={<InfoCircleIcon />}
                     >
                       <span
-                        className="pf-c-label__content"
+                        className="pf-c-label pf-m-green"
                       >
                         <span
-                          className="pf-c-label__icon"
+                          className="pf-c-label__content"
                         >
-                          <InfoCircleIcon>
-                            <MockedComponent />
-                          </InfoCircleIcon>
+                          <span
+                            className="pf-c-label__icon"
+                          >
+                            <InfoCircleIcon>
+                              <MockedComponent />
+                            </InfoCircleIcon>
+                          </span>
+                          Completed
                         </span>
-                        Completed
                       </span>
-                    </span>
-                  </Label>
-                </blockquote>
-              </Text>
+                    </Label>
+                  </blockquote>
+                </Text>
+                 
+              </Tooltip>
               <Text
                 component="p"
                 key="5"

--- a/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
+++ b/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
@@ -467,11 +467,13 @@ const ProcessDetailsPage: React.FC<RouteComponentProps<MatchProps, {}, {}> &
                         <ProcessDetails data={data} from={currentPage} />
                       </FlexItem>
                     )}
-                    <FlexItem>
-                      <ProcessDetailsMilestones
-                        milestones={data.ProcessInstances[0].milestones}
-                      />
-                    </FlexItem>
+                    {data.ProcessInstances[0].milestones.length > 0 && (
+                      <FlexItem>
+                        <ProcessDetailsMilestones
+                          milestones={data.ProcessInstances[0].milestones}
+                        />
+                      </FlexItem>
+                    )}
                   </Flex>
                   <Flex
                     direction={{ default: 'column' }}


### PR DESCRIPTION
Hello,

Please review this PR, intended to hide the milestones panel of process details page when there are no milestones associated with that process instance.
 
JIRA: https://issues.redhat.com/browse/KOGITO-3277