### PR TITLE
KOGITO-4229 - rename DMNResult to KogitoDMNResult

### DIFF
--- a/jitexecutor/jitexecutor-dmn/src/main/java/org/kie/kogito/jitexecutor/dmn/JITDMNService.java
+++ b/jitexecutor/jitexecutor-dmn/src/main/java/org/kie/kogito/jitexecutor/dmn/JITDMNService.java
@@ -18,9 +18,9 @@ package org.kie.kogito.jitexecutor.dmn;
 
 import java.util.Map;
 
-import org.kie.kogito.dmn.rest.DMNResult;
+import org.kie.kogito.dmn.rest.KogitoDMNResult;
 
 public interface JITDMNService {
 
-    DMNResult evaluateModel(String modelXML, Map<String, Object> context);
+    KogitoDMNResult evaluateModel(String modelXML, Map<String, Object> context);
 }

--- a/jitexecutor/jitexecutor-dmn/src/main/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImpl.java
+++ b/jitexecutor/jitexecutor-dmn/src/main/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImpl.java
@@ -29,19 +29,19 @@ import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.internal.utils.DMNRuntimeBuilder;
 import org.kie.dmn.core.internal.utils.DynamicDMNContextBuilder;
 import org.kie.internal.io.ResourceFactory;
-import org.kie.kogito.dmn.rest.DMNResult;
+import org.kie.kogito.dmn.rest.KogitoDMNResult;
 
 @ApplicationScoped
 public class JITDMNServiceImpl implements JITDMNService {
 
     @Override
-    public org.kie.kogito.dmn.rest.DMNResult evaluateModel(String modelXML, Map<String, Object> context) {
+    public KogitoDMNResult evaluateModel(String modelXML, Map<String, Object> context) {
         Resource modelResource = ResourceFactory.newReaderResource(new StringReader(modelXML), "UTF-8");
         DMNRuntime dmnRuntime = DMNRuntimeBuilder.fromDefaults().buildConfiguration()
                 .fromResources(Collections.singletonList(modelResource)).getOrElseThrow(RuntimeException::new);
         DMNModel dmnModel = dmnRuntime.getModels().get(0);
         DMNContext dmnContext = new DynamicDMNContextBuilder(dmnRuntime.newContext(), dmnModel).populateContextWith(context);
         org.kie.dmn.api.core.DMNResult dmnResult = dmnRuntime.evaluateAll(dmnModel, dmnContext);
-        return new DMNResult(dmnModel.getNamespace(), dmnModel.getName(), dmnResult);
+        return new KogitoDMNResult(dmnModel.getNamespace(), dmnModel.getName(), dmnResult);
     }
 }

--- a/jitexecutor/jitexecutor-dmn/src/main/java/org/kie/kogito/jitexecutor/dmn/api/JITDMNResource.java
+++ b/jitexecutor/jitexecutor-dmn/src/main/java/org/kie/kogito/jitexecutor/dmn/api/JITDMNResource.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.kie.dmn.core.internal.utils.MarshallingStubUtils;
-import org.kie.kogito.dmn.rest.DMNResult;
+import org.kie.kogito.dmn.rest.KogitoDMNResult;
 import org.kie.kogito.jitexecutor.dmn.JITDMNService;
 import org.kie.kogito.jitexecutor.dmn.requests.JITDMNPayload;
 
@@ -43,7 +43,7 @@ public class JITDMNResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response jitdmn(JITDMNPayload payload) {
-        DMNResult evaluateAll = jitdmnService.evaluateModel(payload.getModel(), payload.getContext());
+        KogitoDMNResult evaluateAll = jitdmnService.evaluateModel(payload.getModel(), payload.getContext());
         Map<String, Object> restResulk = new HashMap<>();
         for (Entry<String, Object> kv : evaluateAll.getContext().getAll().entrySet()) {
             restResulk.put(kv.getKey(), MarshallingStubUtils.stubDMNResult(kv.getValue(), String::valueOf));
@@ -56,7 +56,7 @@ public class JITDMNResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response jitdmnResult(JITDMNPayload payload) {
-        DMNResult dmnResult = jitdmnService.evaluateModel(payload.getModel(), payload.getContext());
+        KogitoDMNResult dmnResult = jitdmnService.evaluateModel(payload.getModel(), payload.getContext());
         return Response.ok(dmnResult).build();
     }
 }

--- a/jitexecutor/jitexecutor-dmn/src/main/resources/META-INF/native-image/org.kie.kogito/jitexecutor-dmn/reflect-config.json
+++ b/jitexecutor/jitexecutor-dmn/src/main/resources/META-INF/native-image/org.kie.kogito/jitexecutor-dmn/reflect-config.json
@@ -1231,7 +1231,7 @@
       "allPublicFields" : true
     },
     {
-      "name":"org.kie.kogito.dmn.rest.DMNResult",
+      "name":"org.kie.kogito.dmn.rest.KogitoDMNResult",
       "allDeclaredConstructors" : true,
       "allPublicConstructors" : true,
       "allDeclaredMethods" : true,
@@ -1240,7 +1240,7 @@
       "allPublicFields" : true
     },
     {
-      "name":"org.kie.kogito.dmn.rest.DMNDecisionResultSQ",
+      "name":"org.kie.kogito.dmn.rest.KogitoDMNDecisionResult",
       "allDeclaredConstructors" : true,
       "allPublicConstructors" : true,
       "allDeclaredMethods" : true,

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImplTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImplTest.java
@@ -24,7 +24,7 @@ import org.drools.core.util.IoUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.dmn.rest.DMNResult;
+import org.kie.kogito.dmn.rest.KogitoDMNResult;
 import org.kie.kogito.jitexecutor.dmn.api.JITDMNResourceTest;
 
 public class JITDMNServiceImplTest {
@@ -44,7 +44,7 @@ public class JITDMNServiceImplTest {
         context.put("FICO Score", 800);
         context.put("DTI Ratio", .1);
         context.put("PITI Ratio", .1);
-        DMNResult dmnResult = jitdmnService.evaluateModel(model, context);
+        KogitoDMNResult dmnResult = jitdmnService.evaluateModel(model, context);
 
         Assertions.assertEquals("xls2dmn", dmnResult.getModelName());
         Assertions.assertEquals("xls2dmn_741b355c-685c-4827-b13a-833da8321da4", dmnResult.getNamespace());


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-4229

This PR aims to rename org.kie.kogito.dmn.rest.DMNResult so to avoid name conflict with org.kie.dmn.api.core.DMNResult.
Given that these classes have the same name, developers have to check always what is the DMNResult currently used and the code is more hard to read.

Main PR on kogito-runtimes: https://github.com/kiegroup/kogito-runtimes/pull/994

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket