### PR TITLE
KOGITO-4423 - fix JIT configuration tests

### DIFF
--- a/jitexecutor/jitexecutor-dmn/src/main/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImpl.java
+++ b/jitexecutor/jitexecutor-dmn/src/main/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImpl.java
@@ -56,10 +56,18 @@ public class JITDMNServiceImpl implements JITDMNService {
     private static final String EXPLAINABILITY_SUCCEEDED = "SUCCEEDED";
 
     @ConfigProperty(name = "kogito.explainability.lime.sample-size", defaultValue = "300")
-    private static int explainabilityLimeSampleSize;
+    int explainabilityLimeSampleSize;
 
     @ConfigProperty(name = "kogito.explainability.lime.no-of-perturbation", defaultValue = "1")
-    private static int explainabilityLimeNoOfPerturbation;
+    int explainabilityLimeNoOfPerturbation;
+
+    public JITDMNServiceImpl() {
+    }
+
+    public JITDMNServiceImpl(int explainabilityLimeSampleSize, int explainabilityLimeNoOfPerturbation) {
+        this.explainabilityLimeSampleSize = explainabilityLimeSampleSize;
+        this.explainabilityLimeNoOfPerturbation = explainabilityLimeNoOfPerturbation;
+    }
 
     @Override
     public KogitoDMNResult evaluateModel(String modelXML, Map<String, Object> context) {

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImplTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImplTest.java
@@ -37,7 +37,7 @@ public class JITDMNServiceImplTest {
     @BeforeAll
     public static void setup() throws IOException {
         model = new String(IoUtils.readBytesFromInputStream(JITDMNResourceTest.class.getResourceAsStream("/test.dmn")));
-        jitdmnService = new JITDMNServiceImpl();
+        jitdmnService = new JITDMNServiceImpl(300, 1);
     }
 
     @Test


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/KOGITO-4423

Since JITDMNServiceImplTest is not a `QuarkusTest` the configuration has to be provided with the constructor (`@ConfigValue` does not inject the default value).

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket