### PR TITLE
KOGITO-4532 Disable org.kie.kogito.it.trusty.QuarkusTrustyExplainabilityEnd2EndIT

### DIFF
--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/src/test/java/org/kie/kogito/it/trusty/QuarkusTrustyExplainabilityEnd2EndIT.java
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-quarkus/src/test/java/org/kie/kogito/it/trusty/QuarkusTrustyExplainabilityEnd2EndIT.java
@@ -15,8 +15,10 @@
  */
 package org.kie.kogito.it.trusty;
 
+import org.junit.jupiter.api.Disabled;
 import org.kie.kogito.testcontainers.QuarkusKogitoServiceContainer;
 
+@Disabled("see https://issues.redhat.com/browse/KOGITO-4532")
 public class QuarkusTrustyExplainabilityEnd2EndIT extends AbstractTrustyExplainabilityEnd2EndIT {
 
     public QuarkusTrustyExplainabilityEnd2EndIT() {


### PR DESCRIPTION
I am disabling this test because it loops indefinitely very often. Please take a look in the meantime