### PR TITLE
KOGITO-3644 - increase top feature size to increase impact

### DIFF
--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/FraudScoringDmnLimeExplainerTest.java
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/FraudScoringDmnLimeExplainerTest.java
@@ -43,7 +43,6 @@ import org.kie.kogito.explainability.utils.ExplainabilityMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FraudScoringDmnLimeExplainerTest {
 

--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/FraudScoringDmnLimeExplainerTest.java
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/FraudScoringDmnLimeExplainerTest.java
@@ -83,7 +83,7 @@ class FraudScoringDmnLimeExplainerTest {
                 .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
         for (Saliency saliency : saliencyMap.values()) {
             assertNotNull(saliency);
-            List<FeatureImportance> topFeatures = saliency.getTopFeatures(3);
+            List<FeatureImportance> topFeatures = saliency.getTopFeatures(4);
             double topScore = Math.abs(topFeatures.stream().map(FeatureImportance::getScore).findFirst().orElse(0d));
             if (!topFeatures.isEmpty() && topScore > 0) {
                 double v = ExplainabilityMetrics.impactScore(model, prediction, topFeatures);

--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/FraudScoringDmnLimeExplainerTest.java
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/FraudScoringDmnLimeExplainerTest.java
@@ -77,7 +77,7 @@ class FraudScoringDmnLimeExplainerTest {
         List<PredictionOutput> predictionOutputs = model.predictAsync(List.of(predictionInput))
                 .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
         Prediction prediction = new Prediction(predictionInput, predictionOutputs.get(0));
-        LimeExplainer limeExplainer = new LimeExplainer(10, 3);
+        LimeExplainer limeExplainer = new LimeExplainer(100, 5);
         Map<String, Saliency> saliencyMap = limeExplainer.explainAsync(prediction, model)
                 .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
         for (Saliency saliency : saliencyMap.values()) {


### PR DESCRIPTION
In order to avoid random failures in `FraudScoringDmnLimeExplainerTest` top feature size as well as no. of generated samples and perturbations is increased (to increase impact score).

See https://issues.redhat.com/browse/KOGITO-3644

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket