### PR TITLE
FAI-254 Implement counterfactual search using OptaPlanner

### DIFF
--- a/explainability/explainability-core/pom.xml
+++ b/explainability/explainability-core/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <optaplanner.version>8.0.0-SNAPSHOT</optaplanner.version>
+        <version.org.optaplanner>8.0.0-SNAPSHOT</version.org.optaplanner>
     </properties>
 
     <dependencyManagement>
@@ -18,7 +18,7 @@
             <dependency>
                 <groupId>org.optaplanner</groupId>
                 <artifactId>optaplanner-core</artifactId>
-                <version>${optaplanner.version}</version>
+                <version>${version.org.optaplanner}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/explainability/explainability-core/pom.xml
+++ b/explainability/explainability-core/pom.xml
@@ -1,39 +1,59 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <parent>
-    <groupId>org.kie.kogito</groupId>
-    <artifactId>explainability</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <parent>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>explainability</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>explainability-core</artifactId>
-  <name>Kogito :: Explainability Core</name>
-  <dependencies>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+    <properties>
+        <optaplanner.version>8.0.0-SNAPSHOT</optaplanner.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.optaplanner</groupId>
+                <artifactId>optaplanner-core</artifactId>
+                <version>${optaplanner.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+
+    <artifactId>explainability-core</artifactId>
+    <name>Kogito :: Explainability Core</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.optaplanner</groupId>
+            <artifactId>optaplanner-core</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.explainability.local.counterfactual;
+
+
+import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.Output;
+import org.kie.kogito.explainability.model.PredictionInput;
+import org.kie.kogito.explainability.model.PredictionOutput;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+import org.optaplanner.core.api.score.calculator.EasyScoreCalculator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+/**
+ * Counterfactual score calculator.
+ * The score is implementabled as a {@link BendableBigDecimalScore} with two hard levels and one soft level.
+ * The primary hard level penalizes solutions which do not meet the required outcome.
+ * The second hard level penalizes solutions which change constrained {@link CounterfactualEntity}.
+ * The soft level penalizes solutions according to their distance from the original prediction inputs.
+ */
+public class CounterFactualScoreCalculator implements EasyScoreCalculator<CounterfactualSolution, BendableBigDecimalScore> {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(CounterFactualScoreCalculator.class);
+
+    /**
+     * Calculate the prediction's (as a {@link List<PredictionOutput>}) squared distance from the desired outcome (as a {@link List<Output>}).
+     *
+     * @param predictions The list of predictions (containing a single prediction)
+     * @param goal        The desired outcome a list of {@link Output}
+     * @return
+     */
+    private double predictionDistance(List<PredictionOutput> predictions, List<Output> goal) {
+        final List<Output> outputs = predictions.get(0).getOutputs();
+        double distance = 0.0;
+        if (outputs.size() != predictions.size()) {
+            throw new IllegalArgumentException("Prediction size must be equal to goal size");
+        }
+        for (int i = 0; i < outputs.size(); i++) {
+            final Output output = outputs.get(i);
+            distance += goal.get(i).getValue().asNumber() - output.getValue().asNumber();
+        }
+        return distance * distance;
+    }
+
+    @Override
+    public BendableBigDecimalScore calculateScore(CounterfactualSolution solution) {
+
+        double primaryHardScore = 0;
+        int secondaryHardScore = 0;
+        double primarySoftScore = 0.0;
+
+        StringBuilder builder = new StringBuilder();
+
+        for (CounterfactualEntity entity : solution.getEntities()) {
+            primarySoftScore += entity.distance();
+            final Feature f = entity.asFeature();
+            builder.append(f.getName()).append("=").append(f.getValue().getUnderlyingObject()).append("(d: ").append(entity.distance()).append("),");
+
+            if (entity.isConstrained() && (entity.isChanged())) {
+                secondaryHardScore -= 1;
+            }
+        }
+
+        logger.debug(builder.toString());
+
+        List<Feature> input = solution.getEntities().stream().map(CounterfactualEntity::asFeature).collect(Collectors.toList());
+
+        PredictionInput predictionInput = new PredictionInput(input);
+
+        List<PredictionInput> inputs = new ArrayList<>();
+        inputs.add(predictionInput);
+        CompletableFuture<List<PredictionOutput>> predictionAsync = solution.getModel().predictAsync(inputs);
+
+        try {
+            List<PredictionOutput> predictions = predictionAsync.get();
+            final double distance = predictionDistance(predictions, solution.getGoal());
+            primaryHardScore -= distance;
+            logger.info("Penalise outcome (output: {})", distance);
+
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error(e.getMessage());
+        }
+
+        logger.info("Soft score: " + (-Math.abs(primarySoftScore)));
+        return BendableBigDecimalScore.of(
+                new BigDecimal[]{
+                        BigDecimal.valueOf(primaryHardScore), BigDecimal.valueOf(secondaryHardScore)
+                },
+                new BigDecimal[]{BigDecimal.valueOf(-Math.abs(primarySoftScore))});
+    }
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
@@ -51,7 +51,7 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
      *
      * @param predictions The list of predictions (containing a single prediction)
      * @param goal        The desired outcome a list of {@link Output}
-     * @return
+     * @return Numerical distance between prediction and desired outcome
      */
     private double predictionDistance(List<PredictionOutput> predictions, List<Output> goal) {
         final List<Output> outputs = predictions.get(0).getOutputs();
@@ -85,7 +85,7 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
             }
         }
 
-        logger.debug(builder.toString());
+        logger.debug("Current solution: {}", builder);
 
         List<Feature> input = solution.getEntities().stream().map(CounterfactualEntity::asFeature).collect(Collectors.toList());
 
@@ -102,10 +102,10 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
             logger.info("Penalise outcome (output: {})", distance);
 
         } catch (InterruptedException | ExecutionException e) {
-            logger.error(e.getMessage());
+            logger.error("Impossible to obtain prediction {}", e.getMessage());
         }
 
-        logger.info("Soft score: " + (-Math.abs(primarySoftScore)));
+        logger.debug("Soft score: {}", -Math.abs(primarySoftScore));
         return BendableBigDecimalScore.of(
                 new BigDecimal[]{
                         BigDecimal.valueOf(primaryHardScore), BigDecimal.valueOf(secondaryHardScore)

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
@@ -15,6 +15,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CounterfactualConfigurationFactory {
+
+    private CounterfactualConfigurationFactory() {
+        
+    }
+
     public static SolverConfig createSolverConfig(Long timeLimit, int tabuSize, int acceptedCount) {
         SolverConfig solverConfig = new SolverConfig();
 

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualConfigurationFactory.java
@@ -1,0 +1,48 @@
+package org.kie.kogito.explainability.local.counterfactual;
+
+import org.kie.kogito.explainability.local.counterfactual.entities.BooleanEntity;
+import org.kie.kogito.explainability.local.counterfactual.entities.DoubleEntity;
+import org.kie.kogito.explainability.local.counterfactual.entities.IntegerEntity;
+import org.optaplanner.core.config.localsearch.LocalSearchPhaseConfig;
+import org.optaplanner.core.config.localsearch.decider.acceptor.LocalSearchAcceptorConfig;
+import org.optaplanner.core.config.localsearch.decider.forager.LocalSearchForagerConfig;
+import org.optaplanner.core.config.phase.PhaseConfig;
+import org.optaplanner.core.config.score.director.ScoreDirectorFactoryConfig;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CounterfactualConfigurationFactory {
+    public static SolverConfig createSolverConfig(Long timeLimit, int tabuSize, int acceptedCount) {
+        SolverConfig solverConfig = new SolverConfig();
+
+        solverConfig.withEntityClasses(IntegerEntity.class, DoubleEntity.class, BooleanEntity.class);
+        solverConfig.setSolutionClass(CounterfactualSolution.class);
+
+        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = new ScoreDirectorFactoryConfig();
+        scoreDirectorFactoryConfig.setEasyScoreCalculatorClass(CounterFactualScoreCalculator.class);
+        solverConfig.setScoreDirectorFactoryConfig(scoreDirectorFactoryConfig);
+
+        TerminationConfig terminationConfig = new TerminationConfig();
+        terminationConfig.setSecondsSpentLimit(timeLimit);
+        solverConfig.setTerminationConfig(terminationConfig);
+
+        LocalSearchAcceptorConfig acceptorConfig = new LocalSearchAcceptorConfig();
+        acceptorConfig.setEntityTabuSize(tabuSize);
+
+        LocalSearchForagerConfig localSearchForagerConfig = new LocalSearchForagerConfig();
+        localSearchForagerConfig.setAcceptedCountLimit(acceptedCount);
+
+        LocalSearchPhaseConfig localSearchPhaseConfig = new LocalSearchPhaseConfig();
+        localSearchPhaseConfig.setAcceptorConfig(acceptorConfig);
+        localSearchPhaseConfig.setForagerConfig(localSearchForagerConfig);
+
+        List<PhaseConfig> phaseConfigs = new ArrayList<>();
+        phaseConfigs.add(localSearchPhaseConfig);
+
+        solverConfig.setPhaseConfigList(phaseConfigs);
+        return solverConfig;
+    }
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual;
+
+import org.kie.kogito.explainability.local.LocalExplainer;
+import org.kie.kogito.explainability.local.counterfactual.entities.BooleanEntity;
+import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
+import org.kie.kogito.explainability.local.counterfactual.entities.DoubleEntity;
+import org.kie.kogito.explainability.local.counterfactual.entities.IntegerEntity;
+import org.kie.kogito.explainability.model.*;
+import org.optaplanner.core.api.solver.SolverJob;
+import org.optaplanner.core.api.solver.SolverManager;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.SolverManagerConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Provides exemplar (counterfactual) explanations for a predictive model.
+ * This implementation uses the Constraint Solution Problem solver OptaPlanner to search for
+ * counterfactuals which minimize a score calculated by {@link CounterFactualScoreCalculator}.
+ */
+public class CounterfactualExplainer implements LocalExplainer<List<CounterfactualEntity>> {
+
+    private static final long DEFAULT_TIME_LIMIT = 30;
+    private static final int DEFAULT_TABU_SIZE = 70;
+    private static final int DEFAULT_ACCEPTED_COUNT = 5000;
+    private final List<Output> goal;
+    private final DataBoundaries dataBoundaries;
+    private final List<Boolean> constraints;
+    private final SolverConfig solverConfig;
+
+    /**
+     * Create a new {@link CounterfactualExplainer} using OptaPlanner as the underlying engine.
+     *
+     * @param dataBoundaries A {@link DataBoundaries} which specifies the search space boundaries
+     * @param contraints     A list specifying by index which features are constrained
+     * @param goal           A collection of {@link Output} representing the desired outcome
+     * @param solverConfig   An OptaPlanner {@link SolverConfig} configuration
+     */
+    public CounterfactualExplainer(DataBoundaries dataBoundaries, List<Boolean> contraints, List<Output> goal, SolverConfig solverConfig) {
+        this.constraints = contraints;
+        this.goal = goal;
+        this.dataBoundaries = dataBoundaries;
+        this.solverConfig = solverConfig;
+    }
+
+    public CounterfactualExplainer(DataBoundaries dataBoundaries, List<Boolean> constraints, List<Output> goal) {
+        this(dataBoundaries,
+                constraints,
+                goal,
+                CounterfactualConfigurationFactory.createSolverConfig(
+                        DEFAULT_TIME_LIMIT,
+                        DEFAULT_TABU_SIZE,
+                        DEFAULT_ACCEPTED_COUNT)
+        );
+    }
+
+    /**
+     * Create a new {@link CounterfactualExplainer} using OptaPlanner as the underlying engine.
+     *
+     * @param dataBoundaries A {@link DataBoundaries} which specifies the search space boundaries
+     * @param contraints     A list specifying by index which features are constrained
+     * @param goal           A collection of {@link Output} representing the desired outcome
+     * @param timeLimit      Computational time spent limit in seconds
+     * @param tabuSize       Tabu search limit
+     * @param acceptedCount  How many accepted moves should be evaluated during each step
+     * @see "Glover, Fred. "Tabu search—part I." ORSA Journal on computing 1, no. 3 (1989): 190-206"
+     */
+    public CounterfactualExplainer(DataBoundaries dataBoundaries, List<Boolean> contraints, List<Output> goal, Long timeLimit, int tabuSize, int acceptedCount) {
+        this(dataBoundaries, contraints, goal, CounterfactualConfigurationFactory.createSolverConfig(timeLimit, tabuSize, acceptedCount));
+    }
+
+    private List<CounterfactualEntity> createEntities(PredictionInput predictionInput) {
+        final List<CounterfactualEntity> entities = new ArrayList<>();
+
+        for (int i = 0; i < predictionInput.getFeatures().size(); i++) {
+            final Feature feature = predictionInput.getFeatures().get(i);
+            final Boolean isConstrained = constraints.get(i);
+            final FeatureBoundary featureDistribution = dataBoundaries.getFeatureBoundaries().get(i);
+            if (feature.getType() == Type.NUMBER) {
+                if (feature.getValue().getUnderlyingObject() instanceof Double) {
+                    final DoubleEntity doubleEntity = new DoubleEntity(feature, featureDistribution.getStart(), featureDistribution.getEnd(), isConstrained);
+                    entities.add(doubleEntity);
+                } else if (feature.getValue().getUnderlyingObject() instanceof Integer) {
+                    final IntegerEntity integerEntity = new IntegerEntity(feature, (int) featureDistribution.getStart(), (int) featureDistribution.getEnd(), isConstrained);
+                    entities.add(integerEntity);
+                }
+            } else if (feature.getType() == Type.BOOLEAN) {
+                final BooleanEntity booleanEntity = new BooleanEntity(feature, isConstrained);
+                entities.add(booleanEntity);
+            }
+        }
+        return entities;
+    }
+
+    @Override
+    public CompletableFuture<List<CounterfactualEntity>> explainAsync(Prediction prediction, PredictionProvider model) {
+
+        final List<CounterfactualEntity> entities = createEntities(prediction.getInput());
+
+        final UUID problemId = UUID.randomUUID();
+
+        SolverManager<CounterfactualSolution, UUID> solverManager =
+                SolverManager.create(solverConfig, new SolverManagerConfig());
+
+        CounterfactualSolution problem =
+                new CounterfactualSolution(entities, model, goal);
+
+
+        SolverJob<CounterfactualSolution, UUID> solverJob = solverManager.solve(problemId, problem);
+        CounterfactualSolution solution;
+        try {
+            // Wait until the solving ends
+            solution = solverJob.getFinalBestSolution();
+            System.out.println(solution.toString());
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IllegalStateException("Solving failed.", e);
+        }
+
+        System.out.println("The counterfactual is:");
+        for (CounterfactualEntity cfEntity : solution.getEntities()) {
+            System.out.println(cfEntity.asFeature().toString());
+        }
+        return CompletableFuture.completedFuture(solution.getEntities());
+    }
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -130,15 +130,12 @@ public class CounterfactualExplainer implements LocalExplainer<List<Counterfactu
         try {
             // Wait until the solving ends
             solution = solverJob.getFinalBestSolution();
-            System.out.println(solution.toString());
         } catch (InterruptedException | ExecutionException e) {
-            throw new IllegalStateException("Solving failed.", e);
+            throw new IllegalStateException("Solving failed: {}", e);
         }
 
-        System.out.println("The counterfactual is:");
-        for (CounterfactualEntity cfEntity : solution.getEntities()) {
-            System.out.println(cfEntity.asFeature().toString());
-        }
+        solverManager.close();
+
         return CompletableFuture.completedFuture(solution.getEntities());
     }
 }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualSolution.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualSolution.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.explainability.local.counterfactual;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
+import org.kie.kogito.explainability.model.Output;
+import org.kie.kogito.explainability.model.PredictionProvider;
+import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
+import org.optaplanner.core.api.domain.solution.PlanningSolution;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+
+import java.util.List;
+
+/**
+ * Represents an OptaPlanner {@link PlanningSolution}.
+ * This solution stores all the features as {@link CounterfactualEntity}, as well as a reference to the
+ * {@link PredictionProvider} model.
+ */
+@PlanningSolution
+public class CounterfactualSolution {
+
+    @PlanningEntityCollectionProperty
+    private List<CounterfactualEntity> entities;
+
+    @JsonIgnore
+    private List<Output> goal;
+
+    @JsonIgnore
+    private PredictionProvider model;
+
+    private BendableBigDecimalScore score;
+
+    protected CounterfactualSolution() {
+    }
+
+    public CounterfactualSolution(
+            List<CounterfactualEntity> entities,
+            PredictionProvider model,
+            List<Output> goal) {
+        this.entities = entities;
+        this.model = model;
+        this.goal = goal;
+
+    }
+
+    @PlanningScore(bendableHardLevelsSize = 2, bendableSoftLevelsSize = 1)
+    public BendableBigDecimalScore getScore() {
+        return score;
+    }
+
+    public void setScore(BendableBigDecimalScore score) {
+        this.score = score;
+    }
+
+    public PredictionProvider getModel() {
+        return model;
+    }
+
+    public List<Output> getGoal() {
+        return goal;
+    }
+
+    public List<CounterfactualEntity> getEntities() {
+        return entities;
+    }
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualSolution.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualSolution.java
@@ -16,7 +16,6 @@
 
 package org.kie.kogito.explainability.local.counterfactual;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
 import org.kie.kogito.explainability.model.Output;
 import org.kie.kogito.explainability.model.PredictionProvider;
@@ -38,10 +37,8 @@ public class CounterfactualSolution {
     @PlanningEntityCollectionProperty
     private List<CounterfactualEntity> entities;
 
-    @JsonIgnore
     private List<Output> goal;
 
-    @JsonIgnore
     private PredictionProvider model;
 
     private BendableBigDecimalScore score;

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/BooleanEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/BooleanEntity.java
@@ -29,36 +29,41 @@ import org.optaplanner.core.api.domain.variable.PlanningVariable;
 @PlanningEntity
 public class BooleanEntity implements CounterfactualEntity {
     @PlanningVariable(valueRangeProviderRefs = {"booleanRange"})
-    private Boolean value;
-
-    private Feature feature;
+    private Boolean proposedValue;
 
     private boolean constrained;
+    private Boolean originalValue;
+    private String featureName;
 
     public BooleanEntity() {
+    }
+
+    private BooleanEntity(Boolean originalValue, String featureName, boolean constrained) {
+        this.proposedValue = originalValue;
+        this.originalValue = originalValue;
+        this.featureName = featureName;
+        this.constrained = constrained;
     }
 
     /**
      * Creates a {@link BooleanEntity}, taking the original input value from the
      * provided {@link Feature} and specifying whether the entity is contrained or not.
      *
-     * @param feature     Original input {@link Feature}
-     * @param constrained Whether this entity's value should be fixed or not
+     * @param originalFeature Original input {@link Feature}
+     * @param constrained     Whether this entity's value should be fixed or not
      */
-    public BooleanEntity(Feature feature, boolean constrained) {
-        this.value = (Boolean) feature.getValue().getUnderlyingObject();
-        this.feature = feature;
-        this.constrained = constrained;
+    public static BooleanEntity from(Feature originalFeature, boolean constrained) {
+        return new BooleanEntity((Boolean) originalFeature.getValue().getUnderlyingObject(), originalFeature.getName(), constrained);
     }
 
     /**
      * Creates an unconstrained {@link BooleanEntity}, taking the original input value from the
      * provided {@link Feature}.
      *
-     * @param feature feature Original input {@link Feature}
+     * @param originalFeature feature Original input {@link Feature}
      */
-    public BooleanEntity(Feature feature) {
-        this(feature, false);
+    public static BooleanEntity from(Feature originalFeature) {
+        return BooleanEntity.from(originalFeature, false);
     }
 
     /**
@@ -68,7 +73,7 @@ public class BooleanEntity implements CounterfactualEntity {
      * @return Numerical distance
      */
     public double distance() {
-        return value.equals(feature.getValue().getUnderlyingObject()) ? 0.0 : 1.0;
+        return proposedValue.equals(originalValue) ? 0.0 : 1.0;
     }
 
     /**
@@ -78,7 +83,7 @@ public class BooleanEntity implements CounterfactualEntity {
      */
     @Override
     public Feature asFeature() {
-        return FeatureFactory.newBooleanFeature(feature.getName(), this.value);
+        return FeatureFactory.newBooleanFeature(this.featureName, this.proposedValue);
     }
 
     @Override
@@ -94,7 +99,7 @@ public class BooleanEntity implements CounterfactualEntity {
      */
     @Override
     public boolean isChanged() {
-        return !this.feature.getValue().getUnderlyingObject().equals(this.value);
+        return !this.originalValue.equals(this.proposedValue);
     }
 
     @ValueRangeProvider(id = "booleanRange")
@@ -104,6 +109,6 @@ public class BooleanEntity implements CounterfactualEntity {
 
     @Override
     public String toString() {
-        return "BooleanFeature{" + "value=" + value + ", id='" + feature.getName() + '\'' + '}';
+        return "BooleanFeature{" + "value=" + proposedValue + ", id='" + featureName + '\'' + '}';
     }
 }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/BooleanEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/BooleanEntity.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual.entities;
+
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureFactory;
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.valuerange.ValueRange;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+/**
+ * Mapping between a boolean feature an OptaPlanner {@link PlanningEntity}
+ */
+@PlanningEntity
+public class BooleanEntity implements CounterfactualEntity {
+    @PlanningVariable(valueRangeProviderRefs = {"booleanRange"})
+    private Boolean value;
+
+    private Feature feature;
+
+    private boolean constrained;
+
+    public BooleanEntity() {
+    }
+
+    /**
+     * Creates a {@link BooleanEntity}, taking the original input value from the
+     * provided {@link Feature} and specifying whether the entity is contrained or not.
+     *
+     * @param feature     Original input {@link Feature}
+     * @param constrained Whether this entity's value should be fixed or not
+     */
+    public BooleanEntity(Feature feature, boolean constrained) {
+        this.value = (Boolean) feature.getValue().getUnderlyingObject();
+        this.feature = feature;
+        this.constrained = constrained;
+    }
+
+    /**
+     * Creates an unconstrained {@link BooleanEntity}, taking the original input value from the
+     * provided {@link Feature}.
+     *
+     * @param feature feature Original input {@link Feature}
+     */
+    public BooleanEntity(Feature feature) {
+        this(feature, false);
+    }
+
+    /**
+     * Calculates the distance between the current planning value and the reference value
+     * for this feature.
+     *
+     * @return Numerical distance
+     */
+    public double distance() {
+        return value.equals(feature.getValue().getUnderlyingObject()) ? 0.0 : 1.0;
+    }
+
+    /**
+     * Returns the {@link BooleanEntity} as a {@link Feature}
+     *
+     * @return {@link Feature}
+     */
+    @Override
+    public Feature asFeature() {
+        return FeatureFactory.newBooleanFeature(feature.getName(), this.value);
+    }
+
+    @Override
+    public boolean isConstrained() {
+        return constrained;
+    }
+
+    /**
+     * Returns whether the {@link BooleanEntity} new value is different from the reference
+     * {@link Feature} value.
+     *
+     * @return boolean
+     */
+    @Override
+    public boolean isChanged() {
+        return !this.feature.getValue().getUnderlyingObject().equals(this.value);
+    }
+
+    @ValueRangeProvider(id = "booleanRange")
+    public ValueRange getValueRange() {
+        return ValueRangeFactory.createBooleanValueRange();
+    }
+
+    @Override
+    public String toString() {
+        return "BooleanFeature{" + "value=" + value + ", id='" + feature.getName() + '\'' + '}';
+    }
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntity.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual.entities;
+
+import org.kie.kogito.explainability.model.Feature;
+
+public interface CounterfactualEntity {
+    public double distance();
+
+    public Feature asFeature();
+
+    public boolean isConstrained();
+
+    public boolean isChanged();
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
@@ -21,17 +21,21 @@ import org.kie.kogito.explainability.model.Type;
 
 public class CounterfactualEntityFactory {
 
+    private CounterfactualEntityFactory() {
+
+    }
+
     public static CounterfactualEntity from(Feature feature, Boolean isConstrained, FeatureBoundary featureDistribution) {
 
         CounterfactualEntity entity = null;
         if (feature.getType() == Type.NUMBER) {
             if (feature.getValue().getUnderlyingObject() instanceof Double) {
-                entity = new DoubleEntity(feature, featureDistribution.getStart(), featureDistribution.getEnd(), isConstrained);
+                entity = DoubleEntity.from(feature, featureDistribution.getStart(), featureDistribution.getEnd(), isConstrained);
             } else if (feature.getValue().getUnderlyingObject() instanceof Integer) {
-                entity = new IntegerEntity(feature, (int) featureDistribution.getStart(), (int) featureDistribution.getEnd(), isConstrained);
+                entity = IntegerEntity.from(feature, (int) featureDistribution.getStart(), (int) featureDistribution.getEnd(), isConstrained);
             }
         } else if (feature.getType() == Type.BOOLEAN) {
-            entity = new BooleanEntity(feature, isConstrained);
+            entity = BooleanEntity.from(feature, isConstrained);
         } else {
             throw new IllegalArgumentException("Unsupported feature type: " + feature.getType());
         }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual.entities;
+
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureBoundary;
+import org.kie.kogito.explainability.model.Type;
+
+public class CounterfactualEntityFactory {
+
+    public static CounterfactualEntity from(Feature feature, Boolean isConstrained, FeatureBoundary featureDistribution) {
+
+        CounterfactualEntity entity = null;
+        if (feature.getType() == Type.NUMBER) {
+            if (feature.getValue().getUnderlyingObject() instanceof Double) {
+                entity = new DoubleEntity(feature, featureDistribution.getStart(), featureDistribution.getEnd(), isConstrained);
+            } else if (feature.getValue().getUnderlyingObject() instanceof Integer) {
+                entity = new IntegerEntity(feature, (int) featureDistribution.getStart(), (int) featureDistribution.getEnd(), isConstrained);
+            }
+        } else if (feature.getType() == Type.BOOLEAN) {
+            entity = new BooleanEntity(feature, isConstrained);
+        } else {
+            throw new IllegalArgumentException("Unsupported feature type: " + feature.getType());
+        }
+        return entity;
+    }
+}
+

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/DoubleEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/DoubleEntity.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual.entities;
+
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureFactory;
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.valuerange.ValueRange;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+/**
+ * Mapping between a Double feature an OptaPlanner {@link PlanningEntity}
+ */
+@PlanningEntity
+public class DoubleEntity implements CounterfactualEntity {
+    @PlanningVariable(valueRangeProviderRefs = {"doubleRange"})
+    public Double value;
+
+    double doubleRangeMinimum;
+    double doubleRangeMaximum;
+
+    private Feature feature;
+    private boolean constrained;
+
+    public DoubleEntity() {
+    }
+
+    /**
+     * Creates a {@link DoubleEntity}, taking the original input value from the
+     * provided {@link Feature} and specifying whether the entity is constrained or not.
+     *
+     * @param feature     Original input {@link Feature}
+     * @param constrained Whether this entity's value should be fixed or not
+     */
+    public DoubleEntity(Feature feature, double minimum, double maximum, boolean constrained) {
+        this.value = feature.getValue().asNumber();
+        this.feature = feature;
+        this.doubleRangeMinimum = minimum;
+        this.doubleRangeMaximum = maximum;
+        this.constrained = constrained;
+    }
+
+    /**
+     * Creates an unconstrained {@link DoubleEntity}, taking the original input value from the
+     * provided {@link Feature}.
+     *
+     * @param feature feature Original input {@link Feature}
+     */
+    public DoubleEntity(Feature feature, double minimum, double maximum) {
+        this(feature, minimum, maximum, false);
+    }
+
+    @ValueRangeProvider(id = "doubleRange")
+    public ValueRange getValueRange() {
+        return ValueRangeFactory.createDoubleValueRange(doubleRangeMinimum, doubleRangeMaximum);
+    }
+
+    @Override
+    public String toString() {
+        return "DoubleFeature{"
+                + "value="
+                + value
+                + ", doubleRangeMinimum="
+                + doubleRangeMinimum
+                + ", doubleRangeMaximum="
+                + doubleRangeMaximum
+                + ", id='"
+                + feature.getName()
+                + '\''
+                + '}';
+    }
+
+    /**
+     * Calculates the distance between the current planning value and the reference value
+     * for this feature.
+     *
+     * @return Numerical distance
+     */
+    @Override
+    public double distance() {
+        return Math.abs(this.value - this.feature.getValue().asNumber());
+    }
+
+    /**
+     * Returns the {@link BooleanEntity} as a {@link Feature}
+     *
+     * @return {@link Feature}
+     */
+    @Override
+    public Feature asFeature() {
+        return FeatureFactory.newNumericalFeature(feature.getName(), this.value);
+    }
+
+    @Override
+    public boolean isConstrained() {
+        return constrained;
+    }
+
+    /**
+     * Returns whether the {@link BooleanEntity} new value is different from the reference
+     * {@link Feature} value.
+     *
+     * @return boolean
+     */
+    @Override
+    public boolean isChanged() {
+        return !this.feature.getValue().getUnderlyingObject().equals(this.value);
+    }
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/IntegerEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/IntegerEntity.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual.entities;
+
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureFactory;
+import org.optaplanner.core.api.domain.entity.PlanningEntity;
+import org.optaplanner.core.api.domain.valuerange.ValueRange;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeFactory;
+import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
+import org.optaplanner.core.api.domain.variable.PlanningVariable;
+
+/**
+ * Mapping between an integer feature an OptaPlanner {@link PlanningEntity}
+ */
+
+@PlanningEntity
+public class IntegerEntity implements CounterfactualEntity {
+    @PlanningVariable(valueRangeProviderRefs = {"intRange"})
+    public Integer value;
+
+    int intRangeMinimum;
+    int intRangeMaximum;
+    private Feature feature;
+    private boolean constrained;
+
+    public IntegerEntity() {
+    }
+
+    /**
+     * Creates a {@link IntegerEntity}, taking the original input value from the
+     * provided {@link Feature} and specifying whether the entity is constrained or not.
+     *
+     * @param feature     Original input {@link Feature}
+     * @param constrained Whether this entity's value should be fixed or not
+     */
+    public IntegerEntity(Feature feature, int minimum, int maximum, boolean constrained) {
+        this.value = (int) feature.getValue().asNumber();
+        this.feature = feature;
+        this.intRangeMinimum = minimum;
+        this.intRangeMaximum = maximum;
+        this.constrained = constrained;
+    }
+
+    /**
+     * Creates an unconstrained {@link IntegerEntity}, taking the original input value from the
+     * provided {@link Feature}.
+     *
+     * @param feature feature Original input {@link Feature}
+     */
+    public IntegerEntity(Feature feature, int minimum, int maximum) {
+        this(feature, minimum, maximum, false);
+    }
+
+    @ValueRangeProvider(id = "intRange")
+    public ValueRange getValueRange() {
+        return ValueRangeFactory.createIntValueRange(intRangeMinimum, intRangeMaximum);
+    }
+
+    @Override
+    public String toString() {
+        return "IntegerFeature{"
+                + "value="
+                + value
+                + ", intRangeMinimum="
+                + intRangeMinimum
+                + ", intRangeMaximum="
+                + intRangeMaximum
+                + ", id='"
+                + feature.getName()
+                + '\''
+                + '}';
+    }
+
+    /**
+     * Calculates the distance between the current planning value and the reference value
+     * for this feature.
+     *
+     * @return Numerical distance
+     */
+    @Override
+    public double distance() {
+        return Math.abs(this.value - (int) this.feature.getValue().asNumber());
+    }
+
+    /**
+     * Returns the {@link IntegerEntity} as a {@link Feature}
+     *
+     * @return {@link Feature}
+     */
+    @Override
+    public Feature asFeature() {
+        return FeatureFactory.newNumericalFeature(feature.getName(), this.value);
+    }
+
+
+    @Override
+    public boolean isConstrained() {
+        return constrained;
+    }
+
+    /**
+     * Returns whether the {@link DoubleEntity} new value is different from the reference
+     * {@link Feature} value.
+     *
+     * @return boolean
+     */
+    @Override
+    public boolean isChanged() {
+        return !this.feature.getValue().getUnderlyingObject().equals(this.value);
+    }
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/DataBoundaries.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/DataBoundaries.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Information about domain boundaries of data used for training a model.
+ */
+public class DataBoundaries {
+
+    private final List<FeatureBoundary> featureBoundaries;
+
+    public DataBoundaries(List<FeatureBoundary> featureBoundaries) {
+        this.featureBoundaries = Collections.unmodifiableList(featureBoundaries);
+    }
+
+    /**
+     * Get each feature data boundary
+     *
+     * @return feature boundaries
+     */
+    public List<FeatureBoundary> getFeatureBoundaries() {
+        return featureBoundaries;
+    }
+}

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/FeatureBoundary.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/model/FeatureBoundary.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.model;
+
+/**
+ * Information about search space boundaries for features with a theoretically infinite domain.
+ */
+
+public class FeatureBoundary {
+    private final double start;
+    private final double end;
+
+    public FeatureBoundary(double start, double end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
+     * Get start value for this boundary
+     *
+     * @return the start value
+     */
+    public double getStart() {
+        return start;
+    }
+
+    /**
+     * Get the end value for this boundary
+     *
+     * @return the end value
+     */
+    public double getEnd() {
+        return end;
+    }
+}

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/TestUtils.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/TestUtils.java
@@ -101,6 +101,24 @@ public class TestUtils {
         });
     }
 
+    public static PredictionProvider getSumThresholdModel(double center, double epsilon) {
+        return inputs -> supplyAsync(() -> {
+            List<PredictionOutput> predictionOutputs = new LinkedList<>();
+            for (PredictionInput predictionInput : inputs) {
+                List<Feature> features = predictionInput.getFeatures();
+                double result = 0;
+                for (int i = 0; i < features.size(); i++) {
+                        result += features.get(i).getValue().asNumber();
+                }
+                final boolean inside = (result >= center - epsilon && result <= center + epsilon);
+                PredictionOutput predictionOutput = new PredictionOutput(
+                        List.of(new Output("inside", Type.BOOLEAN, new Value<>(inside), 1d)));
+                predictionOutputs.add(predictionOutput);
+            }
+            return predictionOutputs;
+        });
+    }
+
     public static PredictionProvider getDummyTextClassifier() {
         List<String> blackList = Arrays.asList("money", "$", "£", "bitcoin");
         return inputs -> supplyAsync(() -> {

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualEntityFactoryTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualEntityFactoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.explainability.local.counterfactual.entities.*;
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureBoundary;
+import org.kie.kogito.explainability.model.FeatureFactory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CounterfactualEntityFactoryTest {
+
+    @Test
+    void testIntegerFactory() {
+        int value = 5;
+        final Feature feature = FeatureFactory.newNumericalFeature("int-feature", value);
+        final FeatureBoundary boundary = new FeatureBoundary(0.0, 10.0);
+        final CounterfactualEntity counterfactualEntity = CounterfactualEntityFactory.from(feature, false, boundary);
+        assertTrue(counterfactualEntity instanceof IntegerEntity);
+    }
+
+    @Test
+    void testDoubleFactory() {
+        double value = 5.0;
+        final Feature feature = FeatureFactory.newNumericalFeature("double-feature", value);
+        final FeatureBoundary boundary = new FeatureBoundary(0.0, 10.0);
+        final CounterfactualEntity counterfactualEntity = CounterfactualEntityFactory.from(feature, false, boundary);
+        assertTrue(counterfactualEntity instanceof DoubleEntity);
+    }
+
+    @Test
+    void testBooleanFactory() {
+        final Feature feature = FeatureFactory.newBooleanFeature("bool-feature", false);
+        final CounterfactualEntity counterfactualEntity = CounterfactualEntityFactory.from(feature, false, null);
+        assertTrue(counterfactualEntity instanceof BooleanEntity);
+    }
+
+}

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -25,11 +25,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class CounterfactualExplainerTest {
+
+    final long predictionTimeOut = 10L;
+    final TimeUnit predictionTimeUnit = TimeUnit.SECONDS;
 
     @Test
     void testNonEmptyInput() throws ExecutionException, InterruptedException, TimeoutException {
@@ -54,7 +58,7 @@ class CounterfactualExplainerTest {
             PredictionInput input = new PredictionInput(features);
             PredictionProvider model = TestUtils.getSumSkipModel(0);
             PredictionOutput output = model.predictAsync(List.of(input))
-                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit())
+                    .get(predictionTimeOut, predictionTimeUnit)
                     .get(0);
             Prediction prediction = new Prediction(input, output);
             List<CounterfactualEntity> counterfactualEntities = counterfactualExplainer.explainAsync(prediction, model)
@@ -102,7 +106,7 @@ class CounterfactualExplainerTest {
                     .get(0);
             Prediction prediction = new Prediction(input, output);
             List<CounterfactualEntity> counterfactualEntities = counterfactualExplainer.explainAsync(prediction, model)
-                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+                    .get(predictionTimeOut, predictionTimeUnit);
 
             double totalSum = 0;
             for (CounterfactualEntity entity : counterfactualEntities) {
@@ -144,7 +148,7 @@ class CounterfactualExplainerTest {
                     .get(0);
             Prediction prediction = new Prediction(input, output);
             List<CounterfactualEntity> counterfactualEntities = counterfactualExplainer.explainAsync(prediction, model)
-                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+                    .get(predictionTimeOut, predictionTimeUnit);
 
             double totalSum = 0;
             for (CounterfactualEntity entity : counterfactualEntities) {
@@ -190,7 +194,7 @@ class CounterfactualExplainerTest {
                     .get(0);
             Prediction prediction = new Prediction(input, output);
             List<CounterfactualEntity> counterfactualEntities = counterfactualExplainer.explainAsync(prediction, model)
-                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+                    .get(predictionTimeOut, predictionTimeUnit);
 
             double totalSum = 0;
             for (CounterfactualEntity entity : counterfactualEntities) {

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.local.counterfactual;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.explainability.Config;
+import org.kie.kogito.explainability.TestUtils;
+import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
+import org.kie.kogito.explainability.model.*;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CounterfactualExplainerTest {
+
+    @Test
+    void testNonEmptyInput() throws ExecutionException, InterruptedException, TimeoutException {
+        Random random = new Random();
+
+        final List<Output> goal = List.of(new Output("class", Type.BOOLEAN, new Value<>(false), 1d));
+        for (int seed = 0; seed < 5; seed++) {
+            random.setSeed(seed);
+
+
+            List<Feature> features = new LinkedList<>();
+            List<FeatureBoundary> featureBoundaries = new LinkedList<>();
+            List<Boolean> constraints = new LinkedList<>();
+            for (int i = 0; i < 4; i++) {
+                features.add(TestUtils.getMockedNumericFeature(i));
+                featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+                constraints.add(false);
+            }
+            final DataBoundaries dataBoundaries = new DataBoundaries(featureBoundaries);
+            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataBoundaries, constraints, goal, 1L, 70, 5000);
+
+            PredictionInput input = new PredictionInput(features);
+            PredictionProvider model = TestUtils.getSumSkipModel(0);
+            PredictionOutput output = model.predictAsync(List.of(input))
+                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit())
+                    .get(0);
+            Prediction prediction = new Prediction(input, output);
+            List<CounterfactualEntity> counterfactualEntities = counterfactualExplainer.explainAsync(prediction, model)
+                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+            for (CounterfactualEntity entity : counterfactualEntities) {
+                System.out.println(entity);
+            }
+            assertNotNull(counterfactualEntities);
+        }
+    }
+
+    @Test
+    void testCounterfactualMatch() throws ExecutionException, InterruptedException, TimeoutException {
+        Random random = new Random();
+        final List<Output> goal = List.of(new Output("inside", Type.BOOLEAN, new Value<>(true), 1d));
+        for (int seed = 0; seed < 5; seed++) {
+            random.setSeed(seed);
+
+
+            List<Feature> features = new LinkedList<>();
+            List<FeatureBoundary> featureBoundaries = new LinkedList<>();
+            List<Boolean> constraints = new LinkedList<>();
+            features.add(FeatureFactory.newNumericalFeature("f-num1", 100.0));
+            constraints.add(false);
+            featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+            features.add(FeatureFactory.newNumericalFeature("f-num2", 150.0));
+            constraints.add(false);
+            featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+            features.add(FeatureFactory.newNumericalFeature("f-num3", 1.0));
+            constraints.add(false);
+            featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+            features.add(FeatureFactory.newNumericalFeature("f-num4", 2.0));
+            constraints.add(false);
+            featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+
+            final DataBoundaries dataBoundaries = new DataBoundaries(featureBoundaries);
+            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataBoundaries, constraints, goal, 5L, 70, 5000);
+
+            final double center = 500.0;
+            final double epsilon = 10.0;
+            PredictionInput input = new PredictionInput(features);
+            PredictionProvider model = TestUtils.getSumThresholdModel(center, epsilon);
+            PredictionOutput output = model.predictAsync(List.of(input))
+                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit())
+                    .get(0);
+            Prediction prediction = new Prediction(input, output);
+            List<CounterfactualEntity> counterfactualEntities = counterfactualExplainer.explainAsync(prediction, model)
+                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+
+            double totalSum = 0;
+            for (CounterfactualEntity entity : counterfactualEntities) {
+                totalSum += entity.asFeature().getValue().asNumber();
+                System.out.println(entity);
+            }
+            assertTrue(totalSum <= center + epsilon);
+            assertTrue(totalSum >= center - epsilon);
+        }
+    }
+
+    @Test
+    void testCounterfactualConstrainedMatch() throws ExecutionException, InterruptedException, TimeoutException {
+        Random random = new Random();
+
+        final List<Output> goal = List.of(new Output("inside", Type.BOOLEAN, new Value<>(true), 1d));
+        for (int seed = 0; seed < 5; seed++) {
+            random.setSeed(seed);
+
+            List<Feature> features = new LinkedList<>();
+            List<FeatureBoundary> featureBoundaries = new LinkedList<>();
+            List<Boolean> constraints = new LinkedList<>();
+            for (int i = 0; i < 4; i++) {
+                features.add(TestUtils.getMockedNumericFeature(i));
+                featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+                constraints.add(false);
+            }
+            // add a constraint
+            constraints.set(2, true);
+            final DataBoundaries dataBoundaries = new DataBoundaries(featureBoundaries);
+            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataBoundaries, constraints, goal, 5L, 70, 5000);
+
+            final double center = 500.0;
+            final double epsilon = 10.0;
+            PredictionInput input = new PredictionInput(features);
+            PredictionProvider model = TestUtils.getSumThresholdModel(center, epsilon);
+            PredictionOutput output = model.predictAsync(List.of(input))
+                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit())
+                    .get(0);
+            Prediction prediction = new Prediction(input, output);
+            List<CounterfactualEntity> counterfactualEntities = counterfactualExplainer.explainAsync(prediction, model)
+                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+
+            double totalSum = 0;
+            for (CounterfactualEntity entity : counterfactualEntities) {
+                totalSum += entity.asFeature().getValue().asNumber();
+                System.out.println(entity);
+            }
+            assertFalse(counterfactualEntities.get(2).isChanged());
+            assertTrue(totalSum <= center + epsilon);
+            assertTrue(totalSum >= center - epsilon);
+        }
+    }
+
+    @Test
+    void testCounterfactualBoolean() throws ExecutionException, InterruptedException, TimeoutException {
+        Random random = new Random();
+
+        final List<Output> goal = List.of(new Output("inside", Type.BOOLEAN, new Value<>(true), 1d));
+        for (int seed = 0; seed < 5; seed++) {
+            random.setSeed(seed);
+
+            List<Feature> features = new LinkedList<>();
+            List<FeatureBoundary> featureBoundaries = new LinkedList<>();
+            List<Boolean> constraints = new LinkedList<>();
+            for (int i = 0; i < 4; i++) {
+                features.add(TestUtils.getMockedNumericFeature(i));
+                featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+                constraints.add(false);
+            }
+            features.add(FeatureFactory.newBooleanFeature("f-bool", true));
+            featureBoundaries.add(null);
+            constraints.add(false);
+            // add a constraint
+            constraints.set(2, true);
+            final DataBoundaries dataBoundaries = new DataBoundaries(featureBoundaries);
+            CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataBoundaries, constraints, goal, 5L, 70, 5000);
+
+            final double center = 500.0;
+            final double epsilon = 10.0;
+            PredictionInput input = new PredictionInput(features);
+            PredictionProvider model = TestUtils.getSumThresholdModel(center, epsilon);
+            PredictionOutput output = model.predictAsync(List.of(input))
+                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit())
+                    .get(0);
+            Prediction prediction = new Prediction(input, output);
+            List<CounterfactualEntity> counterfactualEntities = counterfactualExplainer.explainAsync(prediction, model)
+                    .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+
+            double totalSum = 0;
+            for (CounterfactualEntity entity : counterfactualEntities) {
+                totalSum += entity.asFeature().getValue().asNumber();
+                System.out.println(entity);
+            }
+            assertFalse(counterfactualEntities.get(2).isChanged());
+            assertTrue(totalSum <= center + epsilon);
+            assertTrue(totalSum >= center - epsilon);
+        }
+    }
+}

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -129,13 +129,22 @@ class CounterfactualExplainerTest {
             List<Feature> features = new LinkedList<>();
             List<FeatureBoundary> featureBoundaries = new LinkedList<>();
             List<Boolean> constraints = new LinkedList<>();
-            for (int i = 0; i < 4; i++) {
-                features.add(TestUtils.getMockedNumericFeature(i));
-                featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
-                constraints.add(false);
-            }
+            features.add(FeatureFactory.newNumericalFeature("f-num1", 100.0));
+            constraints.add(false);
+            featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+            features.add(FeatureFactory.newNumericalFeature("f-num2", 100.0));
+            constraints.add(false);
+            featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+            features.add(FeatureFactory.newNumericalFeature("f-num3", 100.0));
+            constraints.add(false);
+            featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+            features.add(FeatureFactory.newNumericalFeature("f-num4", 100.0));
+            constraints.add(false);
+            featureBoundaries.add(new FeatureBoundary(0.0, 1000.0));
+
             // add a constraint
-            constraints.set(2, true);
+            constraints.set(0, true);
+            constraints.set(3, true);
             final DataBoundaries dataBoundaries = new DataBoundaries(featureBoundaries);
             CounterfactualExplainer counterfactualExplainer = new CounterfactualExplainer(dataBoundaries, constraints, goal, 5L, 70, 5000);
 
@@ -155,7 +164,8 @@ class CounterfactualExplainerTest {
                 totalSum += entity.asFeature().getValue().asNumber();
                 System.out.println(entity);
             }
-            assertFalse(counterfactualEntities.get(2).isChanged());
+            assertFalse(counterfactualEntities.get(0).isChanged());
+            assertFalse(counterfactualEntities.get(3).isChanged());
             assertTrue(totalSum <= center + epsilon);
             assertTrue(totalSum >= center - epsilon);
         }


### PR DESCRIPTION
[FAI-254] Implement counterfactual search using OptaPlanner

Implementation of a counterfactual search using OptaPlanner as the engine.

Current limitations at the moment:

- Only numerical (integer, double) and boolean features supported
- No feature weighting (this relates to a broader discussion on how to provide domain metadata to local explanations)
- No trade-off tuning parameter (primary goal for OptaPlanner's solution is the desired outcome)

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket