### PR TITLE
KOGITO-3890 No primary artifact to install when using Quarkus 1.10.0.Final + uberJar

### DIFF
--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/pom.xml
@@ -68,6 +68,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>

--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/pom.xml
@@ -64,6 +64,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>

--- a/data-index/data-index-service/data-index-service-infinispan/pom.xml
+++ b/data-index/data-index-service/data-index-service-infinispan/pom.xml
@@ -69,6 +69,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+      
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>

--- a/data-index/data-index-service/data-index-service-mongodb/pom.xml
+++ b/data-index/data-index-service/data-index-service-mongodb/pom.xml
@@ -63,6 +63,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>

--- a/explainability/explainability-service-messaging/pom.xml
+++ b/explainability/explainability-service-messaging/pom.xml
@@ -81,6 +81,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>

--- a/explainability/explainability-service-rest/pom.xml
+++ b/explainability/explainability-service-rest/pom.xml
@@ -84,6 +84,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>

--- a/jobs-service/pom.xml
+++ b/jobs-service/pom.xml
@@ -154,6 +154,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${version.io.quarkus}</version>

--- a/management-console/pom.xml
+++ b/management-console/pom.xml
@@ -66,6 +66,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>

--- a/task-console/pom.xml
+++ b/task-console/pom.xml
@@ -66,6 +66,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>

--- a/trusty-ui/pom.xml
+++ b/trusty-ui/pom.xml
@@ -58,6 +58,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>

--- a/trusty/trusty-service/pom.xml
+++ b/trusty/trusty-service/pom.xml
@@ -107,6 +107,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.1</version>
+        <executions>
+            <execution>
+                <id>set-main-artifact</id>
+                <phase>verify</phase>
+                <goals>
+                    <goal>execute</goal>
+                </goals>
+                <configuration>
+                    <source>
+                        project.artifact.setFile(new File(project.build.directory, project.build.finalName + ".jar.original"))
+                    </source>
+                </configuration>
+            </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3890

as reported by @radtriste 

There is a problem on Nexus which is checking artifacts before closing the repository.
This is the error message (https://repository.jboss.org/nexus/#stagingRepositories in Activity tab of the opened repo)

```
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/jobs-service/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/explainability-service-messaging/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/trusty-ui/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/integration-tests-jobs-service-quarkus/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/explainability-service-rest/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/trusty-service/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/integration-tests-trusty-service-quarkus/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/task-console/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/data-index-service-mongodb/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/management-console/1.0.0.Final'
failureMessage  Missing: no main jar artifact found in folder '/org/kie/kogito/data-index-service-infinispan/1.0.0.Final'
```

So, this is apparently due to a change from Quarkus 1.10.0.CR1 introduced in Quarkus 1.10.0.Final – it does not install the main artifact anymore when the project is configured as a uberJar. The original main artifact is present but renamed to '*.jar.original'. This did not occur in CR1.

In fact, this info message is printed in all instances where an uberJar is used in kogito-apps:

```
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ jobs-service ---
[INFO] No primary artifact to install, installing attached artifacts instead.
[INFO] Installing /home/evacchi/Devel/redhat/pr/submarine/kogito-apps/jobs-service/pom.xml to /home/evacchi/.m2/repository/org/kie/kogito/jobs-service/1.0.0-SNAPSHOT/jobs-service-1.0.0-SNAPSHOT.pom
[INFO] Installing /home/evacchi/Devel/redhat/pr/submarine/kogito-apps/jobs-service/target/jobs-service-1.0.0-SNAPSHOT-runner.jar to /home/evacchi/.m2/repository/org/kie/kogito/jobs-service/1.0.0-SNAPSHOT/jobs-service-1.0.0-SNAPSHOT-runner.jar
[INFO] Installing /home/evacchi/Devel/redhat/pr/submarine/kogito-apps/jobs-service/target/jobs-service-1.0.0-SNAPSHOT-tests.jar to /home/evacchi/.m2/repository/org/kie/kogito/jobs-service/1.0.0-SNAPSHOT/jobs-service-1.0.0-SNAPSHOT-tests.jar
[INFO] Installing /home/evacchi/Devel/redhat/pr/submarine/kogito-apps/jobs-service/target/jobs-service-1.0.0-SNAPSHOT-sources.jar to /home/evacchi/.m2/repository/org/kie/kogito/jobs-service/1.0.0-SNAPSHOT/jobs-service-1.0.0-SNAPSHOT-sources.jar
[INFO] Installing /home/evacchi/Devel/redhat/pr/submarine/kogito-apps/jobs-service/target/jobs-service-1.0.0-SNAPSHOT-test-sources.jar to /home/evacchi/.m2/repository/org/kie/kogito/jobs-service/1.0.0-SNAPSHOT/jobs-service-1.0.0-SNAPSHOT-test-sources.jar
```

workaround: force install the '.jar.original' file through an extra Maven plugin. In this PR I am using the Groovy Maven plug-in.

-----


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket