### PR TITLE
[FAI-386] Implement counterfactuals ability to return intermediate results

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -22,6 +22,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -60,6 +62,16 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
     private final SolverConfig solverConfig;
     private final Executor executor;
     private final DataDistribution dataDistribution;
+    private final Consumer<CounterfactualSolution> intermediateResultsConsumer;
+    private final Consumer<CounterfactualSolution> finalResultsConsumer;
+
+    public static Consumer<CounterfactualSolution> defaultIntermediateConsumer = counterfactual -> {
+        logger.debug("Intermediate counterfactual: {}", counterfactual.getEntities());
+    };
+
+    public static Consumer<CounterfactualSolution> defaultFinalConsumer = counterfactual -> {
+        logger.debug("Final counterfactual: {}", counterfactual.getEntities());
+    };
 
     /**
      * Create a new {@link CounterfactualExplainer} using OptaPlanner as the underlying engine.
@@ -69,18 +81,25 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
      * The desired outcome is passed using an {@link Output}, where the score of each feature represents the
      * minimum prediction score for a counterfactual to be considered.
      * A customizable OptaPlanner solver configuration can be passed using a {@link SolverConfig}.
+     * A {@link Consumer<CounterfactualSolution>} should be provided for the intermediate and final search results.
+     * Note that the final counterfactual is always returned by the prediction method itself, which means that the
+     * consumer for the final counterfactual can be used to other purposes.
      *
      * @param dataDistribution Characteristics of the data distribution as {@link DataDistribution}, if available
      * @param dataDomain A {@link DataDomain} which specifies the search space domain
      * @param contraints A list specifying by index which features are constrained
      * @param goal A collection of {@link Output} representing the desired outcome
      * @param solverConfig An OptaPlanner {@link SolverConfig} configuration
+     * @param intermediateConsumer A {@link Consumer<CounterfactualSolution>} for the search intermediate result
+     * @param finalConsumer A {@link Consumer<CounterfactualSolution>} for the final intermediate result
      */
     protected CounterfactualExplainer(DataDistribution dataDistribution,
             DataDomain dataDomain,
             List<Boolean> contraints,
             List<Output> goal,
             SolverConfig solverConfig,
+            Consumer<CounterfactualSolution> intermediateConsumer,
+            Consumer<CounterfactualSolution> finalConsumer,
             Executor executor) {
         this.dataDistribution = dataDistribution;
         this.dataDomain = dataDomain;
@@ -88,6 +107,8 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
         this.goal = goal;
         this.solverConfig = solverConfig;
         this.executor = executor;
+        this.intermediateResultsConsumer = intermediateConsumer;
+        this.finalResultsConsumer = finalConsumer;
     }
 
     public static Builder builder(List<Output> goal, List<Boolean> constraints, DataDomain dataDomain) {
@@ -116,24 +137,25 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
 
         final UUID problemId = UUID.randomUUID();
 
+        Function<UUID, CounterfactualSolution> initial = (UUID uuid) -> new CounterfactualSolution(entities, model, goal);
+
         final CompletableFuture<CounterfactualSolution> cfSolution = CompletableFuture.supplyAsync(() -> {
             try (SolverManager<CounterfactualSolution, UUID> solverManager =
                     SolverManager.create(solverConfig, new SolverManagerConfig())) {
 
-                CounterfactualSolution problem =
-                        new CounterfactualSolution(entities, model, goal);
-
-                SolverJob<CounterfactualSolution, UUID> solverJob = solverManager.solve(problemId, problem);
+                SolverJob<CounterfactualSolution, UUID> solverJob =
+                        solverManager.solveAndListen(problemId, initial, intermediateResultsConsumer, finalResultsConsumer,
+                                null);
                 CounterfactualSolution solution;
                 try {
                     // Wait until the solving ends
                     return solverJob.getFinalBestSolution();
                 } catch (ExecutionException e) {
                     logger.error("Solving failed: {}", e.getMessage());
-                    throw new IllegalStateException("Prediction returned an error", e);
+                    throw new IllegalStateException("Prediction returned an error {}", e);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    throw new IllegalStateException("Solving failed (Thread interrupted)", e);
+                    throw new IllegalStateException("Solving failed (Thread interrupted): {}", e);
                 }
             }
         }, this.executor);
@@ -145,6 +167,7 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
             CounterfactualSolution solution = cfSolution.join();
             return new CounterfactualResult(solution.getEntities(), cfOutputs.join(), solution.getScore().isFeasible());
         });
+
     }
 
     public static class Builder {
@@ -155,6 +178,8 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
         private DataDistribution dataDistribution = null;
         private Executor executor = ForkJoinPool.commonPool();
         private SolverConfig solverConfig = null;
+        private Consumer<CounterfactualSolution> intermediateConsumer = null;
+        private Consumer<CounterfactualSolution> finalConsumer = null;
 
         private Builder(List<Output> goal, List<Boolean> constraints, DataDomain dataDomain) {
             this.goal = goal;
@@ -177,16 +202,35 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
             return this;
         }
 
+        public Builder withIntermediateConsumer(Consumer<CounterfactualSolution> consumer) {
+            this.intermediateConsumer = consumer;
+            return this;
+        }
+
+        public Builder withFinalConsumer(Consumer<CounterfactualSolution> consumer) {
+            this.finalConsumer = consumer;
+            return this;
+        }
+
         public CounterfactualExplainer build() {
             // Create a default solver configuration if none provided
             if (this.solverConfig == null) {
                 this.solverConfig = CounterfactualConfigurationFactory.builder().build();
+            }
+            if (this.intermediateConsumer == null) {
+                this.intermediateConsumer = defaultIntermediateConsumer;
+            }
+
+            if (this.finalConsumer == null) {
+                this.finalConsumer = defaultFinalConsumer;
             }
             return new CounterfactualExplainer(dataDistribution,
                     dataDomain,
                     constraints,
                     goal,
                     solverConfig,
+                    intermediateConsumer,
+                    finalConsumer,
                     executor);
         }
     }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -137,7 +137,7 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
 
         final UUID problemId = UUID.randomUUID();
 
-        Function<UUID, CounterfactualSolution> initial = (UUID uuid) -> new CounterfactualSolution(entities, model, goal);
+        Function<UUID, CounterfactualSolution> initial = uuid -> new CounterfactualSolution(entities, model, goal);
 
         final CompletableFuture<CounterfactualSolution> cfSolution = CompletableFuture.supplyAsync(() -> {
             try (SolverManager<CounterfactualSolution, UUID> solverManager =
@@ -152,10 +152,10 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
                     return solverJob.getFinalBestSolution();
                 } catch (ExecutionException e) {
                     logger.error("Solving failed: {}", e.getMessage());
-                    throw new IllegalStateException("Prediction returned an error {}", e);
+                    throw new IllegalStateException("Prediction returned an error", e);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    throw new IllegalStateException("Solving failed (Thread interrupted): {}", e);
+                    throw new IllegalStateException("Solving failed (Thread interrupted)", e);
                 }
             }
         }, this.executor);

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainer.java
@@ -65,13 +65,11 @@ public class CounterfactualExplainer implements LocalExplainer<CounterfactualRes
     private final Consumer<CounterfactualSolution> intermediateResultsConsumer;
     private final Consumer<CounterfactualSolution> finalResultsConsumer;
 
-    public static Consumer<CounterfactualSolution> defaultIntermediateConsumer = counterfactual -> {
-        logger.debug("Intermediate counterfactual: {}", counterfactual.getEntities());
-    };
+    public static final Consumer<CounterfactualSolution> defaultIntermediateConsumer =
+            counterfactual -> logger.debug("Intermediate counterfactual: {}", counterfactual.getEntities());
 
-    public static Consumer<CounterfactualSolution> defaultFinalConsumer = counterfactual -> {
-        logger.debug("Final counterfactual: {}", counterfactual.getEntities());
-    };
+    public static final Consumer<CounterfactualSolution> defaultFinalConsumer =
+            counterfactual -> logger.debug("Final counterfactual: {}", counterfactual.getEntities());
 
     /**
      * Create a new {@link CounterfactualExplainer} using OptaPlanner as the underlying engine.

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -603,15 +603,10 @@ class CounterfactualExplainerTest {
         final AtomicBoolean finalConsumerCalled = new AtomicBoolean(false);
 
         final Consumer<CounterfactualSolution> assertIntermediateCounterfactualNotNull = counterfactual -> {
-            assertNotNull(counterfactual);
-            assertNotNull(counterfactual.getEntities());
         };
 
-        final Consumer<CounterfactualSolution> assertFinalCounterfactualNotNull = counterfactual -> {
-            assertNotNull(counterfactual);
-            assertNotNull(counterfactual.getEntities());
-            finalConsumerCalled.set(true);
-        };
+        final Consumer<CounterfactualSolution> assertFinalCounterfactualNotNull =
+                counterfactual -> finalConsumerCalled.set(true);
 
         final CounterfactualExplainer counterfactualExplainer =
                 CounterfactualExplainer

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -21,6 +21,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -573,5 +574,56 @@ class CounterfactualExplainerTest {
                         TestUtils.getSumThresholdModel(center, epsilon));
 
         assertFalse(result.isValid());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    void testConsumers(int seed) throws ExecutionException, InterruptedException, TimeoutException {
+        Random random = new Random();
+        random.setSeed(seed);
+
+        final List<Output> goal = List.of(new Output("class", Type.BOOLEAN, new Value(false), 0.0d));
+        List<Feature> features = new LinkedList<>();
+        List<FeatureDomain> featureBoundaries = new LinkedList<>();
+        List<Boolean> constraints = new LinkedList<>();
+        for (int i = 0; i < 4; i++) {
+            features.add(TestUtils.getMockedNumericFeature(i));
+            featureBoundaries.add(NumericalFeatureDomain.create(0.0, 1000.0));
+            constraints.add(false);
+        }
+        final DataDomain dataDomain = new DataDomain(featureBoundaries);
+        final TerminationConfig terminationConfig = new TerminationConfig().withScoreCalculationCountLimit(10L);
+        // for the purpose of this test, only a few steps are necessary
+        final SolverConfig solverConfig = CounterfactualConfigurationFactory
+                .builder().withTerminationConfig(terminationConfig).build();
+        solverConfig.setRandomSeed((long) seed);
+        solverConfig.setEnvironmentMode(EnvironmentMode.REPRODUCIBLE);
+
+        final Consumer<CounterfactualSolution> assertCounterfactualNotNull = counterfactual -> {
+            assertNotNull(counterfactual);
+            assertNotNull(counterfactual.getEntities());
+        };
+
+        final CounterfactualExplainer counterfactualExplainer =
+                CounterfactualExplainer
+                        .builder(goal, constraints, dataDomain)
+                        .withSolverConfig(solverConfig)
+                        .withIntermediateConsumer(assertCounterfactualNotNull)
+                        .withFinalConsumer(assertCounterfactualNotNull)
+                        .build();
+
+        PredictionInput input = new PredictionInput(features);
+        PredictionProvider model = TestUtils.getSumSkipModel(0);
+        PredictionOutput output = model.predictAsync(List.of(input))
+                .get(predictionTimeOut, predictionTimeUnit)
+                .get(0);
+        Prediction prediction = new Prediction(input, output);
+        final CounterfactualResult counterfactualResult = counterfactualExplainer.explainAsync(prediction, model)
+                .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+        for (CounterfactualEntity entity : counterfactualResult.getEntities()) {
+            logger.debug("Entity: {}", entity);
+        }
+
+        logger.debug("Outputs: {}", counterfactualResult.getOutput().get(0).getOutputs());
     }
 }


### PR DESCRIPTION
[FAI-386](https://issues.redhat.com/browse/FAI-386): Allow for services to register a consumer with `CounterfactualExplainer` in order to be notified of intermediate counterfactual results during the search.
This is particularly aimed at long running searches, where intermediate results provide an indication of progress.

If no consumers are provided, default ones will be used which will simply log the intermediate (and final results).

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [ ] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>
</details>