### PR TITLE
KOGITO-4716 Add types.tsx,graphql.schema.json to sonar exclusions

### DIFF
--- a/ui-packages/pom.xml
+++ b/ui-packages/pom.xml
@@ -27,7 +27,7 @@
       ${path.to.packages}/task-inbox/src,
       ${path.to.packages}/task-console-webapp/src
     </sonar.sources>
-    <sonar.exclusions>**/__mocks__/**,**/mocks/**,**/tests/utils/**,**/*.stories.tsx</sonar.exclusions>
+    <sonar.exclusions>**/__mocks__/**,**/mocks/**,**/tests/utils/**,**/*.stories.tsx,**/graphql/types.tsx,**/graphql/graphql.schema.json</sonar.exclusions>
     <sonar.test.inclusions>**/*test.ts,**/*test.tsx</sonar.test.inclusions>
     <sonar.javascript.lcov.reportPaths>
       ${path.to.packages}/common/coverage/lcov.info,


### PR DESCRIPTION
Description : ignoring types,graphql.schema.json for sonar;
JIRA: https://issues.redhat.com/browse/KOGITO-4716;