### PR TITLE
[1.0.x] KOGITO-3868 TestContainer dependency in BOM causes issues in quarkus-platform

### DIFF
--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/pom.xml
@@ -23,6 +23,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-common/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-common/pom.xml
@@ -28,11 +28,13 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
+      <version>${version.testcontainers}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Our BOM is published to platform and therefore end-users get our version of test containers. It would be better to NOT publish our test container dependency. 

Final solution: test bom
Workaround: use version property explicitly

related https://github.com/kiegroup/kogito-runtimes/pull/889