### PR TITLE
KOGITO-3596 Bump to Quarkus 1.9

### DIFF
--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/TestUtils.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/TestUtils.java
@@ -71,16 +71,31 @@ public final class TestUtils {
     }
 
     public static String readFileContent(String file) throws IOException {
-        InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(file);
-        Objects.requireNonNull(inputStream, "Could not resolve file path: " + file);
-        BufferedInputStream bis = new BufferedInputStream(inputStream);
-        ByteArrayOutputStream buf = new ByteArrayOutputStream();
-        int result = bis.read();
-        while (result != -1) {
-            buf.write((byte) result);
-            result = bis.read();
+        InputStream inputStream = null;
+        BufferedInputStream bis = null;
+        ByteArrayOutputStream buf = null;
+        try {
+            inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(file);
+            Objects.requireNonNull(inputStream, "Could not resolve file path: " + file);
+            bis = new BufferedInputStream(inputStream);
+            buf = new ByteArrayOutputStream();
+            int result = bis.read();
+            while (result != -1) {
+                buf.write((byte) result);
+                result = bis.read();
+            }
+            return buf.toString(StandardCharsets.UTF_8.name());
+        } finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+            if (bis != null) {
+                bis.close();
+            }
+            if (buf != null) {
+                buf.close();
+            }
         }
-        return buf.toString(StandardCharsets.UTF_8.name());
     }
 
     public static KogitoProcessCloudEvent getProcessCloudEvent(String processId, String processInstanceId, ProcessInstanceState status, String rootProcessInstanceId, String rootProcessId, String parentProcessInstanceId) {

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/TestUtils.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/TestUtils.java
@@ -16,9 +16,13 @@
 
 package org.kie.kogito.index;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -27,6 +31,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -65,9 +70,17 @@ public final class TestUtils {
         return readFileContent("travels.proto");
     }
 
-    public static String readFileContent(String file) throws URISyntaxException, IOException {
-        Path path = Paths.get(Thread.currentThread().getContextClassLoader().getResource(file).toURI());
-        return new String(Files.readAllBytes(path));
+    public static String readFileContent(String file) throws IOException {
+        InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(file);
+        Objects.requireNonNull(inputStream, "Could not resolve file path: " + file);
+        BufferedInputStream bis = new BufferedInputStream(inputStream);
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        int result = bis.read();
+        while (result != -1) {
+            buf.write((byte) result);
+            result = bis.read();
+        }
+        return buf.toString(StandardCharsets.UTF_8.name());
     }
 
     public static KogitoProcessCloudEvent getProcessCloudEvent(String processId, String processInstanceId, ProcessInstanceState status, String rootProcessInstanceId, String rootProcessId, String parentProcessInstanceId) {

--- a/integration-tests/integration-tests-quarkus/pom.xml
+++ b/integration-tests/integration-tests-quarkus/pom.xml
@@ -26,6 +26,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>integration-tests-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
use alternative to read file, as apparently on CI
readAllBytes() with a classpath resource behaves
in a weird way (FileSystemNotFoundException)

related: 
- https://github.com/kiegroup/kogito-runtimes/pull/826
- https://github.com/kiegroup/kogito-examples/pull/396

-----

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket