### PR TITLE
[KOGITO-4948] Reduce number of termination steps and unit test repetitions

### DIFF
--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -65,7 +65,7 @@ class CounterfactualExplainerTest {
 
     final long predictionTimeOut = 10L;
     final TimeUnit predictionTimeUnit = TimeUnit.MINUTES;
-    final Long steps = 200_000L;
+    final Long steps = 30_000L;
 
     private static final Logger logger =
             LoggerFactory.getLogger(CounterfactualExplainerTest.class);
@@ -94,7 +94,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testNonEmptyInput(int seed) throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
         random.setSeed(seed);
@@ -139,7 +139,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testCounterfactualMatch(int seed) throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
         random.setSeed(seed);
@@ -186,7 +186,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testCounterfactualConstrainedMatchUnscaled(int seed)
             throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
@@ -238,7 +238,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testCounterfactualConstrainedMatchScaled(int seed) throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
         random.setSeed(seed);
@@ -303,7 +303,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testCounterfactualBoolean(int seed) throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
         random.setSeed(seed);
@@ -347,7 +347,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testCounterfactualCategorical(int seed) throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
         random.setSeed(seed);
@@ -414,7 +414,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testCounterfactualMatchThreshold(int seed) throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
         random.setSeed(seed);
@@ -475,7 +475,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testCounterfactualMatchNoThreshold(int seed) throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
         random.setSeed(seed);
@@ -534,7 +534,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testNoCounterfactualPossible(int seed)
             throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
@@ -578,7 +578,7 @@ class CounterfactualExplainerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 0, 1, 2, 3, 4 })
+    @ValueSource(ints = { 0, 1, 2 })
     void testConsumers(int seed) throws ExecutionException, InterruptedException, TimeoutException {
         Random random = new Random();
         random.setSeed(seed);


### PR DESCRIPTION
[KOGITO-4948](https://issues.redhat.com/browse/KOGITO-4948):

This reduces the number of steps for termination and the number of test repetitions.
The counterfactual tests now take (locally) ~16 seconds, down from the previous ~3 minutes, without impact to the test quality.

See also https://github.com/kiegroup/kogito-apps/pull/762.

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket
> 

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>