### PR TITLE
KOGITO-3501: Queries in infinispan aren't correctly grouping clauses inside AND's/OR's

### DIFF
--- a/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/query/InfinispanQuery.java
+++ b/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/query/InfinispanQuery.java
@@ -145,6 +145,9 @@ public class InfinispanQuery<T> implements Query<T> {
     }
 
     private String getRecursiveString(AttributeFilter<?> filter, String joining) {
-        return ((List<AttributeFilter<?>>) filter.getValue()).stream().map(filterStringFunction()).collect(joining(joining));
+        return "(" + ((List<AttributeFilter<?>>) filter.getValue())
+                .stream()
+                .map(filterStringFunction())
+                .collect(joining(joining)) + ")";
     }
 }

--- a/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/query/InfinispanQuery.java
+++ b/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/query/InfinispanQuery.java
@@ -145,9 +145,9 @@ public class InfinispanQuery<T> implements Query<T> {
     }
 
     private String getRecursiveString(AttributeFilter<?> filter, String joining) {
-        return "(" + ((List<AttributeFilter<?>>) filter.getValue())
+        return ((List<AttributeFilter<?>>) filter.getValue())
                 .stream()
                 .map(filterStringFunction())
-                .collect(joining(joining)) + ")";
+                .collect(joining(joining,  "(", ")"));
     }
 }

--- a/persistence-commons/persistence-commons-infinispan/src/test/java/org/kie/kogito/persistence/infinispan/query/InfinispanQueryTest.java
+++ b/persistence-commons/persistence-commons-infinispan/src/test/java/org/kie/kogito/persistence/infinispan/query/InfinispanQueryTest.java
@@ -107,15 +107,19 @@ class InfinispanQueryTest {
                 ),
                 Arguments.of(
                         asList(and(asList(lessThanEqual("priority", 1), greaterThan("priority", 1)))),
-                        "from org.kie.kogito.index.model.ProcessInstance o where o.priority <= 1 and o.priority > 1"
+                        "from org.kie.kogito.index.model.ProcessInstance o where (o.priority <= 1 and o.priority > 1)"
                 ),
                 Arguments.of(
                         asList(or(asList(lessThanEqual("priority", 1), greaterThan("priority", 1)))),
-                        "from org.kie.kogito.index.model.ProcessInstance o where o.priority <= 1 or o.priority > 1"
+                        "from org.kie.kogito.index.model.ProcessInstance o where (o.priority <= 1 or o.priority > 1)"
                 ),
                 Arguments.of(
                         asList(and(asList(notNull("name"), contains("name", "test"))), or(asList(lessThanEqual("priority", 1), greaterThan("priority", 1)))),
-                        "from org.kie.kogito.index.model.ProcessInstance o where o.name is not null and o.name = 'test' and o.priority <= 1 or o.priority > 1"
+                        "from org.kie.kogito.index.model.ProcessInstance o where (o.name is not null and o.name = 'test') and (o.priority <= 1 or o.priority > 1)"
+                ),
+                Arguments.of(
+                        asList(or(asList(isNull("name"), contains("name", "test"))), and(asList(between("start", "2019-01-01", "2020-01-01"), or(asList(lessThanEqual("priority", 1), greaterThan("priority", 1)))))),
+                        "from org.kie.kogito.index.model.ProcessInstance o where (o.name is null or o.name = 'test') and (o.start between '2019-01-01' and '2020-01-01' and (o.priority <= 1 or o.priority > 1))"
                 )
         );
     }


### PR DESCRIPTION
fixing grouping issue in queries when nesting and/or's.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket