### PR TITLE
[Jobs Service] reschedule operarion on patch API + attributes restriction

### DIFF
--- a/jobs-service/docker/docker-compose.yaml
+++ b/jobs-service/docker/docker-compose.yaml
@@ -8,7 +8,9 @@ services:
       - 11222:11222
     command: "/opt/infinispan/bin/server.sh -c infinispan-demo.xml"
     volumes:
-      - ./infinispan/infinispan.xml:/opt/infinispan/server/conf/infinispan-demo.xml:z
+      - ./infinispan/infinispan.xml:/opt/infinispan/server/conf/infinispan-demo.xml
+      - ./infinispan/users.properties:/opt/infinispan/server/conf/users.properties
+      - ./infinispan/groups.properties:/opt/infinispan/server/conf/groups.properties
 
   zookeeper:
     image: strimzi/kafka:0.19.0-kafka-2.5.0

--- a/jobs-service/docker/infinispan/groups.properties
+++ b/jobs-service/docker/infinispan/groups.properties
@@ -1,0 +1,16 @@
+##
+#  Copyright 2020 Red Hat, Inc. and/or its affiliates.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+admin=admin

--- a/jobs-service/docker/infinispan/infinispan.xml
+++ b/jobs-service/docker/infinispan/infinispan.xml
@@ -1,6 +1,6 @@
-<infinispan xmlns='urn:infinispan:config:11.0' xsi:schemaLocation='urn:infinispan:config:11.0 http://www.infinispan.org/schemas/infinispan-config-11.0.xsd urn:infinispan:server:11.0 http://www.infinispan.org/schemas/infinispan-server-11.0.xsd'
+<infinispan xmlns='urn:infinispan:config:10.0' xsi:schemaLocation='urn:infinispan:config:10.0 http://www.infinispan.org/schemas/infinispan-config-10.0.xsd urn:infinispan:server:10.0 http://www.infinispan.org/schemas/infinispan-server-10.0.xsd'
             xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
-  <server xmlns='urn:infinispan:server:11.0'>
+  <server xmlns='urn:infinispan:server:10.0'>
     <interfaces>
       <interface name='public'>
         <inet-address value='${infinispan.bind.address:0.0.0.0}'/>
@@ -13,14 +13,18 @@
       <security-realms>
         <security-realm name='default'>
           <properties-realm groups-attribute='Roles'>
-            <user-properties path='users.properties' relative-to='infinispan.server.config.path'/>
+            <user-properties path='users.properties' relative-to='infinispan.server.config.path' plain-text='true'/>
             <group-properties path='groups.properties' relative-to='infinispan.server.config.path'/>
           </properties-realm>
         </security-realm>
       </security-realms>
     </security>
     <endpoints socket-binding='default' security-realm='default'>
-      <hotrod-connector name="hotrod"/>
+      <hotrod-connector name="hotrod">
+        <authentication>
+          <sasl mechanisms="PLAIN DIGEST-MD5 SCRAM-SHA-512" qop="auth" server-name="infinispan"/>
+        </authentication>
+      </hotrod-connector>
       <rest-connector name="rest"/>
     </endpoints>
   </server>

--- a/jobs-service/docker/infinispan/users.properties
+++ b/jobs-service/docker/infinispan/users.properties
@@ -1,0 +1,1 @@
+admin=admin

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/model/job/ScheduledJobAdapter.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/model/job/ScheduledJobAdapter.java
@@ -37,7 +37,7 @@ public class ScheduledJobAdapter {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    {
+    static {
         OBJECT_MAPPER.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
         OBJECT_MAPPER.configure(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT, true);
         OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -91,7 +91,7 @@ public class ScheduledJobAdapter {
                 .executionCounter(scheduledJob.getExecutionCounter())
                 .lastUpdate(scheduledJob.getLastUpdate())
                 .recipient(Optional.ofNullable(scheduledJob.getCallbackEndpoint())
-                                   .map(e -> new Recipient.HTTPRecipient(e))
+                                   .map(Recipient.HTTPRecipient::new)
                                    .orElse(null))
                 .retries(scheduledJob.getRetries())
                 .scheduledId(scheduledJob.getScheduledId())

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/resource/JobResource.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/resource/JobResource.java
@@ -76,7 +76,7 @@ public class JobResource {
     @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public CompletionStage<ScheduledJob> patch(@PathParam("id") String id, @RequestBody Job job) throws Exception {
+    public CompletionStage<ScheduledJob> patch(@PathParam("id") String id, @RequestBody Job job) {
         LOGGER.debug("REST patch update {}", job);
         JobDetails jobToBeMerged = ScheduledJobAdapter.to(ScheduledJobBuilder.from(job));
         //validating allowed patch attributes

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/BaseTimerJobScheduler.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/BaseTimerJobScheduler.java
@@ -104,6 +104,14 @@ public abstract class BaseTimerJobScheduler implements ReactiveJobScheduler {
                 .buildRs();
     }
 
+    @Override
+    public PublisherBuilder<JobDetails> reschedule(String id, Trigger trigger) {
+        return ReactiveStreams.fromCompletionStageNullable(jobRepository.merge(id, JobDetails.builder().trigger(trigger).build()))
+                .peek(this::doCancel)
+                .map(this::schedule)
+                .flatMapRsPublisher(j -> j);
+    }
+
     private JobDetails jobWithStatus(JobDetails job, JobStatus status) {
         return JobDetails.builder().of(job).status(status).build();
     }

--- a/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/ReactiveJobScheduler.java
+++ b/jobs-service/src/main/java/org/kie/kogito/jobs/service/scheduler/ReactiveJobScheduler.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletionStage;
 import org.eclipse.microprofile.reactive.streams.operators.PublisherBuilder;
 import org.kie.kogito.jobs.service.model.JobExecutionResponse;
 import org.kie.kogito.jobs.service.model.job.JobDetails;
+import org.kie.kogito.timer.Trigger;
 import org.reactivestreams.Publisher;
 
 public interface ReactiveJobScheduler extends JobScheduler<Publisher<JobDetails>, CompletionStage<JobDetails>> {
@@ -28,6 +29,8 @@ public interface ReactiveJobScheduler extends JobScheduler<Publisher<JobDetails>
     Publisher<JobDetails> schedule(JobDetails job);
 
     CompletionStage<JobDetails> cancel(String jobId);
+
+    PublisherBuilder<JobDetails> reschedule(String id, Trigger trigger);
 
     PublisherBuilder<JobDetails> handleJobExecutionError(JobExecutionResponse errorResponse);
 

--- a/jobs-service/src/main/resources/application.properties
+++ b/jobs-service/src/main/resources/application.properties
@@ -49,11 +49,11 @@ quarkus.swagger-ui.path=/swagger-ui
 
 #Infinispan - more specific configs on hotrod-client.properties file.
 quarkus.infinispan-client.server-list=localhost:11222
-quarkus.infinispan-client.auth-username=${infinispan_username:}
-quarkus.infinispan-client.auth-password=${infinispan_password:}
-quarkus.infinispan-client.use-auth=${infinispan_useauth:false}
-quarkus.infinispan-client.auth-realm=${infinispan_authrealm:}
-quarkus.infinispan-client.sasl-mechanism=${infinispan_saslmechanism:}
+quarkus.infinispan-client.auth-username=${infinispan_username:admin}
+quarkus.infinispan-client.auth-password=${infinispan_password:admin}
+quarkus.infinispan-client.use-auth=${infinispan_useauth:true}
+quarkus.infinispan-client.auth-realm=${infinispan_authrealm:default}
+quarkus.infinispan-client.sasl-mechanism=${infinispan_saslmechanism:DIGEST-MD5}
 
 #Job Service
 #Persistence values = in-memory, infinispan

--- a/jobs-service/src/main/resources/application.properties
+++ b/jobs-service/src/main/resources/application.properties
@@ -39,7 +39,6 @@ quarkus.ssl.native=true
 quarkus.resteasy.gzip.enabled=true
 quarkus.resteasy.gzip.max-input=10M
 quarkus.http.cors=true
-quarkus.http.cors.methods=GET,PUT,POST,DELETE
 quarkus.http.limits.max-body-size=10M
 quarkus.http.port=8080
 

--- a/jobs-service/src/test/java/org/kie/kogito/jobs/service/model/job/ScheduledJobAdapterTest.java
+++ b/jobs-service/src/test/java/org/kie/kogito/jobs/service/model/job/ScheduledJobAdapterTest.java
@@ -109,6 +109,25 @@ class ScheduledJobAdapterTest {
         assertThat(trigger.nextFireTime()).isEqualTo(DateUtil.toDate(TIME));
     }
 
+    @Test
+    void testToJobDetailsWithEmptyPayload() {
+        ScheduledJob scheduledJob = ScheduledJob.builder()
+                .job(JobBuilder.builder().id(UUID.randomUUID().toString()).build())
+                .build();
+        JobDetails jobDetails = ScheduledJobAdapter.to(scheduledJob);
+        assertThat(jobDetails.getPayload()).isNull();
+    }
+
+    @Test
+    void testToScheduledJobWithEmptyPayload() {
+        JobDetails jobDetails = JobDetails.builder().id(UUID.randomUUID().toString()).build();
+        ScheduledJob scheduledJob = ScheduledJobAdapter.of(jobDetails);
+        assertThat(scheduledJob.getProcessId()).isNull();
+        assertThat(scheduledJob.getProcessInstanceId()).isNull();
+        assertThat(scheduledJob.getRootProcessId()).isNull();
+        assertThat(scheduledJob.getRootProcessInstanceId()).isNull();
+    }
+
     private ScheduledJob.ScheduledJobBuilder getScheduledJobCommonBuilder(JobBuilder jobBuilder) {
         return ScheduledJob.builder()
                 .job(jobBuilder


### PR DESCRIPTION
Changes required by the **management-console** for job management.

- reschedule on patch
- restrict attributes to be updated to only job timer triggers
- allow CORS on all http methods

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket