### PR TITLE
FAI-450: Features Scores Chart labels are wrongfully sorted

### DIFF
--- a/ui-packages/packages/trusty/src/components/Organisms/FeaturesScoreChartBySign/FeaturesScoreChartBySign.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/FeaturesScoreChartBySign/FeaturesScoreChartBySign.tsx
@@ -8,7 +8,6 @@ import {
   ChartGroup,
   ChartLabel,
   ChartLegend,
-  ChartBarProps,
   ChartProps
 } from '@patternfly/react-charts';
 import { Split, SplitItem } from '@patternfly/react-core';
@@ -25,8 +24,12 @@ const FeaturesScoreChartBySign = (props: FeaturesScoreChartBySignProps) => {
   const chartPadding = { top: 60, bottom: 30 };
 
   const scores = useMemo(() => {
-    const positives = featuresScore.filter(feature => feature.featureScore > 0);
-    const negatives = featuresScore.filter(feature => feature.featureScore < 0);
+    const positives = featuresScore
+      .filter(feature => feature.featureScore > 0)
+      .sort((a, b) => b.featureScore - a.featureScore);
+    const negatives = featuresScore
+      .filter(feature => feature.featureScore < 0)
+      .sort((a, b) => a.featureScore - b.featureScore);
     const maxNumberOfValues = Math.max(positives.length, negatives.length);
     const barWidth = (height - 90) / maxNumberOfValues / 2;
     return { positives, negatives, maxNumberOfValues, barWidth };
@@ -48,7 +51,6 @@ const FeaturesScoreChartBySign = (props: FeaturesScoreChartBySignProps) => {
               width={width}
               height={height}
               scores={scores.positives}
-              sortOrder="descending"
               yDomain={[0, maxValue]}
               barWidth={scores.barWidth}
               maxValue={maxValue}
@@ -63,7 +65,6 @@ const FeaturesScoreChartBySign = (props: FeaturesScoreChartBySignProps) => {
               width={width}
               height={height}
               scores={scores.negatives}
-              sortOrder="ascending"
               yDomain={[-maxValue, 0]}
               barWidth={scores.barWidth}
               maxValue={maxValue}
@@ -85,7 +86,6 @@ type ScoresBarChartProps = {
   width: number;
   height: number;
   scores: FeatureScores[];
-  sortOrder: ChartBarProps['sortOrder'];
   yDomain: [number, number];
   barWidth: number;
   maxValue: number;
@@ -100,7 +100,6 @@ const ScoresBarChart = (props: ScoresBarChartProps) => {
     width,
     height,
     scores,
-    sortOrder,
     yDomain,
     barWidth,
     maxValue,
@@ -150,8 +149,6 @@ const ScoresBarChart = (props: ScoresBarChartProps) => {
         x="featureName"
         y="featureScore"
         alignment="middle"
-        sortKey="featureScore"
-        sortOrder={sortOrder}
         barWidth={barWidth}
         style={{
           data: {

--- a/ui-packages/packages/trusty/src/components/Organisms/FeaturesScoreChartBySign/tests/__snapshots__/FeaturesScoreChartBySign.test.tsx.snap
+++ b/ui-packages/packages/trusty/src/components/Organisms/FeaturesScoreChartBySign/tests/__snapshots__/FeaturesScoreChartBySign.test.tsx.snap
@@ -24,14 +24,14 @@ exports[`FeaturesScoreChart renders a chart for a list of feature scores grouped
         scores={
           Array [
             Object {
-              "featureId": "66aaad87-25e0-4074-86e6-db804b0c72e6",
-              "featureName": "Liabilities",
-              "featureScore": 0.6780527129423648,
-            },
-            Object {
               "featureId": "a14a8292-579e-4937-9133-7f4986b31072",
               "featureName": "Liabilities 2",
               "featureScore": 0.7693802543201365,
+            },
+            Object {
+              "featureId": "66aaad87-25e0-4074-86e6-db804b0c72e6",
+              "featureName": "Liabilities",
+              "featureScore": 0.6780527129423648,
             },
             Object {
               "featureId": "a5621def-cfd5-4d4f-a984-a29970b39644",
@@ -40,7 +40,6 @@ exports[`FeaturesScoreChart renders a chart for a list of feature scores grouped
             },
           ]
         }
-        sortOrder="descending"
         width={480}
         yDomain={
           Array [
@@ -71,18 +70,17 @@ exports[`FeaturesScoreChart renders a chart for a list of feature scores grouped
         scores={
           Array [
             Object {
-              "featureId": "ae35bfc0-52c0-4725-96b5-0f231a68345e",
-              "featureName": "Lender Ratings",
-              "featureScore": -0.08937896629080377,
-            },
-            Object {
               "featureId": "cfe35995-375d-4b30-801c-ae0b18d707f6",
               "featureName": "Employment Income",
               "featureScore": -0.9240811677386516,
             },
+            Object {
+              "featureId": "ae35bfc0-52c0-4725-96b5-0f231a68345e",
+              "featureName": "Lender Ratings",
+              "featureScore": -0.08937896629080377,
+            },
           ]
         }
-        sortOrder="ascending"
         width={480}
         yDomain={
           Array [

--- a/ui-packages/packages/trusty/src/components/Templates/Explanation/Explanation.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/Explanation/Explanation.tsx
@@ -51,11 +51,10 @@ const Explanation = ({ outcomes }: ExplanationProps) => {
   const [outcomeId, setOutcomeId] = useState<string | null>(null);
   const outcomeDetail = useOutcomeDetail(executionId, outcomeId);
   const saliencies = useSaliencies(executionId);
-  const {
-    featuresScores,
-    topFeaturesScores,
-    topFeaturesScoresBySign
-  } = useFeaturesScores(saliencies, outcomeId);
+  const { featuresScores, topFeaturesScoresBySign } = useFeaturesScores(
+    saliencies,
+    outcomeId
+  );
   const [displayChart, setDisplayChart] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const history = useHistory();
@@ -276,8 +275,8 @@ const Explanation = ({ outcomes }: ExplanationProps) => {
                         {saliencies.status === RemoteDataStatus.SUCCESS && (
                           <FeaturesScoreTable
                             featuresScore={
-                              topFeaturesScores.length > 0
-                                ? topFeaturesScores
+                              topFeaturesScoresBySign.length > 0
+                                ? topFeaturesScoresBySign
                                 : featuresScores
                             }
                           />


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/FAI-450

The PR fixes the order of the feature score chart labels. It also fixes the values displayed inside the features scores table.