### PR TITLE
KOGITO-3882 security-commons does not install security-commons-${version}.jar

### DIFF
--- a/security-commons/pom.xml
+++ b/security-commons/pom.xml
@@ -77,9 +77,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION

cherry pick from https://github.com/kiegroup/kogito-apps/pull/540

original text:

> https://issues.redhat.com/browse/KOGITO-3882
>
> uberJar = true causes the jar to be renamed to jar.original and security-commons-${version}.jar is no longer installed which may cause a cascade of failures because then security-commons-${version}.jar is not found anywhere
>
>We never saw the issue occur because we were erroneously fetching security-commons-${version}.jar from our nexus
>
> this is a hotfix, because I am not 100% sure having tests running this way is good for a shared library. We should probably move these tests to integration-tests


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket