### PR TITLE
KOGITO-3252: REST endpoint that returns the process SVG

### DIFF
--- a/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/vertx/VertxRouterSetup.java
+++ b/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/vertx/VertxRouterSetup.java
@@ -51,6 +51,10 @@ public class VertxRouterSetup {
     String graphUIPath;
 
     @Inject
+    @ConfigProperty(name = "kogito.data-index.vertx-diagram.folder.path", defaultValue = "META-INF/processSVG")
+    String staticResourceRootPath;
+
+    @Inject
     GraphQL graphQL;
 
     void setupRouter(@Observes Router router) {
@@ -60,6 +64,12 @@ public class VertxRouterSetup {
         }
         router.route(graphUIPath + "/*").handler(graphiQLHandler);
         router.route().handler(LoggerHandler.create());
+
+        StaticHandler diagramHandler = StaticHandler.create();
+        diagramHandler.setAllowRootFileSystemAccess(true);
+        diagramHandler.setWebRoot(staticResourceRootPath);
+        router.route("/diagram/*").handler(diagramHandler);
+
         router.route().handler(StaticHandler.create());
         router.route().handler(FaviconHandler.create());
         router.route("/").handler(ctx -> ctx.response().putHeader("location", graphUIPath + "/").setStatusCode(302).end());

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/vertx/VertxRouterSetupTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/vertx/VertxRouterSetupTest.java
@@ -74,6 +74,7 @@ public class VertxRouterSetupTest {
     public void setup() {
         lenient().when(routerMock.route()).thenReturn(routeMock);
         lenient().when(routerMock.route(anyString())).thenReturn(routeMock);
+        vertxRouterSetup.staticResourceRootPath="/WEB-INF/processSVG";
     }
 
     @Test


### PR DESCRIPTION
Jira related: https://issues.redhat.com/browse/KOGITO-3252
Added a new endpoint that serves the process svg at /diagram/.
