### PR TITLE
KOGITO-4501 Clean node in pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,8 +77,6 @@ pipeline {
                 archiveArtifacts artifacts: 'kogito-apps/management-console/target/*-runner.jar, kogito-apps/data-index/data-index-service/target/*-runner.jar, kogito-apps/jobs-service/target/*-runner.jar', fingerprint: true
                 junit '**/**/junit.xml'
                 junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
             }
         }
         failure {
@@ -94,6 +92,11 @@ pipeline {
         fixed {
             script {
                 mailer.sendEmail_fixedPR()
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -145,9 +145,11 @@ pipeline {
                 def propertiesStr = deployProperties.collect { entry ->  "${entry.key}=${entry.value}" }.join('\n')
                 writeFile(text: propertiesStr, file: 'deployment.properties')
                 archiveArtifacts(artifacts: 'deployment.properties')
-
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -91,10 +91,9 @@ pipeline {
         }
     }
     post {
-        always {
+        cleanup {
             script {
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+                util.cleanNode('docker')
             }
         }
     }

--- a/Jenkinsfile.sonarcloud
+++ b/Jenkinsfile.sonarcloud
@@ -62,8 +62,11 @@ pipeline {
         always {
             script {
                 junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'
-                cleanWs()
-                cloud.cleanContainersAndImages('docker')
+            }
+        }
+        cleanup {
+            script {
+                util.cleanNode('docker')
             }
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4501

Use shared library to clean the node used by Jenkins.
This will also allow to improve the shared lib later on without having to modify all pipelines.

Related PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1090
- https://github.com/kiegroup/optaplanner/pull/1172
- https://github.com/kiegroup/kogito-apps/pull/665
- https://github.com/kiegroup/kogito-examples/pull/584

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket