### PR TITLE
KOGITO-3734: Resolve the port in integration tests in start method

### DIFF
--- a/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/it/KogitoServiceRandomPortTestResource.java
+++ b/integration-tests/integration-tests-common/src/main/java/org/kie/kogito/it/KogitoServiceRandomPortTestResource.java
@@ -32,23 +32,13 @@ public class KogitoServiceRandomPortTestResource implements TestResource {
         return NAME;
     }
 
-    public KogitoServiceRandomPortTestResource() {
-        initialize();
-    }
-
-    //The port should be set and Testcontainers.exposeHostPorts should be called before the this.start() method, in
-    // this way the container is able to resolve hostname for the host (running the test) otherwise it won't work.
-    private void initialize() {
+    @Override
+    public void start() {
         httpPort = SocketUtils.findAvailablePort();
         Testcontainers.exposeHostPorts(httpPort);
         //the hostname for the container to access the host is "host.testcontainers.internal"
         //https://www.testcontainers.org/features/networking/#exposing-host-ports-to-the-container
         System.setProperty(KOGITO_SERVICE_URL, "http://host.testcontainers.internal:" + httpPort);
-    }
-
-    @Override
-    public void start() {
-
     }
 
     @Override

--- a/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/resources/KogitoServiceRandomPortQuarkusTestResource.java
+++ b/integration-tests/integration-tests-quarkus/src/test/java/org/kie/kogito/resources/KogitoServiceRandomPortQuarkusTestResource.java
@@ -25,6 +25,14 @@ public class KogitoServiceRandomPortQuarkusTestResource extends ConditionalQuark
         super(new KogitoServiceRandomPortTestResource());
     }
 
+    /**
+     * The Kogito Service must be run first to make the port available in the rest of services.
+     */
+    @Override
+    public int order() {
+        return -1;
+    }
+
     @Override
     protected String getKogitoProperty() {
         return QUARKUS_SERVICE_HTTP_PORT;


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-3734
Description: Resolve the kogito service port in the start method.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket