### PR TITLE
KOGITO-4673 Remove Data Index Storage Protobuf dependency on Infinispan Persisten…

### DIFF
--- a/data-index/data-index-storage/data-index-storage-protobuf/pom.xml
+++ b/data-index/data-index-storage/data-index-storage-protobuf/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>infinispan-persistence-addon</artifactId>
+      <artifactId>protobuf-persistence-common</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-4673

Removes the dependency of `data-index-service-protobuf` on `infinispan-persistence-addon` to prevent `data-index-service-mongodb` transitively depending on the infinispan stuff.

