### PR TITLE
KOGITO-4253 force-pin jib-core version for Quarkus 1.11.2/1.12 alignment

### DIFF
--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/pom.xml
@@ -64,6 +64,12 @@
       <artifactId>integration-tests-trusty-service-common</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>commons-logging-jboss-logging</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/pom.xml
@@ -48,6 +48,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools</groupId>
+      <artifactId>jib-core</artifactId>
+      <version>${version.apps.jib-core}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/explainability/explainability-service-messaging/pom.xml
+++ b/explainability/explainability-service-messaging/pom.xml
@@ -59,6 +59,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools</groupId>
+      <artifactId>jib-core</artifactId>
+      <version>${version.apps.jib-core}</version>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/jobs-service/pom.xml
+++ b/jobs-service/pom.xml
@@ -63,6 +63,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools</groupId>
+      <artifactId>jib-core</artifactId>
+      <version>${version.apps.jib-core}</version>
+    </dependency>
 
     <!-- Messaging Streams -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
   <description>Kogito Apps</description>
 
   <properties>
+    <version.apps.jib-core>0.17.0</version.apps.jib-core>
     <version.frontend.plugin>1.9.1</version.frontend.plugin>
     <version.node>v12.16.2</version.node>
     <version.npm>6.10.3</version.npm>

--- a/trusty/trusty-service/pom.xml
+++ b/trusty/trusty-service/pom.xml
@@ -71,6 +71,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.tools</groupId>
+      <artifactId>jib-core</artifactId>
+      <version>${version.apps.jib-core}</version>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4253

~~https://github.com/kiegroup/kogito-runtimes/pull/1001
this is required for jackson bump -- will be removed when we upgrade to a stable Quarkus release -- which will include this change~~ not necessary

---

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket