### PR TITLE
KOGITO-4325 - Remove deprecated skipOriginalJarRename and use quarkus.package.type

### DIFF
--- a/data-index/data-index-service/data-index-service-infinispan/pom.xml
+++ b/data-index/data-index-service/data-index-service-infinispan/pom.xml
@@ -71,10 +71,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/data-index/data-index-service/data-index-service-infinispan/src/main/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-infinispan/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 # Infinispan
 quarkus.infinispan-client.server-list=localhost:11222
 kogito.persistence.type=infinispan

--- a/data-index/data-index-service/data-index-service-mongodb/pom.xml
+++ b/data-index/data-index-service/data-index-service-mongodb/pom.xml
@@ -65,10 +65,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/data-index/data-index-service/data-index-service-mongodb/src/main/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-mongodb/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 # MongoDB
 kogito.persistence.type=mongodb
 quarkus.mongodb.connection-string=mongodb://localhost:27017

--- a/explainability/explainability-service-messaging/pom.xml
+++ b/explainability/explainability-service-messaging/pom.xml
@@ -92,10 +92,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/explainability/explainability-service-messaging/src/main/resources/application.properties
+++ b/explainability/explainability-service-messaging/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 #Container image
 quarkus.container-image.build=true
 quarkus.container-image.group=org.kie.kogito

--- a/explainability/explainability-service-rest/pom.xml
+++ b/explainability/explainability-service-rest/pom.xml
@@ -86,10 +86,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/explainability/explainability-service-rest/src/main/resources/application.properties
+++ b/explainability/explainability-service-rest/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 #oidc
 quarkus.oidc.enabled=true
 quarkus.oidc.tenant-enabled=false

--- a/jitexecutor/jitexecutor-dmn/src/main/resources/application.properties
+++ b/jitexecutor/jitexecutor-dmn/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 # quarkus.log.console.enable=true
 # quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 # quarkus.log.console.level=INFO

--- a/jitexecutor/jitexecutor-runner/pom.xml
+++ b/jitexecutor/jitexecutor-runner/pom.xml
@@ -41,10 +41,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/jobs-service/pom.xml
+++ b/jobs-service/pom.xml
@@ -166,10 +166,6 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${version.io.quarkus}</version>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/jobs-service/src/main/resources/application.properties
+++ b/jobs-service/src/main/resources/application.properties
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+quarkus.package.type=uber-jar
+
 #Log Config
 quarkus.log.level=INFO
 %dev.quarkus.log.category."org.kie.kogito.jobs".level=DEBUG

--- a/management-console/pom.xml
+++ b/management-console/pom.xml
@@ -76,10 +76,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/management-console/src/main/resources/application.properties
+++ b/management-console/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 quarkus.http.cors=true
 
 quarkus.oidc.enabled=true

--- a/task-console/pom.xml
+++ b/task-console/pom.xml
@@ -72,10 +72,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/task-console/src/main/resources/application.properties
+++ b/task-console/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 quarkus.http.cors=true
 
 quarkus.oidc.enabled=true

--- a/trusty-ui/pom.xml
+++ b/trusty-ui/pom.xml
@@ -75,10 +75,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/trusty-ui/src/main/resources/application.properties
+++ b/trusty-ui/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 quarkus.http.cors=true
 kogito.trusty.http.url=${KOGITO_TRUSTY_HTTP_URL:http://localhost:8180}
 

--- a/trusty/trusty-service/pom.xml
+++ b/trusty/trusty-service/pom.xml
@@ -118,10 +118,6 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <configuration>
-          <uberJar>true</uberJar>
-          <skipOriginalJarRename>true</skipOriginalJarRename>
-        </configuration>
         <executions>
           <execution>
             <goals>

--- a/trusty/trusty-service/src/main/resources/application.properties
+++ b/trusty/trusty-service/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+quarkus.package.type=uber-jar
+
 quarkus.http.cors=true
 
 #oidc


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-4325

This PR aims to use `quarkus.package.type` to build the uber jar of the kogito-apps and remove the deprecated skipOriginalJarRename

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket