### PR TITLE
KOGITO-4077: Update consoles templates to use Qute

### DIFF
--- a/management-console/pom.xml
+++ b/management-console/pom.xml
@@ -53,6 +53,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-qute</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
@@ -107,6 +111,9 @@
               <resources>
                 <resource>
                   <directory>${path.to.frontend.app}/dist</directory>
+                  <excludes>
+                    <exclude>index.html</exclude>
+                  </excludes>
                   <filtering>false</filtering>
                 </resource>
               </resources>

--- a/management-console/src/main/java/org/kie/kogito/mgmt/VertxRouter.java
+++ b/management-console/src/main/java/org/kie/kogito/mgmt/VertxRouter.java
@@ -19,49 +19,29 @@ package org.kie.kogito.mgmt;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
-import javax.inject.Inject;
 
-import io.vertx.core.Vertx;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.api.ResourcePath;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.StaticHandler;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 @ApplicationScoped
 public class VertxRouter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VertxRouter.class);
 
-    @Inject
-    @ConfigProperty(name = "kogito.dataindex.http.url", defaultValue = "http://localhost:8180")
-    String dataIndexHttpURL;
+    @ResourcePath("index")
+    Template indexTemplate;
 
-    @Inject
-    @ConfigProperty(name = "quarkus.oidc.tenant-enabled", defaultValue = "false")
-    String authEnabled;
-
-    @Inject
-    @ConfigProperty(name = "kogito.test.user-system.enabled", defaultValue = "false")
-    String testUserSystemEnabled;
-
-    @Inject
-    Vertx vertx;
-
-    private String resource;
+    private String index;
 
     @PostConstruct
     public void init() {
-        resource = vertx.fileSystem()
-                .readFileBlocking("META-INF/resources/index.html")
-                .toString(UTF_8)
-                .replace("__DATA_INDEX_ENDPOINT__", "\"" + dataIndexHttpURL + "/graphql\"")
-                .replace("__KOGITO_AUTH_ENABLED__", authEnabled)
-                .replace("__KOGITO_TEST_USER_SYSTEM_ENABLED__", testUserSystemEnabled);
+        index = indexTemplate.render();
     }
 
     void setupRouter(@Observes Router router) {
@@ -76,7 +56,7 @@ public class VertxRouter {
             context.response()
                     .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache")
                     .putHeader(HttpHeaders.CONTENT_TYPE, "text/html;charset=utf8")
-                    .end(resource);
+                    .end(index);
         } catch (Exception ex) {
             LOGGER.error("Error handling index.html", ex);
             context.fail(500, ex);

--- a/management-console/src/main/resources/templates/index.html
+++ b/management-console/src/main/resources/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>Kogito - Management Console</title>
+    <meta id="appName" name="application-name" content="Patternfly Seed" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" type="image/ico" />
+  </head>
+  <script>
+    window.DATA_INDEX_ENDPOINT = '{config:property('kogito.dataindex.http.url') or 'http://localhost:8180'}/graphql';
+    window.KOGITO_AUTH_ENABLED = {config:property('quarkus.oidc.tenant-enabled') or false};
+    window.TEST_USER_SYSTEM_ENABLED = {config:property('kogito.test.user-system.enabled') or false};
+  </script>
+  <body class="pf-m-redhat-font">
+    <noscript>Enabling JavaScript is required to run this app.</noscript>
+    <div id="root" style="height: 100%;"></div>
+    <script type="text/javascript" src="/app.bundle.js"></script>
+  </body>
+</html>

--- a/management-console/src/test/java/org/kie/kogito/StaticContentTest.java
+++ b/management-console/src/test/java/org/kie/kogito/StaticContentTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 public class StaticContentTest {
 
-    @TestHTTPResource("index.html")
+    @TestHTTPResource
     URL url;
 
     private static String readStream(InputStream in) throws IOException {

--- a/task-console/pom.xml
+++ b/task-console/pom.xml
@@ -49,6 +49,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-qute</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
@@ -103,6 +107,9 @@
               <resources>
                 <resource>
                   <directory>${path.to.frontend.app}/dist</directory>
+                  <excludes>
+                    <exclude>index.html</exclude>
+                  </excludes>
                   <filtering>false</filtering>
                 </resource>
               </resources>

--- a/task-console/src/main/java/org/kie/kogito/task/console/VertxRouter.java
+++ b/task-console/src/main/java/org/kie/kogito/task/console/VertxRouter.java
@@ -19,59 +19,30 @@ package org.kie.kogito.task.console;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
-import javax.inject.Inject;
 
-import io.vertx.core.Vertx;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.api.ResourcePath;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.StaticHandler;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 @ApplicationScoped
 public class VertxRouter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VertxRouter.class);
 
-    @Inject
-    @ConfigProperty(name = "kogito.dataindex.http.url", defaultValue = "http://localhost:8180")
-    String dataIndexHttpURL;
+    @ResourcePath("index")
+    Template indexTemplate;
 
-    @Inject
-    @ConfigProperty(name = "quarkus.oidc.tenant-enabled", defaultValue = "false")
-    String authEnabled;
-
-    @Inject
-    @ConfigProperty(name = "kogito.task.active.states.list", defaultValue = "Ready,Reserved")
-    String activeTaskStates;
-
-    @Inject
-    @ConfigProperty(name = "kogito.task.states.list", defaultValue = "Ready,Reserved,Completed,Aborted,Skipped")
-    String allTaskStates;
-
-    @ConfigProperty(name = "kogito.test.user-system.enabled", defaultValue = "false")
-    String testUserSystemEnabled;
-
-
-    @Inject
-    Vertx vertx;
-
-    private String resource;
+    private String index;
 
     @PostConstruct
     public void init() {
-        resource = vertx.fileSystem()
-                .readFileBlocking("META-INF/resources/index.html")
-                .toString(UTF_8)
-                .replace("__DATA_INDEX_ENDPOINT__", "\"" + dataIndexHttpURL + "/graphql\"")
-                .replace("__KOGITO_AUTH_ENABLED__", authEnabled)
-                .replace("__KOGITO_TASK_ACTIVE_STATES_LIST__", "\"" + activeTaskStates + "\"")
-                .replace("__KOGITO_TASK_STATES_LIST__", "\"" + allTaskStates + "\"")
-                .replace("__KOGITO_TEST_USER_SYSTEM_ENABLED__", testUserSystemEnabled);
+        index = indexTemplate.render();
     }
 
     void setupRouter(@Observes Router router) {
@@ -86,7 +57,7 @@ public class VertxRouter {
             context.response()
                     .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache")
                     .putHeader(HttpHeaders.CONTENT_TYPE, "text/html;charset=utf8")
-                    .end(resource);
+                    .end(index);
         } catch (Exception ex) {
             LOGGER.error("Error handling index.html", ex);
             context.fail(500, ex);

--- a/task-console/src/main/resources/templates/index.html
+++ b/task-console/src/main/resources/templates/index.html
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <title>Kogito - Task Console</title>
+    <meta id="appName" name="application-name" content="Patternfly Seed" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" type="image/ico" />
+  </head>
+  <script>
+    window.DATA_INDEX_ENDPOINT = '{config:property('kogito.dataindex.http.url') or 'http://localhost:8180'}/graphql';
+    window.KOGITO_AUTH_ENABLED = {config:property('quarkus.oidc.tenant-enabled') or false};
+    window.KOGITO_TASK_STATES_LIST = '{config:property('kogito.task.states.list') or 'Ready,Reserved,Completed,Aborted,Skipped'}';
+    window.KOGITO_TASK_ACTIVE_STATES_LIST = '{config:property('kogito.task.active.states.list') or 'Ready,Reserved'}';
+    window.TEST_USER_SYSTEM_ENABLED = {config:property('kogito.test.user-system.enabled') or false};
+  </script>
+  <body class="pf-m-redhat-font">
+    <noscript>Enabling JavaScript is required to run this app.</noscript>
+    <div id="root" style="height: 100%;"></div>
+    <script type="text/javascript" src="/app.bundle.js"></script>
+  </body>
+</html>

--- a/task-console/src/test/java/org/kie/kogito/task/console/StaticContentTest.java
+++ b/task-console/src/test/java/org/kie/kogito/task/console/StaticContentTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @QuarkusTest
 class StaticContentTest {
 
-    @TestHTTPResource("index.html")
+    @TestHTTPResource
     URL url;
 
     private static String readStream(InputStream in) throws IOException {

--- a/ui-packages/packages/management-console/src/index.html
+++ b/ui-packages/packages/management-console/src/index.html
@@ -7,11 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="~/favicon.ico" type="image/ico" />
   </head>
-  <script>
-    window.DATA_INDEX_ENDPOINT = __DATA_INDEX_ENDPOINT__;
-    window.KOGITO_AUTH_ENABLED = __KOGITO_AUTH_ENABLED__;
-    window.TEST_USER_SYSTEM_ENABLED = __KOGITO_TEST_USER_SYSTEM_ENABLED__;
-  </script>
   <body class="pf-m-redhat-font">
     <noscript>Enabling JavaScript is required to run this app.</noscript>
     <div id="root" style="height: 100%;"></div>

--- a/ui-packages/packages/task-console/src/index.html
+++ b/ui-packages/packages/task-console/src/index.html
@@ -7,13 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="~/favicon.ico" type="image/ico" />
   </head>
-  <script>
-    window.DATA_INDEX_ENDPOINT = __DATA_INDEX_ENDPOINT__;
-    window.KOGITO_AUTH_ENABLED = __KOGITO_AUTH_ENABLED__;
-    window.TEST_USER_SYSTEM_ENABLED = __KOGITO_TEST_USER_SYSTEM_ENABLED__;
-    window.KOGITO_TASK_STATES_LIST = __KOGITO_TASK_STATES_LIST__;
-    window.KOGITO_TASK_ACTIVE_STATES_LIST = __KOGITO_TASK_ACTIVE_STATES_LIST__;
-  </script>
   <body class="pf-m-redhat-font">
     <noscript>Enabling JavaScript is required to run this app.</noscript>
     <div id="root" style="height: 100%;"></div>


### PR DESCRIPTION
Guys, just played a little with Qute to make the consoles use it to generate the HTML, the issue I found is that it needs to have the index.html in the resources folder, so I couldn't take the one from the ui module. Let's see how you see that.

It should be merge after:
https://github.com/kiegroup/kogito-apps/pull/546

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket