### PR TITLE
KOGITO-3279 - more robust LIME perturbation selection

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/LimeExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/lime/LimeExplainer.java
@@ -287,7 +287,8 @@ public class LimeExplainer implements LocalExplainer<Map<String, Saliency>> {
         // as per LIME paper, the dataset size should be at least |features|^2
         double perturbedDataSize = Math.max(noOfSamples, Math.pow(2, features.size()));
         for (int i = 0; i < perturbedDataSize; i++) {
-            perturbedInputs.add(DataUtils.perturbFeatures(features, perturbationContext));
+            List<Feature> newFeatures = DataUtils.perturbFeatures(features, perturbationContext);
+            perturbedInputs.add(new PredictionInput(newFeatures));
         }
         return perturbedInputs;
     }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/Type.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/Type.java
@@ -312,30 +312,7 @@ public enum Type {
         @Override
         public Value<?> perturb(Value<?> value, PerturbationContext perturbationContext) {
             List<Feature> composite = getFeatures(value);
-            List<Feature> newList = new ArrayList<>(composite);
-            if (!newList.isEmpty()) {
-                // perturb at most in the range [|features|/2), noOfPerturbations]
-                int lowerBound = (int) Math.min(perturbationContext.getNoOfPerturbations(), 0.5d * composite.size());
-                int upperBound = (int) Math.max(perturbationContext.getNoOfPerturbations(), 0.5d * composite.size());
-                upperBound = Math.min(upperBound, composite.size() - 1);
-                lowerBound = Math.max(1, lowerBound); // lower bound should always greater than zero (not ok to not perturb)
-                int perturbationSize = 0;
-                if (lowerBound == upperBound) {
-                    perturbationSize = lowerBound;
-                }
-                else if (upperBound > lowerBound) {
-                    perturbationSize = perturbationContext.getRandom().ints(lowerBound, 1 + upperBound).findFirst().orElse(1);
-                }
-                if (perturbationSize > 0) {
-                    int[] indexesToBePerturbed = perturbationContext.getRandom().ints(1, newList.size())
-                            .distinct().limit(perturbationSize).toArray();
-                    for (int index : indexesToBePerturbed) {
-                        Feature cf = composite.get(index);
-                        Feature f = FeatureFactory.copyOf(cf, cf.getType().perturb(cf.getValue(), perturbationContext));
-                        newList.set(index, f);
-                    }
-                }
-            }
+            List<Feature> newList = DataUtils.perturbFeatures(composite, perturbationContext);
             return new Value<>(newList);
         }
 

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/Type.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/Type.java
@@ -159,7 +159,7 @@ public enum Type {
 
         @Override
         public Value<?> perturb(Value<?> value, PerturbationContext perturbationContext) {
-            return new Value<>(!Boolean.getBoolean(value.asString()));
+            return new Value<>(!Boolean.parseBoolean(value.asString()));
         }
 
         @Override

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/DataUtils.java
@@ -146,11 +146,10 @@ public class DataUtils {
      *
      * @param originalFeatures    the input features that need to be perturbed
      * @param perturbationContext the perturbation context
-     * @return a new input with perturbed features
+     * @return a perturbed copy of the input features
      */
-    public static PredictionInput perturbFeatures(List<Feature> originalFeatures, PerturbationContext perturbationContext) {
+    public static List<Feature> perturbFeatures(List<Feature> originalFeatures, PerturbationContext perturbationContext) {
         List<Feature> newFeatures = new ArrayList<>(originalFeatures);
-        PredictionInput perturbedInput = new PredictionInput(newFeatures);
         if (!newFeatures.isEmpty()) {
             // perturb at most in the range [|features|/2), noOfPerturbations]
             int lowerBound = (int) Math.min(perturbationContext.getNoOfPerturbations(), 0.5d * newFeatures.size());
@@ -165,16 +164,16 @@ public class DataUtils {
                 perturbationSize = perturbationContext.getRandom().ints(lowerBound, 1 + upperBound).findFirst().orElse(1);
             }
             if (perturbationSize > 0) {
-                int[] indexesToBePerturbed = perturbationContext.getRandom().ints(1, perturbedInput.getFeatures().size())
+                int[] indexesToBePerturbed = perturbationContext.getRandom().ints(1, newFeatures.size())
                         .distinct().limit(perturbationSize).toArray();
                 for (int index : indexesToBePerturbed) {
-                    Feature feature = perturbedInput.getFeatures().get(index);
+                    Feature feature = newFeatures.get(index);
                     Feature perturbedFeature = FeatureFactory.copyOf(feature, feature.getType().perturb(feature.getValue(), perturbationContext));
-                    perturbedInput.getFeatures().set(index, perturbedFeature);
+                    newFeatures.set(index, perturbedFeature);
                 }
             }
         }
-        return perturbedInput;
+        return newFeatures;
     }
 
     /**

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/model/TypeTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/model/TypeTest.java
@@ -132,15 +132,19 @@ class TypeTest {
 
     @Test
     void testPerturbCompositeFeature() {
-        PerturbationContext perturbationContext = new PerturbationContext(new Random(), 2);
-        List<Feature> features = new LinkedList<>();
-        features.add(new Feature("f1", Type.TEXT, new Value<>("foo bar")));
-        features.add(new Feature("f2", Type.NUMBER, new Value<>(1d)));
-        features.add(new Feature("f3", Type.BOOLEAN, new Value<>(true)));
-        Value<?> value = new Value<>(features);
-        Feature f = new Feature("name", Type.COMPOSITE, value);
-        Value<?> perturbedValue = f.getType().perturb(f.getValue(), perturbationContext);
-        assertNotEquals(value, perturbedValue);
+        Random random = new Random();
+        for (int i = 0; i < 10000; i++) {
+            random.setSeed(i);
+            PerturbationContext perturbationContext = new PerturbationContext(random, 2);
+            List<Feature> features = new LinkedList<>();
+            features.add(new Feature("f1", Type.TEXT, new Value<>("foo bar")));
+            features.add(new Feature("f2", Type.NUMBER, new Value<>(1d)));
+            features.add(new Feature("f3", Type.BOOLEAN, new Value<>(true)));
+            Value<?> value = new Value<>(features);
+            Feature f = new Feature("name", Type.COMPOSITE, value);
+            Value<?> perturbedValue = f.getType().perturb(f.getValue(), perturbationContext);
+            assertNotEquals(value, perturbedValue, "fail with seed " + i);
+        }
     }
 
     @Test

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/DataUtilsTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/DataUtilsTest.java
@@ -34,6 +34,8 @@ import org.kie.kogito.explainability.model.PredictionInput;
 import org.kie.kogito.explainability.model.Type;
 import org.kie.kogito.explainability.model.Value;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -235,7 +237,8 @@ class DataUtilsTest {
                 changedFeatures++;
             }
         }
-        assertEquals(noOfPerturbations, changedFeatures);
+        assertThat(changedFeatures).isBetween((int) Math.min(noOfPerturbations, input.getFeatures().size() * 0.5),
+                                              (int) Math.max(noOfPerturbations, input.getFeatures().size() * 0.5));
     }
 
     private void assertPerturbDropString(PredictionInput input, int noOfPerturbations) {
@@ -248,7 +251,8 @@ class DataUtilsTest {
                 changedFeatures++;
             }
         }
-        assertEquals(noOfPerturbations, changedFeatures);
+        assertThat(changedFeatures).isBetween((int) Math.min(noOfPerturbations, input.getFeatures().size() * 0.5),
+                                              (int) Math.max(noOfPerturbations, input.getFeatures().size() * 0.5));
     }
 
     @Test

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/DataUtilsTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/DataUtilsTest.java
@@ -138,9 +138,9 @@ class DataUtilsTest {
     void testPerturbFeaturesEmpty() {
         List<Feature> features = new LinkedList<>();
         PerturbationContext perturbationContext = new PerturbationContext(random, 0);
-        PredictionInput predictionInput = DataUtils.perturbFeatures(features, perturbationContext);
-        assertNotNull(predictionInput);
-        assertEquals(features.size(), predictionInput.getFeatures().size());
+        List<Feature> newFeatures = DataUtils.perturbFeatures(features, perturbationContext);
+        assertNotNull(newFeatures);
+        assertEquals(features.size(), newFeatures.size());
     }
 
     @Test
@@ -228,11 +228,11 @@ class DataUtilsTest {
     }
 
     private void assertPerturbDropNumeric(PredictionInput input, int noOfPerturbations) {
-        PredictionInput perturbedInput = DataUtils.perturbFeatures(input.getFeatures(), new PerturbationContext(random, noOfPerturbations));
+        List<Feature> newFeatures = DataUtils.perturbFeatures(input.getFeatures(), new PerturbationContext(random, noOfPerturbations));
         int changedFeatures = 0;
         for (int i = 0; i < input.getFeatures().size(); i++) {
             double v = input.getFeatures().get(i).getValue().asNumber();
-            double pv = perturbedInput.getFeatures().get(i).getValue().asNumber();
+            double pv = newFeatures.get(i).getValue().asNumber();
             if (v != pv) {
                 changedFeatures++;
             }
@@ -242,11 +242,11 @@ class DataUtilsTest {
     }
 
     private void assertPerturbDropString(PredictionInput input, int noOfPerturbations) {
-        PredictionInput perturbedInput = DataUtils.perturbFeatures(input.getFeatures(), new PerturbationContext(random, noOfPerturbations));
+        List<Feature> newFeatures = DataUtils.perturbFeatures(input.getFeatures(), new PerturbationContext(random, noOfPerturbations));
         int changedFeatures = 0;
         for (int i = 0; i < input.getFeatures().size(); i++) {
             String v = input.getFeatures().get(i).getValue().asString();
-            String pv = perturbedInput.getFeatures().get(i).getValue().asString();
+            String pv = newFeatures.get(i).getValue().asString();
             if (!v.equals(pv)) {
                 changedFeatures++;
             }


### PR DESCRIPTION
Make LIME choice of the number of features to perturb more robust, especially when working with lists of inputs (hence the no. of features is not known in advance).
This change make perturbation happen not on a fixed number of features but rather on a number of features that is constrained to a `[|features|/2, noOfPerturbations]` range (the range is flipped in case `noOfPerturbations` is smaller than half the number of existing features in the input).
Note that the smallest lower bound for perturbation is kept to `1` to avoid not perturbing _any_ feature.

See https://issues.redhat.com/browse/KOGITO-3279

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket