### PR TITLE
KOGITO-3669 Node trigger should not be enabled for completed or aborted process instances

### DIFF
--- a/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
+++ b/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/ProcessDetailsPage.tsx
@@ -511,13 +511,17 @@ const ProcessDetailsPage: React.FC<RouteComponentProps<
                     </FlexItem>
                     {data.ProcessInstances[0].addons.includes(
                       'process-management'
-                    ) && (
-                      <FlexItem>
-                        <ProcessDetailsNodeTrigger
-                          processInstanceData={data.ProcessInstances[0]}
-                        />
-                      </FlexItem>
-                    )}
+                    ) &&
+                      data.ProcessInstances[0].state !==
+                        GraphQL.ProcessInstanceState.Completed &&
+                      data.ProcessInstances[0].state !==
+                        GraphQL.ProcessInstanceState.Aborted && (
+                        <FlexItem>
+                          <ProcessDetailsNodeTrigger
+                            processInstanceData={data.ProcessInstances[0]}
+                          />
+                        </FlexItem>
+                      )}
                   </Flex>
                   {errorModal()}
                   {RenderConfirmationModal()}

--- a/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/ProcessDetailsPage.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/ProcessDetailsPage.test.tsx
@@ -12,6 +12,7 @@ import axios from 'axios';
 jest.mock('axios');
 import * as Utils from '../../../../utils/Utils';
 import { act } from 'react-dom/test-utils';
+import _ from 'lodash';
 // tslint:disable: no-string-literal
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 jest.mock('../../../Atoms/ProcessListModal/ProcessListModal');
@@ -495,5 +496,55 @@ describe('Process Details Page component tests', () => {
     });
     window.location = location;
     expect(handleVariableUpdateSpy).toHaveBeenCalled();
+  });
+  it('test node tirgger presence', async () => {
+    // with active state- node trigger panel present
+    const wrapperWithNodeTrigger = await getWrapperAsync(
+      <MockedProvider mocks={mocks1} addTypename={false}>
+        <BrowserRouter>
+          <ProcessDetailsPage {...props} />
+        </BrowserRouter>
+      </MockedProvider>,
+      'ProcessDetailsPage'
+    );
+    expect(
+      wrapperWithNodeTrigger.find('MockedProcessDetailsNodeTrigger').exists()
+    ).toBeTruthy();
+
+    const mockWithCompletedState = _.cloneDeep(mocks1);
+    mockWithCompletedState[0].result.data.ProcessInstances[0].state =
+      GraphQL.ProcessInstanceState.Completed;
+    // with completed state - node trigger panel absent
+    const wrapperWithoutNodeTrigger1 = await getWrapperAsync(
+      <MockedProvider mocks={mockWithCompletedState} addTypename={false}>
+        <BrowserRouter>
+          <ProcessDetailsPage {...props} />
+        </BrowserRouter>
+      </MockedProvider>,
+      'ProcessDetailsPage'
+    );
+    expect(
+      wrapperWithoutNodeTrigger1
+        .find('MockedProcessDetailsNodeTrigger')
+        .exists()
+    ).toBeFalsy();
+
+    const mockWithAbortedState = _.cloneDeep(mocks1);
+    mockWithAbortedState[0].result.data.ProcessInstances[0].state =
+      GraphQL.ProcessInstanceState.Aborted;
+    // with Aborted state - node trigger panel absent
+    const wrapperWithoutNodeTrigger2 = await getWrapperAsync(
+      <MockedProvider mocks={mockWithAbortedState} addTypename={false}>
+        <BrowserRouter>
+          <ProcessDetailsPage {...props} />
+        </BrowserRouter>
+      </MockedProvider>,
+      'ProcessDetailsPage'
+    );
+    expect(
+      wrapperWithoutNodeTrigger2
+        .find('MockedProcessDetailsNodeTrigger')
+        .exists()
+    ).toBeFalsy();
   });
 });

--- a/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/ProcessDetailsPage.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Templates/ProcessDetailsPage/tests/ProcessDetailsPage.test.tsx
@@ -497,7 +497,7 @@ describe('Process Details Page component tests', () => {
     window.location = location;
     expect(handleVariableUpdateSpy).toHaveBeenCalled();
   });
-  it('test node tirgger presence', async () => {
+  it('test node trigger presence', async () => {
     // with active state- node trigger panel present
     const wrapperWithNodeTrigger = await getWrapperAsync(
       <MockedProvider mocks={mocks1} addTypename={false}>


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

description: added a condition to hide NodeTrigger panel(hide for completed and aborted)

JIRA: https://issues.redhat.com/browse/KOGITO-3669

