### PR TITLE
KOGITO-3268 Trusty UI: Rely to enums for remote data status handling

### DIFF
--- a/ui-packages/packages/trusty/src/components/Organisms/ExecutionHeader/ExecutionHeader.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/ExecutionHeader/ExecutionHeader.tsx
@@ -3,7 +3,7 @@ import { Flex, FlexItem, Title, Tooltip } from '@patternfly/react-core';
 import SkeletonStripe from '../../Atoms/SkeletonStripe/SkeletonStripe';
 import ExecutionStatus from '../../Atoms/ExecutionStatus/ExecutionStatus';
 import FormattedDate from '../../Atoms/FormattedDate/FormattedDate';
-import { RemoteData, Execution } from '../../../types';
+import { RemoteData, Execution, RemoteDataStatus } from '../../../types';
 import './ExecutionHeader.scss';
 
 type ExecutionHeaderProps = {
@@ -17,7 +17,7 @@ const ExecutionHeader = (props: ExecutionHeaderProps) => {
     <section className="execution-header">
       <Flex>
         <FlexItem>
-          {execution.status === 'LOADING' && (
+          {execution.status === RemoteDataStatus.LOADING && (
             <SkeletonStripe
               isInline={true}
               customStyle={{
@@ -28,7 +28,7 @@ const ExecutionHeader = (props: ExecutionHeaderProps) => {
               }}
             />
           )}
-          {execution.status === 'SUCCESS' && (
+          {execution.status === RemoteDataStatus.SUCCESS && (
             <Title size="3xl" headingLevel="h2">
               <span className="execution-header__uuid">
                 ID# {execution.data.executionId}
@@ -37,7 +37,7 @@ const ExecutionHeader = (props: ExecutionHeaderProps) => {
           )}
         </FlexItem>
         <FlexItem className="execution-header__property">
-          {execution.status === 'SUCCESS' && (
+          {execution.status === RemoteDataStatus.SUCCESS && (
             <Tooltip
               entryDelay={23}
               exitDelay={23}

--- a/ui-packages/packages/trusty/src/components/Organisms/ExecutionHeader/tests/ExecutionHeader.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/ExecutionHeader/tests/ExecutionHeader.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import ExecutionHeader from '../ExecutionHeader';
 import { shallow } from 'enzyme';
-import { Execution, RemoteData } from '../../../../types';
+import { Execution, RemoteData, RemoteDataStatus } from '../../../../types';
 
 describe('ExecutionHeader', () => {
   test('renders a loading animation while fetching data', () => {
     const execution = {
-      status: 'LOADING'
+      status: RemoteDataStatus.LOADING
     } as RemoteData<Error, Execution>;
 
     const wrapper = shallow(<ExecutionHeader execution={execution} />);
@@ -17,7 +17,7 @@ describe('ExecutionHeader', () => {
 
   test('renders the execution info', () => {
     const execution = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: {
         executionId: 'b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000',
         executionDate: '2020-08-12T12:54:53.933Z',

--- a/ui-packages/packages/trusty/src/components/Organisms/ExecutionTable/ExecutionTable.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/ExecutionTable/ExecutionTable.tsx
@@ -8,11 +8,16 @@ import {
   EmptyStateIcon,
   Title
 } from '@patternfly/react-core';
-import { SearchIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import ExecutionStatus from '../../Atoms/ExecutionStatus/ExecutionStatus';
 import FormattedDate from '../../Atoms/FormattedDate/FormattedDate';
 import skeletonRows from '../../../utils/skeletonRows/skeletonRows';
-import { Execution, Executions, RemoteData } from '../../../types';
+import {
+  Execution,
+  Executions,
+  RemoteData,
+  RemoteDataStatus
+} from '../../../types';
 
 type ExecutionTableProps = {
   data: RemoteData<Error, Executions>;
@@ -41,18 +46,18 @@ const prepareRows = (
 ) => {
   let rows;
   switch (data.status) {
-    case 'NOT_ASKED':
-    case 'LOADING':
+    case RemoteDataStatus.NOT_ASKED:
+    case RemoteDataStatus.LOADING:
       rows = skeletonRows(columnsNumber, 10, 'executionKey');
       break;
-    case 'SUCCESS':
+    case RemoteDataStatus.SUCCESS:
       if (data.data.headers.length > 0) {
         rows = prepareExecutionsRows(data.data.headers);
       } else {
         rows = noExecutions(columnsNumber);
       }
       break;
-    case 'FAILURE':
+    case RemoteDataStatus.FAILURE:
       rows = loadingError(columnsNumber);
       break;
   }

--- a/ui-packages/packages/trusty/src/components/Organisms/ExecutionTable/tests/ExecutionTable.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/ExecutionTable/tests/ExecutionTable.test.tsx
@@ -1,24 +1,30 @@
 import React from 'react';
 import ExecutionTable from '../ExecutionTable';
 import { shallow } from 'enzyme';
-import { Executions, RemoteData } from '../../../../types';
+import { Executions, RemoteData, RemoteDataStatus } from '../../../../types';
 
 describe('Execution table', () => {
   test('renders loading skeletons when the data is not yet fetching', () => {
-    const data = { status: 'NOT_ASKED' } as RemoteData<Error, Executions>;
+    const data = { status: RemoteDataStatus.NOT_ASKED } as RemoteData<
+      Error,
+      Executions
+    >;
     const wrapper = shallow(<ExecutionTable data={data} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   test('renders loading skeletons when the data is loading', () => {
-    const data = { status: 'LOADING' } as RemoteData<Error, Executions>;
+    const data = { status: RemoteDataStatus.LOADING } as RemoteData<
+      Error,
+      Executions
+    >;
     const wrapper = shallow(<ExecutionTable data={data} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   test('renders a loading error message when data loading fails', () => {
     const data = {
-      status: 'FAILURE',
+      status: RemoteDataStatus.FAILURE,
       error: { name: '', message: '' }
     } as RemoteData<Error, Executions>;
     const wrapper = shallow(<ExecutionTable data={data} />);
@@ -27,7 +33,7 @@ describe('Execution table', () => {
 
   test('renders a list of executions', () => {
     const data = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: {
         total: 2,
         limit: 10,
@@ -59,7 +65,7 @@ describe('Execution table', () => {
 
   test('renders no result message if no executions are found', () => {
     const data = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: {
         total: 0,
         limit: 10,

--- a/ui-packages/packages/trusty/src/components/Organisms/InputDataBrowser/InputDataBrowser.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/InputDataBrowser/InputDataBrowser.tsx
@@ -21,10 +21,11 @@ import SkeletonFlexStripes from '../../Molecules/SkeletonFlexStripes/SkeletonFle
 import { OutlinedMehIcon } from '@patternfly/react-icons';
 import {
   InputRow,
-  ItemObject,
   isItemObjectArray,
   isItemObjectMultiArray,
-  RemoteData
+  ItemObject,
+  RemoteData,
+  RemoteDataStatus
 } from '../../../types';
 import './InputDataBrowser.scss';
 
@@ -42,7 +43,10 @@ const InputDataBrowser = ({ inputData }: InputDataBrowserProps) => {
   };
 
   useEffect(() => {
-    if (inputData.status === 'SUCCESS' && inputData.data.length > 0) {
+    if (
+      inputData.status === RemoteDataStatus.SUCCESS &&
+      inputData.data.length > 0
+    ) {
       const items: ItemObject[] = [];
       const categoryList = [];
       const rootSection: ItemObject = {
@@ -74,7 +78,7 @@ const InputDataBrowser = ({ inputData }: InputDataBrowserProps) => {
 
   return (
     <div className="input-browser">
-      {inputData.status === 'LOADING' && (
+      {inputData.status === RemoteDataStatus.LOADING && (
         <>
           <div className="input-browser__section-list">
             <SkeletonFlexStripes
@@ -86,68 +90,70 @@ const InputDataBrowser = ({ inputData }: InputDataBrowserProps) => {
           <SkeletonDataList rowsCount={4} colsCount={6} hasHeader={true} />
         </>
       )}
-      {inputData.status === 'SUCCESS' && inputData.data.length > 0 && (
-        <>
-          <div className="input-browser__section-list">
-            <Split>
-              <SplitItem>
-                <span className="input-browser__section-list__label">
-                  Browse Sections
-                </span>
-              </SplitItem>
-              <SplitItem>
-                {categories.map((item, index) => (
-                  <Button
-                    type={'button'}
-                    variant={index === viewSection ? 'primary' : 'control'}
-                    isActive={index === viewSection}
-                    key={`section-${index}`}
-                    onClick={() => handleSectionSwitch(index)}
-                  >
-                    {item}
-                  </Button>
-                ))}
-              </SplitItem>
-            </Split>
-          </div>
-          <DataList
-            aria-label="Input Data"
-            className="input-browser__data-list"
-          >
-            <DataListItem
-              aria-labelledby="header"
-              key="header"
-              className="input-browser__header"
+      {inputData.status === RemoteDataStatus.SUCCESS &&
+        inputData.data.length > 0 && (
+          <>
+            <div className="input-browser__section-list">
+              <Split>
+                <SplitItem>
+                  <span className="input-browser__section-list__label">
+                    Browse Sections
+                  </span>
+                </SplitItem>
+                <SplitItem>
+                  {categories.map((item, index) => (
+                    <Button
+                      type={'button'}
+                      variant={index === viewSection ? 'primary' : 'control'}
+                      isActive={index === viewSection}
+                      key={`section-${index}`}
+                      onClick={() => handleSectionSwitch(index)}
+                    >
+                      {item}
+                    </Button>
+                  ))}
+                </SplitItem>
+              </Split>
+            </div>
+            <DataList
+              aria-label="Input Data"
+              className="input-browser__data-list"
             >
-              <DataListItemRow>
-                <DataListItemCells
-                  dataListCells={[
-                    <DataListCell width={3} key="Input Data">
-                      <span>Input Data</span>
-                    </DataListCell>,
-                    <DataListCell width={3} key="Value">
-                      <span>Value</span>
-                    </DataListCell>,
-                    <DataListCell width={3} key="Distribution">
-                      <></>
-                    </DataListCell>
-                  ]}
-                />
-              </DataListItemRow>
-            </DataListItem>
-            {inputs && renderItem(inputs[viewSection])}
-          </DataList>
-        </>
-      )}
-      {inputData.status === 'SUCCESS' && inputData.data.length === 0 && (
-        <EmptyState variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={OutlinedMehIcon} />
-          <Title headingLevel="h5" size="lg">
-            No input data
-          </Title>
-          <EmptyStateBody>No inputs available to display.</EmptyStateBody>
-        </EmptyState>
-      )}
+              <DataListItem
+                aria-labelledby="header"
+                key="header"
+                className="input-browser__header"
+              >
+                <DataListItemRow>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell width={3} key="Input Data">
+                        <span>Input Data</span>
+                      </DataListCell>,
+                      <DataListCell width={3} key="Value">
+                        <span>Value</span>
+                      </DataListCell>,
+                      <DataListCell width={3} key="Distribution">
+                        <></>
+                      </DataListCell>
+                    ]}
+                  />
+                </DataListItemRow>
+              </DataListItem>
+              {inputs && renderItem(inputs[viewSection])}
+            </DataList>
+          </>
+        )}
+      {inputData.status === RemoteDataStatus.SUCCESS &&
+        inputData.data.length === 0 && (
+          <EmptyState variant={EmptyStateVariant.full}>
+            <EmptyStateIcon icon={OutlinedMehIcon} />
+            <Title headingLevel="h5" size="lg">
+              No input data
+            </Title>
+            <EmptyStateBody>No inputs available to display.</EmptyStateBody>
+          </EmptyState>
+        )}
     </div>
   );
 };

--- a/ui-packages/packages/trusty/src/components/Organisms/InputDataBrowser/tests/InputDataBrowser.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/InputDataBrowser/tests/InputDataBrowser.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import InputDataBrowser from '../InputDataBrowser';
-import { shallow, mount } from 'enzyme';
-import { ItemObject, RemoteData } from '../../../../types';
+import { mount, shallow } from 'enzyme';
+import { ItemObject, RemoteData, RemoteDataStatus } from '../../../../types';
 
 describe('InputDataBrowser', () => {
   test('renders a loading animation while fetching data', () => {
-    const inputData = { status: 'LOADING' } as RemoteData<Error, ItemObject[]>;
+    const inputData = { status: RemoteDataStatus.LOADING } as RemoteData<
+      Error,
+      ItemObject[]
+    >;
     const wrapper = shallow(<InputDataBrowser inputData={inputData} />);
 
     expect(wrapper).toMatchSnapshot();
@@ -13,7 +16,7 @@ describe('InputDataBrowser', () => {
 
   test('renders a list of inputs', () => {
     const inputData = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: [
         {
           name: 'Asset Score',

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/AuditDetail.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/AuditDetail.tsx
@@ -17,7 +17,7 @@ import {
   useParams,
   useRouteMatch
 } from 'react-router-dom';
-import { ExecutionRouteParams } from '../../../types';
+import { ExecutionRouteParams, RemoteDataStatus } from '../../../types';
 import SkeletonFlexStripes from '../../Molecules/SkeletonFlexStripes/SkeletonFlexStripes';
 import useExecutionInfo from './useExecutionInfo';
 import ExecutionHeader from '../../Organisms/ExecutionHeader/ExecutionHeader';
@@ -42,7 +42,7 @@ const AuditDetail = () => {
   >([]);
 
   useEffect(() => {
-    if (outcomes.status === 'SUCCESS') {
+    if (outcomes.status === RemoteDataStatus.SUCCESS) {
       const newNav = [];
       if (outcomes.data.length === 1) {
         newNav.push({
@@ -106,17 +106,23 @@ const AuditDetail = () => {
           <ModelLookup />
         </Route>
         <Route exact path={`${path}/`}>
-          {outcomes.status === 'SUCCESS' && outcomes.data.length === 1 && (
-            <Redirect
-              exact
-              from={path}
-              to={`${location.pathname}/single-outcome?outcomeId=${outcomes.data[0].outcomeId}`}
-            />
-          )}
-          {outcomes.status === 'SUCCESS' && outcomes.data.length > 1 && (
-            <Redirect exact from={path} to={`${location.pathname}/outcomes`} />
-          )}
-          {outcomes.status === 'LOADING' && (
+          {outcomes.status === RemoteDataStatus.SUCCESS &&
+            outcomes.data.length === 1 && (
+              <Redirect
+                exact
+                from={path}
+                to={`${location.pathname}/single-outcome?outcomeId=${outcomes.data[0].outcomeId}`}
+              />
+            )}
+          {outcomes.status === RemoteDataStatus.SUCCESS &&
+            outcomes.data.length > 1 && (
+              <Redirect
+                exact
+                from={path}
+                to={`${location.pathname}/outcomes`}
+              />
+            )}
+          {outcomes.status === RemoteDataStatus.LOADING && (
             <PageSection>
               <Stack hasGutter>
                 <StackItem>

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/tests/AuditDetail.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/tests/AuditDetail.test.tsx
@@ -3,7 +3,12 @@ import { mount } from 'enzyme';
 import AuditDetail from '../AuditDetail';
 import useExecutionInfo from '../useExecutionInfo';
 import useDecisionOutcomes from '../useDecisionOutcomes';
-import { Execution, Outcome, RemoteData } from '../../../../types';
+import {
+  Execution,
+  Outcome,
+  RemoteData,
+  RemoteDataStatus
+} from '../../../../types';
 import { MemoryRouter } from 'react-router';
 
 jest.mock('../useExecutionInfo');
@@ -22,10 +27,10 @@ jest.mock('react-router-dom', () => ({
 describe('AuditDetail', () => {
   test('renders loading animation while fetching data', () => {
     const execution = {
-      status: 'LOADING'
+      status: RemoteDataStatus.LOADING
     } as RemoteData<Error, Execution>;
     const outcomes = {
-      status: 'LOADING'
+      status: RemoteDataStatus.LOADING
     } as RemoteData<Error, Outcome[]>;
 
     (useExecutionInfo as jest.Mock).mockReturnValue(execution);
@@ -75,7 +80,7 @@ describe('AuditDetail', () => {
 
   test('renders correctly an execution', () => {
     const execution = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: {
         executionId: 'b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000',
         executionDate: '2020-08-12T12:54:53.933Z',
@@ -86,7 +91,7 @@ describe('AuditDetail', () => {
       }
     } as RemoteData<Error, Execution>;
     const outcomes = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: [
         {
           outcomeId: '_12268B68-94A1-4960-B4C8-0B6071AFDE58',

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/tests/useDecisionOutcomes.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/tests/useDecisionOutcomes.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-test-renderer';
 import * as api from '../../../../utils/api/httpClient';
 import useDecisionOutcomes from '../useDecisionOutcomes';
-import { Execution, Outcome } from '../../../../types';
+import { Execution, Outcome, RemoteDataStatus } from '../../../../types';
 
 const flushPromises = () => new Promise(setImmediate);
 const apiMock = jest.spyOn(api, 'httpClient');
@@ -61,14 +61,17 @@ describe('useDecisionOutcome', () => {
       return useDecisionOutcomes('b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000');
     });
 
-    expect(result.current).toStrictEqual({ status: 'LOADING' });
+    expect(result.current).toStrictEqual({ status: RemoteDataStatus.LOADING });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current).toStrictEqual(
-      Object.assign({ status: 'SUCCESS' }, { data: outcomes.data.outcomes })
+      Object.assign(
+        { status: RemoteDataStatus.SUCCESS },
+        { data: outcomes.data.outcomes }
+      )
     );
     expect(apiMock).toHaveBeenCalledTimes(1);
   });

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/tests/useExecutionInfo.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/tests/useExecutionInfo.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-test-renderer';
 import * as api from '../../../../utils/api/httpClient';
 import useExecutionInfo from '../useExecutionInfo';
-import { Execution } from '../../../../types';
+import { Execution, RemoteDataStatus } from '../../../../types';
 
 const flushPromises = () => new Promise(setImmediate);
 const apiMock = jest.spyOn(api, 'httpClient');
@@ -32,14 +32,14 @@ describe('useExecutionInfo', () => {
       return useExecutionInfo('b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000');
     });
 
-    expect(result.current).toStrictEqual({ status: 'LOADING' });
+    expect(result.current).toStrictEqual({ status: RemoteDataStatus.LOADING });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current).toStrictEqual(
-      Object.assign({ status: 'SUCCESS' }, execution)
+      Object.assign({ status: RemoteDataStatus.SUCCESS }, execution)
     );
     expect(apiMock).toHaveBeenCalledTimes(1);
   });

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/useDecisionOutcomes.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/useDecisionOutcomes.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
-import { RemoteData, Outcome } from '../../../types';
+import { RemoteData, Outcome, RemoteDataStatus } from '../../../types';
 import { AxiosRequestConfig } from 'axios';
 
 const useDecisionOutcomes = (executionId: string) => {
   const [outcomes, setOutcomes] = useState<RemoteData<Error, Outcome[]>>({
-    status: 'NOT_ASKED'
+    status: RemoteDataStatus.NOT_ASKED
   });
 
   useEffect(() => {
@@ -15,15 +15,18 @@ const useDecisionOutcomes = (executionId: string) => {
       method: 'get'
     };
 
-    setOutcomes({ status: 'LOADING' });
+    setOutcomes({ status: RemoteDataStatus.LOADING });
     httpClient(config)
       .then(response => {
         if (isMounted) {
-          setOutcomes({ status: 'SUCCESS', data: response.data.outcomes });
+          setOutcomes({
+            status: RemoteDataStatus.SUCCESS,
+            data: response.data.outcomes
+          });
         }
       })
       .catch(error => {
-        setOutcomes({ status: 'FAILURE', error });
+        setOutcomes({ status: RemoteDataStatus.FAILURE, error });
       });
     return () => {
       isMounted = false;

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/useExecutionInfo.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/useExecutionInfo.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import { RemoteData, Execution } from '../../../types';
+import { RemoteData, Execution, RemoteDataStatus } from '../../../types';
 import { AxiosRequestConfig } from 'axios';
 import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
 
 const useExecutionInfo = (executionId: string) => {
   const [execution, setExecution] = useState<RemoteData<Error, Execution>>({
-    status: 'NOT_ASKED'
+    status: RemoteDataStatus.NOT_ASKED
   });
 
   useEffect(() => {
@@ -14,15 +14,18 @@ const useExecutionInfo = (executionId: string) => {
       url: `${EXECUTIONS_PATH}/decisions/${executionId}`,
       method: 'get'
     };
-    setExecution({ status: 'LOADING' });
+    setExecution({ status: RemoteDataStatus.LOADING });
     httpClient(config)
       .then(response => {
         if (isMounted) {
-          setExecution({ status: 'SUCCESS', data: response.data });
+          setExecution({
+            status: RemoteDataStatus.SUCCESS,
+            data: response.data
+          });
         }
       })
       .catch(error => {
-        setExecution({ status: 'FAILURE', error });
+        setExecution({ status: RemoteDataStatus.FAILURE, error });
       });
     return () => {
       isMounted = false;

--- a/ui-packages/packages/trusty/src/components/Templates/AuditOverview/AuditOverview.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditOverview/AuditOverview.tsx
@@ -13,6 +13,7 @@ import {
 import ExecutionTable from '../../Organisms/ExecutionTable/ExecutionTable';
 import useExecutions from './useExecutions';
 import { formatISO, sub } from 'date-fns';
+import { RemoteDataStatus } from '../../../types';
 
 type AuditOverviewProps = {
   dateRangePreset?: {
@@ -44,7 +45,7 @@ const AuditOverview = (props: AuditOverviewProps) => {
   });
 
   useEffect(() => {
-    if (executions.status === 'SUCCESS') {
+    if (executions.status === RemoteDataStatus.SUCCESS) {
       setTotal(executions.data.total);
     }
   }, [executions]);

--- a/ui-packages/packages/trusty/src/components/Templates/AuditOverview/tests/AuditOverview.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditOverview/tests/AuditOverview.test.tsx
@@ -3,6 +3,7 @@ import { mount, shallow } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import AuditOverview from '../AuditOverview';
 import useExecutions from '../useExecutions';
+import { RemoteDataStatus } from '../../../../types';
 
 jest.mock('../useExecutions');
 
@@ -10,7 +11,7 @@ describe('Audit overview', () => {
   test('renders correctly a list of executions', () => {
     const mockLoadExecutions = jest.fn();
     const executions = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: {
         total: 1,
         limit: 10,
@@ -42,7 +43,7 @@ describe('Audit overview', () => {
   test('loads a list of executions from the last month by default', () => {
     const mockLoadExecutions = jest.fn();
     const executions = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: {
         total: 1,
         limit: 10,

--- a/ui-packages/packages/trusty/src/components/Templates/AuditOverview/tests/__snapshots__/AuditOverview.test.tsx.snap
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditOverview/tests/__snapshots__/AuditOverview.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Audit overview renders correctly a list of executions 1`] = `
             "offset": 0,
             "total": 1,
           },
-          "status": "SUCCESS",
+          "status": 3,
         }
       }
     />

--- a/ui-packages/packages/trusty/src/components/Templates/AuditOverview/tests/useExecutions.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditOverview/tests/useExecutions.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import useExecutions from '../useExecutions';
 import * as api from '../../../../utils/api/httpClient';
 import { act } from 'react-test-renderer';
+import { RemoteDataStatus } from '../../../../types';
 
 const flushPromises = () => new Promise(setImmediate);
 const apiMock = jest.spyOn(api, 'callOnceHandler');
@@ -75,14 +76,16 @@ describe('useExecutions', () => {
         offset: 0
       });
     });
-    expect(result.current.executions).toStrictEqual({ status: 'LOADING' });
+    expect(result.current.executions).toStrictEqual({
+      status: RemoteDataStatus.LOADING
+    });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current.executions).toStrictEqual(
-      Object.assign({ status: 'SUCCESS' }, executionsResponse)
+      Object.assign({ status: RemoteDataStatus.SUCCESS }, executionsResponse)
     );
     expect(apiMock).toHaveBeenCalledTimes(1);
 
@@ -90,14 +93,16 @@ describe('useExecutions', () => {
       result.current.loadExecutions();
     });
 
-    expect(result.current.executions).toStrictEqual({ status: 'LOADING' });
+    expect(result.current.executions).toStrictEqual({
+      status: RemoteDataStatus.LOADING
+    });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current.executions).toStrictEqual(
-      Object.assign({ status: 'SUCCESS' }, executionsResponse)
+      Object.assign({ status: RemoteDataStatus.SUCCESS }, executionsResponse)
     );
     expect(apiMock).toHaveBeenCalledTimes(1);
   });
@@ -113,14 +118,16 @@ describe('useExecutions', () => {
         offset: 0
       });
     });
-    expect(result.current.executions).toStrictEqual({ status: 'LOADING' });
+    expect(result.current.executions).toStrictEqual({
+      status: RemoteDataStatus.LOADING
+    });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current.executions).toStrictEqual(
-      Object.assign({ error: 'error', status: 'FAILURE' })
+      Object.assign({ error: 'error', status: RemoteDataStatus.FAILURE })
     );
     expect(apiMock).toHaveBeenCalledTimes(1);
   });

--- a/ui-packages/packages/trusty/src/components/Templates/AuditOverview/useExecutions.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditOverview/useExecutions.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  EXECUTIONS_PATH,
-  callOnceHandler
+  callOnceHandler,
+  EXECUTIONS_PATH
 } from '../../../utils/api/httpClient';
-import { RemoteData, Executions } from '../../../types';
+import { Executions, RemoteData, RemoteDataStatus } from '../../../types';
 import axios, { AxiosRequestConfig } from 'axios';
 
 type useExecutionsParameters = {
@@ -17,14 +17,14 @@ type useExecutionsParameters = {
 const useExecutions = (parameters: useExecutionsParameters) => {
   const { searchString, from, to, limit, offset } = parameters;
   const [executions, setExecutions] = useState<RemoteData<Error, Executions>>({
-    status: 'NOT_ASKED'
+    status: RemoteDataStatus.NOT_ASKED
   });
 
   const getExecutions = useMemo(() => callOnceHandler(), []);
 
   const loadExecutions = useCallback(() => {
     let isMounted = true;
-    setExecutions({ status: 'LOADING' });
+    setExecutions({ status: RemoteDataStatus.LOADING });
 
     const config: AxiosRequestConfig = {
       url: EXECUTIONS_PATH,
@@ -35,12 +35,15 @@ const useExecutions = (parameters: useExecutionsParameters) => {
     getExecutions(config)
       .then(response => {
         if (isMounted) {
-          setExecutions({ status: 'SUCCESS', data: response.data });
+          setExecutions({
+            status: RemoteDataStatus.SUCCESS,
+            data: response.data
+          });
         }
       })
       .catch(error => {
         if (!axios.isCancel(error)) {
-          setExecutions({ status: 'FAILURE', error });
+          setExecutions({ status: RemoteDataStatus.FAILURE, error });
         }
       });
     return () => {

--- a/ui-packages/packages/trusty/src/components/Templates/ExecutionDetail/ExecutionDetail.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/ExecutionDetail/ExecutionDetail.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { PageSection, Stack, StackItem, Title } from '@patternfly/react-core';
 import Outcomes from '../../Organisms/Outcomes/Outcomes';
 import SkeletonCards from '../../Molecules/SkeletonCards/SkeletonCards';
-import { RemoteData, Outcome } from '../../../types';
+import { Outcome, RemoteData, RemoteDataStatus } from '../../../types';
 import './ExecutionDetail.scss';
 
 type ExecutionDetailProps = {
@@ -33,8 +33,10 @@ const ExecutionDetail = (props: ExecutionDetailProps) => {
             </Title>
           </StackItem>
           <StackItem>
-            {outcomes.status === 'LOADING' && <SkeletonCards quantity={2} />}
-            {outcomes.status === 'SUCCESS' && (
+            {outcomes.status === RemoteDataStatus.LOADING && (
+              <SkeletonCards quantity={2} />
+            )}
+            {outcomes.status === RemoteDataStatus.SUCCESS && (
               <Outcomes
                 outcomes={outcomes.data}
                 onExplanationClick={goToExplanation}

--- a/ui-packages/packages/trusty/src/components/Templates/ExecutionDetail/tests/ExecutionDetail.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/ExecutionDetail/tests/ExecutionDetail.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import ExecutionDetail from '../ExecutionDetail';
-import { Outcome, RemoteData } from '../../../../types';
+import { Outcome, RemoteData, RemoteDataStatus } from '../../../../types';
 import { MemoryRouter } from 'react-router';
 
 const mockHistoryPush = jest.fn();
@@ -15,7 +15,7 @@ jest.mock('react-router-dom', () => ({
 describe('ExecutionDetail', () => {
   test('renders a loading animation while fetching data', () => {
     const outcome = {
-      status: 'LOADING'
+      status: RemoteDataStatus.LOADING
     } as RemoteData<Error, Outcome[]>;
     const wrapper = mount(<ExecutionDetail outcomes={outcome} />);
 
@@ -37,7 +37,7 @@ describe('ExecutionDetail', () => {
     expect(wrapper.find('SkeletonCards')).toHaveLength(0);
     expect(wrapper.find('Outcomes')).toHaveLength(1);
     expect(wrapper.find('Outcomes').prop('outcomes')).toStrictEqual(
-      outcomes.status === 'SUCCESS' && outcomes.data
+      outcomes.status === RemoteDataStatus.SUCCESS && outcomes.data
     );
   });
 
@@ -61,7 +61,7 @@ describe('ExecutionDetail', () => {
 });
 
 const outcomes = {
-  status: 'SUCCESS',
+  status: RemoteDataStatus.SUCCESS,
   data: [
     {
       outcomeId: '_12268B68-94A1-4960-B4C8-0B6071AFDE58',

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/Explanation.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/Explanation.tsx
@@ -35,6 +35,7 @@ import {
   ExecutionRouteParams,
   Outcome,
   RemoteData,
+  RemoteDataStatus,
   SaliencyStatus
 } from '../../../types';
 import './Explanation.scss';
@@ -82,7 +83,7 @@ const Explanation = ({ outcomes }: ExplanationProps) => {
     }
   }, [featuresScores]);
   useEffect(() => {
-    if (outcomes.status === 'SUCCESS') {
+    if (outcomes.status === RemoteDataStatus.SUCCESS) {
       setOutcomesList(outcomes.data);
     }
   }, [outcomes]);
@@ -183,8 +184,8 @@ const Explanation = ({ outcomes }: ExplanationProps) => {
               </Title>
             </StackItem>
             <StackItem>
-              {(saliencies.status === 'LOADING' ||
-                (saliencies.status === 'SUCCESS' &&
+              {(saliencies.status === RemoteDataStatus.LOADING ||
+                (saliencies.status === RemoteDataStatus.SUCCESS &&
                   featuresScores.length > 0)) && (
                 <Grid hasGutter>
                   <GridItem span={8}>
@@ -201,13 +202,13 @@ const Explanation = ({ outcomes }: ExplanationProps) => {
                         )}
                       </CardHeader>
                       <CardBody>
-                        {saliencies.status === 'LOADING' && (
+                        {saliencies.status === RemoteDataStatus.LOADING && (
                           <SkeletonDoubleBarChart
                             valuesCount={5}
                             height={400}
                           />
                         )}
-                        {saliencies.status === 'SUCCESS' && (
+                        {saliencies.status === RemoteDataStatus.SUCCESS && (
                           <>
                             {topFeaturesScoresBySign.length === 0 && (
                               <div className="explanation-view__chart">
@@ -269,10 +270,10 @@ const Explanation = ({ outcomes }: ExplanationProps) => {
                         </Title>
                       </CardHeader>
                       <CardBody>
-                        {saliencies.status === 'LOADING' && (
+                        {saliencies.status === RemoteDataStatus.LOADING && (
                           <SkeletonGrid rowsCount={4} colsDefinition={2} />
                         )}
-                        {saliencies.status === 'SUCCESS' && (
+                        {saliencies.status === RemoteDataStatus.SUCCESS && (
                           <FeaturesScoreTable
                             featuresScore={
                               topFeaturesScores.length > 0
@@ -286,7 +287,7 @@ const Explanation = ({ outcomes }: ExplanationProps) => {
                   </GridItem>
                 </Grid>
               )}
-              {saliencies.status === 'SUCCESS' && (
+              {saliencies.status === RemoteDataStatus.SUCCESS && (
                 <>
                   {saliencies.data.status === SaliencyStatus.SUCCEEDED &&
                     featuresScores.length === 0 && <ExplanationUnavailable />}

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/Explanation.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/Explanation.tsx
@@ -31,7 +31,12 @@ import ExplanationError from '../../Molecules/ExplanationError/ExplanationError'
 import EvaluationStatus from '../../Atoms/EvaluationStatus/EvaluationStatus';
 import SkeletonDoubleBarChart from '../../Molecules/SkeletonDoubleBarChart/SkeletonDoubleBarChart';
 import FeaturesScoreChartBySign from '../../Organisms/FeaturesScoreChartBySign/FeaturesScoreChartBySign';
-import { ExecutionRouteParams, Outcome, RemoteData } from '../../../types';
+import {
+  ExecutionRouteParams,
+  Outcome,
+  RemoteData,
+  SaliencyStatus
+} from '../../../types';
 import './Explanation.scss';
 
 type ExplanationProps = {
@@ -283,9 +288,9 @@ const Explanation = ({ outcomes }: ExplanationProps) => {
               )}
               {saliencies.status === 'SUCCESS' && (
                 <>
-                  {saliencies.data.status === 'SUCCEEDED' &&
+                  {saliencies.data.status === SaliencyStatus.SUCCEEDED &&
                     featuresScores.length === 0 && <ExplanationUnavailable />}
-                  {saliencies.data.status === 'FAILED' && (
+                  {saliencies.data.status === SaliencyStatus.FAILED && (
                     <ExplanationError
                       statusDetail={saliencies.data.statusDetail}
                     />

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/Explanation.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/Explanation.test.tsx
@@ -5,7 +5,13 @@ import { orderBy } from 'lodash';
 import Explanation from '../Explanation';
 import useOutcomeDetail from '../useOutcomeDetail';
 import useSaliencies from '../useSaliencies';
-import { ItemObject, Outcome, RemoteData, Saliencies } from '../../../../types';
+import {
+  ItemObject,
+  Outcome,
+  RemoteData,
+  Saliencies,
+  SaliencyStatus
+} from '../../../../types';
 
 const executionId = 'b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000';
 
@@ -189,7 +195,7 @@ const outcomeDetail = {
 const saliencies = {
   status: 'SUCCESS',
   data: {
-    status: 'SUCCEEDED',
+    status: SaliencyStatus.SUCCEEDED,
     saliencies: [
       {
         outcomeId: '_12268B68-94A1-4960-B4C8-0B6071AFDE58',
@@ -223,7 +229,7 @@ const saliencies = {
 const noSaliencies = {
   status: 'SUCCESS',
   data: {
-    status: 'SUCCEEDED',
+    status: SaliencyStatus.SUCCEEDED,
     saliencies: [
       {
         outcomeId: '_12268B68-94A1-4960-B4C8-0B6071AFDE58',

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/Explanation.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/Explanation.test.tsx
@@ -9,6 +9,7 @@ import {
   ItemObject,
   Outcome,
   RemoteData,
+  RemoteDataStatus,
   Saliencies,
   SaliencyStatus
 } from '../../../../types';
@@ -31,13 +32,13 @@ jest.mock('react-router-dom', () => ({
 describe('Explanation', () => {
   test('renders animations while fetching data', () => {
     const loadingOutcomes = {
-      status: 'LOADING'
+      status: RemoteDataStatus.LOADING
     } as RemoteData<Error, Outcome[]>;
     const loadingOutcomeDetail = {
-      status: 'LOADING'
+      status: RemoteDataStatus.LOADING
     } as RemoteData<Error, ItemObject[]>;
     const loadingSaliencies = {
-      status: 'LOADING'
+      status: RemoteDataStatus.LOADING
     } as RemoteData<Error, Saliencies>;
 
     (useOutcomeDetail as jest.Mock).mockReturnValue(loadingOutcomeDetail);
@@ -90,7 +91,7 @@ describe('Explanation', () => {
       </MemoryRouter>
     );
     let sortedFeatures;
-    if (saliencies.status === 'SUCCESS') {
+    if (saliencies.status === RemoteDataStatus.SUCCESS) {
       sortedFeatures = orderBy(
         saliencies.data.saliencies[0].featureImportance,
         item => Math.abs(item.featureScore),
@@ -106,7 +107,9 @@ describe('Explanation', () => {
     expect(wrapper.find('ExplanationSwitch')).toHaveLength(1);
     expect(
       wrapper.find('ExplanationSwitch').prop('outcomesList')
-    ).toStrictEqual(outcomes.status === 'SUCCESS' && outcomes.data);
+    ).toStrictEqual(
+      outcomes.status === RemoteDataStatus.SUCCESS && outcomes.data
+    );
     expect(wrapper.find('FeaturesScoreChartBySign')).toHaveLength(1);
     expect(
       wrapper.find('FeaturesScoreChartBySign').prop('featuresScore')
@@ -145,7 +148,7 @@ describe('Explanation', () => {
 });
 
 const outcomes = {
-  status: 'SUCCESS',
+  status: RemoteDataStatus.SUCCESS,
   data: [
     {
       outcomeId: '_12268B68-94A1-4960-B4C8-0B6071AFDE58',
@@ -176,7 +179,7 @@ const outcomes = {
   ]
 } as RemoteData<Error, Outcome[]>;
 const outcomeDetail = {
-  status: 'SUCCESS',
+  status: RemoteDataStatus.SUCCESS,
   data: [
     {
       name: 'Asset Score',
@@ -193,7 +196,7 @@ const outcomeDetail = {
   ]
 } as RemoteData<Error, ItemObject[]>;
 const saliencies = {
-  status: 'SUCCESS',
+  status: RemoteDataStatus.SUCCESS,
   data: {
     status: SaliencyStatus.SUCCEEDED,
     saliencies: [
@@ -227,7 +230,7 @@ const saliencies = {
   } as Saliencies
 } as RemoteData<Error, Saliencies>;
 const noSaliencies = {
-  status: 'SUCCESS',
+  status: RemoteDataStatus.SUCCESS,
   data: {
     status: SaliencyStatus.SUCCEEDED,
     saliencies: [

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useFeaturesScores.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useFeaturesScores.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useFeaturesScores from '../useFeaturesScores';
-import { RemoteData, Saliencies } from '../../../../types';
+import { RemoteData, Saliencies, SaliencyStatus } from '../../../../types';
 import { orderBy } from 'lodash';
 
 describe('useFeaturesScores', () => {
@@ -28,7 +28,7 @@ describe('useFeaturesScores', () => {
 const saliencies = {
   status: 'SUCCESS',
   data: {
-    status: 'SUCCEEDED',
+    status: SaliencyStatus.SUCCEEDED,
     saliencies: [
       {
         outcomeId: 'b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000',

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useFeaturesScores.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useFeaturesScores.test.tsx
@@ -1,6 +1,11 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useFeaturesScores from '../useFeaturesScores';
-import { RemoteData, Saliencies, SaliencyStatus } from '../../../../types';
+import {
+  RemoteData,
+  RemoteDataStatus,
+  Saliencies,
+  SaliencyStatus
+} from '../../../../types';
 import { orderBy } from 'lodash';
 
 describe('useFeaturesScores', () => {
@@ -13,7 +18,7 @@ describe('useFeaturesScores', () => {
       );
     });
     let sortedFeatures;
-    if (saliencies.status === 'SUCCESS') {
+    if (saliencies.status === RemoteDataStatus.SUCCESS) {
       sortedFeatures = orderBy(
         saliencies.data.saliencies[0].featureImportance,
         item => Math.abs(item.featureScore),
@@ -26,7 +31,7 @@ describe('useFeaturesScores', () => {
 });
 
 const saliencies = {
-  status: 'SUCCESS',
+  status: RemoteDataStatus.SUCCESS,
   data: {
     status: SaliencyStatus.SUCCEEDED,
     saliencies: [

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useOutcomeDetail.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useOutcomeDetail.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import useOutcomeDetail from '../useOutcomeDetail';
 import { act } from 'react-test-renderer';
 import * as api from '../../../../utils/api/httpClient';
+import { RemoteDataStatus } from '../../../../types';
 
 const flushPromises = () => new Promise(setImmediate);
 const apiMock = jest.spyOn(api, 'httpClient');
@@ -53,14 +54,14 @@ describe('useOutcomeDetail', () => {
       );
     });
 
-    expect(result.current).toStrictEqual({ status: 'LOADING' });
+    expect(result.current).toStrictEqual({ status: RemoteDataStatus.LOADING });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current).toStrictEqual({
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: details.data.outcomeInputs
     });
   });

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useSaliencies.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useSaliencies.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useSaliencies from '../useSaliencies';
 import * as api from '../../../../utils/api/httpClient';
-import { Saliencies } from '../../../../types';
+import { Saliencies, SaliencyStatus } from '../../../../types';
 import { act } from 'react-test-renderer';
 
 const flushPromises = () => new Promise(setImmediate);
@@ -15,7 +15,7 @@ describe('useSaliencies', () => {
   test('retrieves explanation info of an execution', async () => {
     const saliencies = {
       data: {
-        status: 'SUCCEEDED',
+        status: SaliencyStatus.SUCCEEDED,
         saliencies: [
           {
             outcomeId: '12345',

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useSaliencies.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/tests/useSaliencies.test.tsx
@@ -1,7 +1,11 @@
 import { renderHook } from '@testing-library/react-hooks';
 import useSaliencies from '../useSaliencies';
 import * as api from '../../../../utils/api/httpClient';
-import { Saliencies, SaliencyStatus } from '../../../../types';
+import {
+  RemoteDataStatus,
+  Saliencies,
+  SaliencyStatus
+} from '../../../../types';
 import { act } from 'react-test-renderer';
 
 const flushPromises = () => new Promise(setImmediate);
@@ -42,14 +46,14 @@ describe('useSaliencies', () => {
       return useSaliencies('b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000');
     });
 
-    expect(result.current).toStrictEqual({ status: 'LOADING' });
+    expect(result.current).toStrictEqual({ status: RemoteDataStatus.LOADING });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current).toStrictEqual({
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: saliencies.data
     });
     expect(apiMock).toHaveBeenCalledTimes(1);

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/useFeaturesScores.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/useFeaturesScores.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import {
   FeatureScores,
   RemoteData,
+  RemoteDataStatus,
   Saliencies,
   SaliencyStatus
 } from '../../../types';
@@ -20,7 +21,7 @@ const useFeaturesScores = (
   >([]);
 
   useEffect(() => {
-    if (saliencies.status === 'SUCCESS' && outcomeId) {
+    if (saliencies.status === RemoteDataStatus.SUCCESS && outcomeId) {
       if (saliencies.data.status === SaliencyStatus.SUCCEEDED) {
         const selectedExplanation = find(
           saliencies.data.saliencies,

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/useFeaturesScores.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/useFeaturesScores.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react';
-import { FeatureScores, RemoteData, Saliencies } from '../../../types';
+import {
+  FeatureScores,
+  RemoteData,
+  Saliencies,
+  SaliencyStatus
+} from '../../../types';
 import { orderBy, find } from 'lodash';
 
 const useFeaturesScores = (
@@ -16,7 +21,7 @@ const useFeaturesScores = (
 
   useEffect(() => {
     if (saliencies.status === 'SUCCESS' && outcomeId) {
-      if (saliencies.data.status === 'SUCCEEDED') {
+      if (saliencies.data.status === SaliencyStatus.SUCCEEDED) {
         const selectedExplanation = find(
           saliencies.data.saliencies,
           saliency => {

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/useOutcomeDetail.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/useOutcomeDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { RemoteData, ItemObject } from '../../../types';
+import { ItemObject, RemoteData, RemoteDataStatus } from '../../../types';
 import { AxiosRequestConfig } from 'axios';
 import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
 
@@ -7,7 +7,7 @@ const useOutcomeDetail = (executionId: string, outcomeId: string | null) => {
   const [outcomeDetail, setOutcomeDetail] = useState<
     RemoteData<Error, ItemObject[]>
   >({
-    status: 'NOT_ASKED'
+    status: RemoteDataStatus.NOT_ASKED
   });
 
   useEffect(() => {
@@ -17,18 +17,18 @@ const useOutcomeDetail = (executionId: string, outcomeId: string | null) => {
         url: `${EXECUTIONS_PATH}/decisions/${executionId}/outcomes/${outcomeId}`,
         method: 'get'
       };
-      setOutcomeDetail({ status: 'LOADING' });
+      setOutcomeDetail({ status: RemoteDataStatus.LOADING });
       httpClient(config)
         .then(response => {
           if (isMounted) {
             setOutcomeDetail({
-              status: 'SUCCESS',
+              status: RemoteDataStatus.SUCCESS,
               data: response.data.outcomeInputs
             });
           }
         })
         .catch(error => {
-          setOutcomeDetail({ status: 'FAILURE', error });
+          setOutcomeDetail({ status: RemoteDataStatus.FAILURE, error });
         });
     }
     return () => {

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/useSaliencies.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/useSaliencies.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import { RemoteData, Saliencies } from '../../../types';
+import { RemoteData, RemoteDataStatus, Saliencies } from '../../../types';
 import { AxiosRequestConfig } from 'axios';
 import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
 
 const useSaliencies = (executionId: string) => {
   const [saliencies, setSaliencies] = useState<RemoteData<Error, Saliencies>>({
-    status: 'NOT_ASKED'
+    status: RemoteDataStatus.NOT_ASKED
   });
 
   useEffect(() => {
@@ -15,15 +15,18 @@ const useSaliencies = (executionId: string) => {
       method: 'get'
     };
 
-    setSaliencies({ status: 'LOADING' });
+    setSaliencies({ status: RemoteDataStatus.LOADING });
     httpClient(config)
       .then(response => {
         if (isMounted) {
-          setSaliencies({ status: 'SUCCESS', data: response.data });
+          setSaliencies({
+            status: RemoteDataStatus.SUCCESS,
+            data: response.data
+          });
         }
       })
       .catch(error => {
-        setSaliencies({ status: 'FAILURE', error });
+        setSaliencies({ status: RemoteDataStatus.FAILURE, error });
       });
     return () => {
       isMounted = false;

--- a/ui-packages/packages/trusty/src/components/Templates/InputData/tests/InputData.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/InputData/tests/InputData.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import InputData from '../InputData';
 import useInputData from '../useInputData';
 import { MemoryRouter } from 'react-router';
-import { ItemObject } from '../../../../types';
+import { ItemObject, RemoteDataStatus } from '../../../../types';
 
 jest.mock('../useInputData');
 jest.mock('react-router-dom', () => ({
@@ -20,7 +20,7 @@ jest.mock('react-router-dom', () => ({
 describe('InputData', () => {
   test('renders inputs of an execution', () => {
     const inputData = {
-      status: 'SUCCESS',
+      status: RemoteDataStatus.SUCCESS,
       data: {
         inputs: [
           {

--- a/ui-packages/packages/trusty/src/components/Templates/InputData/tests/useInputData.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/InputData/tests/useInputData.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-test-renderer';
 import useInputData from '../useInputData';
 import * as api from '../../../../utils/api/httpClient';
-import { ItemObject } from '../../../../types';
+import { ItemObject, RemoteDataStatus } from '../../../../types';
 
 const flushPromises = () => new Promise(setImmediate);
 const apiMock = jest.spyOn(api, 'httpClient');
@@ -40,14 +40,17 @@ describe('useInputData', () => {
       return useInputData('b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000');
     });
 
-    expect(result.current).toStrictEqual({ status: 'LOADING' });
+    expect(result.current).toStrictEqual({ status: RemoteDataStatus.LOADING });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current).toStrictEqual(
-      Object.assign({ status: 'SUCCESS' }, { data: inputData.data.inputs })
+      Object.assign(
+        { status: RemoteDataStatus.SUCCESS },
+        { data: inputData.data.inputs }
+      )
     );
     expect(apiMock).toHaveBeenCalledTimes(1);
   });

--- a/ui-packages/packages/trusty/src/components/Templates/InputData/useInputData.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/InputData/useInputData.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import { RemoteData, ItemObject } from '../../../types';
+import { ItemObject, RemoteData, RemoteDataStatus } from '../../../types';
 import { AxiosRequestConfig } from 'axios';
 import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
 
 const useInputData = (executionId: string) => {
   const [inputData, setInputData] = useState<RemoteData<Error, ItemObject[]>>({
-    status: 'NOT_ASKED'
+    status: RemoteDataStatus.NOT_ASKED
   });
 
   useEffect(() => {
@@ -14,15 +14,18 @@ const useInputData = (executionId: string) => {
       url: `${EXECUTIONS_PATH}/decisions/${executionId}/structuredInputs`,
       method: 'get'
     };
-    setInputData({ status: 'LOADING' });
+    setInputData({ status: RemoteDataStatus.LOADING });
     httpClient(config)
       .then(response => {
         if (isMounted) {
-          setInputData({ status: 'SUCCESS', data: response.data.inputs });
+          setInputData({
+            status: RemoteDataStatus.SUCCESS,
+            data: response.data.inputs
+          });
         }
       })
       .catch(error => {
-        setInputData({ status: 'FAILURE', error });
+        setInputData({ status: RemoteDataStatus.FAILURE, error });
       });
     return () => {
       isMounted = false;

--- a/ui-packages/packages/trusty/src/components/Templates/ModelLookup/ModelLookup.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/ModelLookup/ModelLookup.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Divider, PageSection } from '@patternfly/react-core';
 import useModelData from './useModelData';
 import { useParams } from 'react-router-dom';
-import { ExecutionRouteParams } from '../../../types';
+import { ExecutionRouteParams, RemoteDataStatus } from '../../../types';
 import ModelDiagram from '../../Organisms/ModelDiagram/ModelDiagram';
 
 const ModelLookup = () => {
@@ -17,7 +17,7 @@ const ModelLookup = () => {
         <Divider />
       </PageSection>
       <PageSection variant={'light'}>
-        {modelData.status === 'SUCCESS' && (
+        {modelData.status === RemoteDataStatus.SUCCESS && (
           <ModelDiagram model={modelData.data} />
         )}
       </PageSection>

--- a/ui-packages/packages/trusty/src/components/Templates/ModelLookup/tests/ModelLookup.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/ModelLookup/tests/ModelLookup.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import ModelLookup from '../ModelLookup';
 import useModelData from '../useModelData';
 import { MemoryRouter } from 'react-router';
-import { ModelData } from '../../../../types';
+import { ModelData, RemoteDataStatus } from '../../../../types';
 
 jest.mock('../useModelData');
 jest.mock('react-router-dom', () => ({
@@ -49,7 +49,7 @@ describe('ModelLookup', () => {
 });
 
 const modelData = {
-  status: 'SUCCESS',
+  status: RemoteDataStatus.SUCCESS,
   data: {
     executionId: 'b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000',
     deploymentDate: '01012020',

--- a/ui-packages/packages/trusty/src/components/Templates/ModelLookup/tests/useModelData.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/ModelLookup/tests/useModelData.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { act } from 'react-test-renderer';
 import useModelData from '../useModelData';
 import * as api from '../../../../utils/api/httpClient';
-import { ModelData } from '../../../../types';
+import { ModelData, RemoteDataStatus } from '../../../../types';
 
 const flushPromises = () => new Promise(setImmediate);
 const apiMock = jest.spyOn(api, 'httpClient');
@@ -21,14 +21,17 @@ describe('useModelData', () => {
       return useModelData('b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000');
     });
 
-    expect(result.current).toStrictEqual({ status: 'LOADING' });
+    expect(result.current).toStrictEqual({ status: RemoteDataStatus.LOADING });
 
     await act(async () => {
       await flushPromises();
     });
 
     expect(result.current).toStrictEqual(
-      Object.assign({ status: 'SUCCESS' }, { data: modelData.data })
+      Object.assign(
+        { status: RemoteDataStatus.SUCCESS },
+        { data: modelData.data }
+      )
     );
     expect(apiMock).toHaveBeenCalledTimes(1);
   });

--- a/ui-packages/packages/trusty/src/components/Templates/ModelLookup/useModelData.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/ModelLookup/useModelData.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
-import { RemoteData, ModelData } from '../../../types';
+import { ModelData, RemoteData, RemoteDataStatus } from '../../../types';
 import { AxiosRequestConfig } from 'axios';
 import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
 
 const useModelData = (executionId: string) => {
   const [modelData, setModelData] = useState<RemoteData<Error, ModelData>>({
-    status: 'NOT_ASKED'
+    status: RemoteDataStatus.NOT_ASKED
   });
 
   useEffect(() => {
@@ -14,15 +14,18 @@ const useModelData = (executionId: string) => {
       url: `${EXECUTIONS_PATH}/${executionId}/model`,
       method: 'get'
     };
-    setModelData({ status: 'LOADING' });
+    setModelData({ status: RemoteDataStatus.LOADING });
     httpClient(config)
       .then(response => {
         if (isMounted) {
-          setModelData({ status: 'SUCCESS', data: response.data });
+          setModelData({
+            status: RemoteDataStatus.SUCCESS,
+            data: response.data
+          });
         }
       })
       .catch(error => {
-        setModelData({ status: 'FAILURE', error });
+        setModelData({ status: RemoteDataStatus.FAILURE, error });
       });
     return () => {
       isMounted = false;

--- a/ui-packages/packages/trusty/src/types.ts
+++ b/ui-packages/packages/trusty/src/types.ts
@@ -1,8 +1,15 @@
 export type RemoteData<E, D> =
-  | { status: 'NOT_ASKED' }
-  | { status: 'LOADING' }
-  | { status: 'FAILURE'; error: E }
-  | { status: 'SUCCESS'; data: D };
+  | { status: RemoteDataStatus.NOT_ASKED }
+  | { status: RemoteDataStatus.LOADING }
+  | { status: RemoteDataStatus.FAILURE; error: E }
+  | { status: RemoteDataStatus.SUCCESS; data: D };
+
+export enum RemoteDataStatus {
+  NOT_ASKED,
+  LOADING,
+  FAILURE,
+  SUCCESS
+}
 
 export interface Execution {
   executionId: string;

--- a/ui-packages/packages/trusty/src/types.ts
+++ b/ui-packages/packages/trusty/src/types.ts
@@ -80,8 +80,14 @@ export interface Saliency {
   outcomeId: string;
   featureImportance: FeatureScores[];
 }
+export enum SaliencyStatus {
+  SUCCEEDED = 'SUCCEEDED',
+  FAILED = 'FAILED'
+}
+export type SaliencyStatusStrings = keyof typeof SaliencyStatus;
+
 export interface Saliencies {
-  status: 'SUCCEEDED' | 'FAILED';
+  status: SaliencyStatusStrings;
   statusDetail: string;
   saliencies: Saliency[];
 }


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/KOGITO-3268

This PR replaces `SaliencyStatus` and `RemoteDataStatus` string literals with enums.