### PR TITLE
KOGITO-3907: Jobs management bug fixes

### DIFF
--- a/ui-packages/packages/management-console/src/components/Organisms/JobsManagementFilters/JobsManagementFilters.tsx
+++ b/ui-packages/packages/management-console/src/components/Organisms/JobsManagementFilters/JobsManagementFilters.tsx
@@ -52,7 +52,7 @@ const JobsManagementFilters: React.FC<IOwnProps & OUIAProps> = ({
 
   const onSelect = (event, selection: GraphQL.JobStatus): void => {
     let selectionText = event.target.id;
-    selectionText = selectionText.split('pf-random-id-2-')[1];
+    selectionText = selectionText.split('pf-random-id-')[1].split('-')[1];
     if (selectedStatus.includes(selectionText)) {
       setSelectedStatus(prev => prev.filter(item => item !== selectionText));
     } else {

--- a/ui-packages/packages/management-console/src/components/Organisms/JobsManagementFilters/__mocks__/JobsManagementFilters.tsx
+++ b/ui-packages/packages/management-console/src/components/Organisms/JobsManagementFilters/__mocks__/JobsManagementFilters.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-const JobsManagementFilters = () => {
+const JobsManagementFilters = ({ setChips }) => {
+  React.useEffect(() => {
+    setChips([]);
+  }, []);
   return <></>;
 };
 

--- a/ui-packages/packages/management-console/src/components/Organisms/JobsManagementFilters/tests/JobsManagementFilters.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Organisms/JobsManagementFilters/tests/JobsManagementFilters.test.tsx
@@ -127,7 +127,7 @@ describe('Jobs management filters component tests', () => {
       wrapper.find('JobsManagementFilters').props()['selectedStatus'].length
     ).toEqual(0);
   });
-  it('test select component props', async () => {
+  it('test select component props with selection', async () => {
     let wrapper = mount(<TestWrapper />);
     const event2: any = { target: { id: 'pf-random-id-2-EXECUTED' } };
     await act(async () => {
@@ -141,5 +141,23 @@ describe('Jobs management filters component tests', () => {
     expect(
       wrapper.find('JobsManagementFilters').props()['selectedStatus'].length
     ).toEqual(2);
+    expect(
+      wrapper.find('JobsManagementFilters').props()['selectedStatus']
+    ).toContain('EXECUTED');
+  });
+  it('test select component props with De-selection', async () => {
+    let wrapper = mount(<TestWrapper />);
+    const event2: any = { target: { id: 'pf-random-id-2-SCHEDULED' } };
+    await act(async () => {
+      wrapper
+        .find('#status-select')
+        .first()
+        .props()
+        ['onSelect'](event2);
+    });
+    wrapper = wrapper.update();
+    expect(
+      wrapper.find('JobsManagementFilters').props()['selectedStatus'].length
+    ).toEqual(0);
   });
 });

--- a/ui-packages/packages/management-console/src/components/Organisms/JobsManagementTable/tests/JobsManagementTable.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Organisms/JobsManagementTable/tests/JobsManagementTable.test.tsx
@@ -103,10 +103,12 @@ describe('Jobs management table component tests', () => {
     );
     expect(wrapper).toMatchSnapshot();
     const event: any = {};
-    wrapper
-      .find('Table')
-      .props()
-      ['onSelect'](event);
+    await act(async () => {
+      wrapper
+        .find('Table')
+        .props()
+        ['onSelect'](event);
+    });
   });
 
   it('test job details action', async () => {

--- a/ui-packages/packages/management-console/src/components/Templates/JobsManagementPage/JobsManagementPage.tsx
+++ b/ui-packages/packages/management-console/src/components/Templates/JobsManagementPage/JobsManagementPage.tsx
@@ -93,12 +93,6 @@ const JobsManagementPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
   );
   const [chips, setChips] = useState<GraphQL.JobStatus[]>(defaultStatus);
   const [values, setValues] = useState<GraphQL.JobStatus[]>(defaultStatus);
-
-  const { loading, data, error, refetch } = GraphQL.useGetAllJobsQuery({
-    fetchPolicy: 'network-only',
-    notifyOnNetworkStatusChange: true,
-    variables: { values }
-  });
   const [isKebabOpen, setIsKebabOpen] = useState<boolean>(false);
   const [selectedJobInstances, setSelectedJobInstances] = useState<
     GraphQL.Job[]
@@ -112,6 +106,13 @@ const JobsManagementPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
       ignoredJobs: {}
     }
   });
+
+  const { loading, data, error, refetch } = GraphQL.useGetAllJobsQuery({
+    fetchPolicy: 'network-only',
+    notifyOnNetworkStatusChange: true,
+    variables: { values }
+  });
+
   const jobOperations: IOperations = {
     CANCEL: {
       results: jobOperationResults[JobOperationType.CANCEL],
@@ -212,7 +213,7 @@ const JobsManagementPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
     setValues(defaultStatus);
   };
 
-  const dropdownItemsJobsManagementButtons = () => {
+  const dropdownItemsJobsManagementButtons = (): JSX.Element[] => {
     return [
       <DropdownItem
         key="cancel"
@@ -224,7 +225,7 @@ const JobsManagementPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
     ];
   };
 
-  const jobManagementButtons = (
+  const jobManagementButtons: JSX.Element = (
     <OverflowMenu breakpoint="xl">
       <OverflowMenuContent>
         <OverflowMenuItem>
@@ -291,7 +292,7 @@ const JobsManagementPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
   };
 
   if (data) {
-    if (!loading && selectedStatus.length > 0 && data.Jobs.length === 0) {
+    if (!loading && values.length > 0 && data.Jobs.length === 0) {
       return (
         <Redirect
           to={{
@@ -344,7 +345,7 @@ const JobsManagementPage: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
                       setSelectedJobInstances={setSelectedJobInstances}
                     />
                   </refetchContext.Provider>
-                  {selectedStatus.length === 0 && (
+                  {chips.length === 0 && (
                     <KogitoEmptyState
                       type={KogitoEmptyStateType.Reset}
                       title="No filter applied."

--- a/ui-packages/packages/management-console/src/components/Templates/JobsManagementPage/tests/JobsManagementPage.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Templates/JobsManagementPage/tests/JobsManagementPage.test.tsx
@@ -13,10 +13,17 @@ jest.mock('../../../Atoms/JobsCancelModal/JobsCancelModal');
 const MockedServerErrors = (): React.ReactElement => {
   return <></>;
 };
+
+const MockedKogitoEmptyState = (): React.ReactElement => {
+  return <></>;
+};
 jest.mock('@kogito-apps/common', () => ({
   ...jest.requireActual('@kogito-apps/common'),
   ServerErrors: () => {
     return <MockedServerErrors />;
+  },
+  KogitoEmptyState: () => {
+    return <MockedKogitoEmptyState />;
   }
 }));
 
@@ -265,5 +272,30 @@ describe('Jobs management page tests', () => {
         .children()
         .contains('Cancel selected')
     ).toBeTruthy();
+  });
+  it('test click handler on empty state', async () => {
+    let wrapper = await getWrapperAsync(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <BrowserRouter>
+          <JobsManagementPage />
+        </BrowserRouter>
+      </MockedProvider>,
+      'JobsManagementPage'
+    );
+    const event: any = {};
+    await act(async () => {
+      wrapper
+        .find('KogitoEmptyState')
+        .props()
+        ['onClick'](event);
+    });
+    wrapper = wrapper.update();
+    const defaultChip: string[] = ['SCHEDULED'];
+    expect(wrapper.find('JobsManagementFilters').props()['chips']).toEqual(
+      defaultChip
+    );
+    expect(
+      wrapper.find('JobsManagementFilters').props()['selectedStatus']
+    ).toEqual(defaultChip);
   });
 });

--- a/ui-packages/packages/management-console/src/components/Templates/JobsManagementPage/tests/__snapshots__/JobsManagementPage.test.tsx.snap
+++ b/ui-packages/packages/management-console/src/components/Templates/JobsManagementPage/tests/__snapshots__/JobsManagementPage.test.tsx.snap
@@ -115,11 +115,7 @@ exports[`Jobs management page tests snapshot test with mock data 1`] = `
                   className="pf-c-toolbar__content-section"
                 >
                   <JobsManagementFilters
-                    chips={
-                      Array [
-                        "SCHEDULED",
-                      ]
-                    }
+                    chips={Array []}
                     selectedStatus={
                       Array [
                         "SCHEDULED",
@@ -253,7 +249,7 @@ exports[`Jobs management page tests snapshot test with mock data 1`] = `
                                   >
                                     <div
                                       className="pf-c-dropdown"
-                                      data-ouia-component-id={5}
+                                      data-ouia-component-id={6}
                                       data-ouia-component-type="PF4/Dropdown"
                                       data-ouia-safe={true}
                                     >
@@ -270,7 +266,7 @@ exports[`Jobs management page tests snapshot test with mock data 1`] = `
                                           Object {
                                             "current": <div
                                               class="pf-c-dropdown"
-                                              data-ouia-component-id="5"
+                                              data-ouia-component-id="6"
                                               data-ouia-component-type="PF4/Dropdown"
                                               data-ouia-safe="true"
                                             >
@@ -320,7 +316,7 @@ exports[`Jobs management page tests snapshot test with mock data 1`] = `
                                             Object {
                                               "current": <div
                                                 class="pf-c-dropdown"
-                                                data-ouia-component-id="5"
+                                                data-ouia-component-id="6"
                                                 data-ouia-component-type="PF4/Dropdown"
                                                 data-ouia-safe="true"
                                               >
@@ -414,7 +410,7 @@ exports[`Jobs management page tests snapshot test with mock data 1`] = `
                     Object {
                       "current": <div
                         class="pf-c-toolbar__expandable-content"
-                        id="data-toolbar-with-chip-groups-expandable-content-2"
+                        id="data-toolbar-with-chip-groups-expandable-content-3"
                       >
                         <div
                           class="pf-c-toolbar__group"
@@ -422,13 +418,13 @@ exports[`Jobs management page tests snapshot test with mock data 1`] = `
                       </div>,
                     }
                   }
-                  id="data-toolbar-with-chip-groups-expandable-content-2"
+                  id="data-toolbar-with-chip-groups-expandable-content-3"
                   isExpanded={false}
                   showClearFiltersButton={false}
                 >
                   <div
                     className="pf-c-toolbar__expandable-content"
-                    id="data-toolbar-with-chip-groups-expandable-content-2"
+                    id="data-toolbar-with-chip-groups-expandable-content-3"
                   >
                     <ForwardRef>
                       <ToolbarGroupWithRef
@@ -486,7 +482,7 @@ exports[`Jobs management page tests snapshot test with mock data 1`] = `
         <Card>
           <article
             className="pf-c-card"
-            data-ouia-component-id={6}
+            data-ouia-component-id={7}
             data-ouia-component-type="PF4/Card"
             data-ouia-safe={true}
           >
@@ -558,6 +554,14 @@ exports[`Jobs management page tests snapshot test with mock data 1`] = `
                   setSelectedJob={[Function]}
                   setSelectedJobInstances={[Function]}
                 />
+                <KogitoEmptyState
+                  body="Try applying at least one filter to see results"
+                  onClick={[Function]}
+                  title="No filter applied."
+                  type={2}
+                >
+                  <MockedKogitoEmptyState />
+                </KogitoEmptyState>
               </div>
             </CardBody>
           </article>


### PR DESCRIPTION
Hello,

please review this PR intended to fix below bugs.

Bug fixes on Jobs Management - Empty state and filter selections. 

1) Empty state was displayed along with table

2) filter selections was not happening when returning from process instance page