### PR TITLE
FAI-421: MathUtils class for combinametrics utilities

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/MathUtils.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/MathUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.explainability.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class MathUtils {
+    private static double binomialRaw(int n, int k) {
+        if (n < k || n < 0 || k < 0) {
+            throw new IllegalArgumentException(String.format(
+                    "n >= k >= 0 for binomial coefficients: n: %d, k:%d", n, k));
+        }
+
+        if (k == 0 || k == n) {
+            return 1.0;
+        } else if (k == 1 || k == n - 1) {
+            return n;
+        } else {
+            return ((n + 1. - k) / k) * binomialRaw(n, k - 1);
+        }
+    }
+
+    public static int binomial(int n, int k) {
+        return (int) Math.round(binomialRaw(n, k));
+    }
+
+    private static List<List<Integer>> combinations(List<Integer> set, int size, List<Integer> filled) {
+        List<List<Integer>> newCombinations = new ArrayList<>();
+        if (set.size() < size || size < 1 || set.size() < 1) {
+            throw new IllegalArgumentException(String.format(
+                    "Set size >= combination size > 0: %d, size:%d", set.size(), size));
+        } else if (set.size() == size) {
+            List<Integer> newCombination = new ArrayList<>(filled);
+            newCombination.addAll(set);
+            newCombinations.add(newCombination);
+        } else if (size == 1) {
+            for (int i = 0; i < set.size(); i++) {
+                List<Integer> newCombination = new ArrayList<>(filled);
+                newCombination.add(set.get(i));
+                newCombinations.add(newCombination);
+            }
+        } else {
+            List<Integer> allButFirst = new ArrayList<>(set);
+            allButFirst.remove(0);
+            List<Integer> newFilled = new ArrayList<>(filled);
+            newFilled.add(set.get(0));
+            newCombinations.addAll(combinations(allButFirst, size - 1, newFilled));
+            newCombinations.addAll(combinations(allButFirst, size, filled));
+        }
+        return newCombinations;
+    }
+
+    public static List<List<Integer>> combinations(int n, int size) {
+        List<Integer> set = IntStream.range(0, n).boxed().collect(Collectors.toList());
+        return combinations(set, size, new ArrayList<>());
+    }
+}

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MathUtilsTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MathUtilsTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.explainability.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class MathUtilsTest {
+
+    // binomial coefficient testing ====================================================================================
+    int[][] binomialTests = {
+            { 10, 1, 10 },
+            { 10, 10, 1 },
+            { 10, 9, 10 },
+            { 10, 3, 120 },
+            { 10, 7, 120 },
+            { 25, 24, 25 },
+            { 25, 0, 1 },
+            { 25, 20, 53130 },
+            { 23, 7, 245157 },
+            { 23, 18, 33649 },
+    };
+
+    @Test
+    void testBinomial() {
+        for (int i = 0; i < binomialTests.length; i++) {
+            int[] values = binomialTests[i];
+            assertEquals(values[2], MathUtils.binomial(values[0], values[1]));
+        }
+    }
+
+    @Test
+    void testBinomialError() {
+        assertThrows(IllegalArgumentException.class, () -> MathUtils.binomial(5, 6));
+        assertThrows(IllegalArgumentException.class, () -> MathUtils.binomial(5, -1));
+        assertThrows(IllegalArgumentException.class, () -> MathUtils.binomial(-2, -1));
+    }
+
+    // combinations testing ============================================================================================
+    List<List<Integer>> expected4Get3Combinations = List.of(
+            List.of(0, 1, 2),
+            List.of(0, 2, 3),
+            List.of(0, 1, 3),
+            List.of(1, 2, 3));
+
+    List<List<Integer>> expected5Get2Combinations = List.of(
+            List.of(0, 1),
+            List.of(0, 2),
+            List.of(0, 3),
+            List.of(0, 4),
+            List.of(1, 2),
+            List.of(1, 3),
+            List.of(1, 4),
+            List.of(2, 3),
+            List.of(2, 4),
+            List.of(3, 4));
+
+    @Test
+    void testCombinations4Get3() {
+        List<List<Integer>> expectedCombinationsCopy = new ArrayList<>(expected4Get3Combinations);
+        List<List<Integer>> combs = MathUtils.combinations(4, 3);
+        assertEquals(MathUtils.binomial(4, 3), combs.size());
+        for (int i = 0; i < combs.size(); i++) {
+            boolean pass = false;
+            for (int j = 0; j < expectedCombinationsCopy.size(); j++) {
+                if (expectedCombinationsCopy.get(j).equals(combs.get(i))) {
+                    expectedCombinationsCopy.remove(j);
+                    pass = true;
+                    break;
+                }
+            }
+            // if none of the combinations match:
+            if (!pass) {
+                fail(String.format("Comb %s not in expected", combs.get(i)));
+            }
+            ;
+        }
+    }
+
+    @Test
+    void testCombinations5Get2() {
+        List<List<Integer>> expectedCombinationsCopy = new ArrayList<>(expected5Get2Combinations);
+        List<List<Integer>> combs = MathUtils.combinations(5, 2);
+        assertEquals(MathUtils.binomial(5, 2), combs.size());
+        for (int i = 0; i < combs.size(); i++) {
+            boolean pass = false;
+            for (int j = 0; j < expectedCombinationsCopy.size(); j++) {
+                if (expectedCombinationsCopy.get(j).equals(combs.get(i))) {
+                    expectedCombinationsCopy.remove(j);
+                    pass = true;
+                    break;
+                }
+            }
+            // if none of the combinations match:
+            if (!pass) {
+                fail(String.format("Comb %s not in expected", combs.get(i)));
+            }
+            ;
+        }
+    }
+
+    @Test
+    void testCombinationsError() {
+        assertThrows(IllegalArgumentException.class, () -> MathUtils.combinations(5, 6));
+        assertThrows(IllegalArgumentException.class, () -> MathUtils.combinations(-2, -1));
+    }
+}


### PR DESCRIPTION
Needed a few functions to compute BinomialCoefficients and set combinations for SHAP, implemented them into a MathUtils class.

[FAI-421](https://issues.redhat.com/browse/FAI-421l)

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket