### PR TITLE
KOGITO-4498_mock-date-time

### DIFF
--- a/ui-packages/packages/management-console/src/components/Molecules/ProcessListChildTable/tests/ProcessListChildTable.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Molecules/ProcessListChildTable/tests/ProcessListChildTable.test.tsx
@@ -9,7 +9,7 @@ import { act } from 'react-dom/test-utils';
 jest.mock('../../../Atoms/ErrorPopover/ErrorPopover');
 jest.mock('../../DisablePopup/DisablePopup');
 jest.mock('../../../Atoms/ProcessListActionsKebab/ProcessListActionsKebab');
-
+Date.now = jest.fn(() => 1592000000000); // UTC Fri Jun 12 2020 22:13:20
 describe('Process List Child Table tests', () => {
   const childData = {
     id: 'e4448857-fa0c-403b-ad69-f0a353458b9d',

--- a/ui-packages/packages/management-console/src/components/Molecules/ProcessListChildTable/tests/__snapshots__/ProcessListChildTable.test.tsx.snap
+++ b/ui-packages/packages/management-console/src/components/Molecules/ProcessListChildTable/tests/__snapshots__/ProcessListChildTable.test.tsx.snap
@@ -6132,7 +6132,7 @@ exports[`Process List Child Table tests snapshot of children in table 1`] = `
                                                 <time
                                                   dateTime={"2019-10-22T03:40:44.089Z"}
                                                 >
-                                                  a year ago
+                                                  8 months ago
                                                 </time>
                                               </t>
                                             </td>
@@ -6218,7 +6218,7 @@ exports[`Process List Child Table tests snapshot of children in table 1`] = `
                                                   <time
                                                     dateTime={"2019-10-22T03:40:44.089Z"}
                                                   >
-                                                    a year ago
+                                                    8 months ago
                                                   </time>
                                                 </t>
                                               </span>

--- a/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/tests/ProcessListTable.test.tsx
+++ b/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/tests/ProcessListTable.test.tsx
@@ -13,7 +13,7 @@ jest.mock('../../../Atoms/ProcessListModal/ProcessListModal');
 jest.mock('../../../Atoms/ErrorPopover/ErrorPopover');
 jest.mock('../../../Molecules/DisablePopup/DisablePopup');
 jest.mock('../../../Atoms/ProcessListActionsKebab/ProcessListActionsKebab');
-
+Date.now = jest.fn(() => 1592000000000); // UTC Fri Jun 12 2020 22:13:20
 const data = {
   ProcessInstances: [
     {

--- a/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/tests/__snapshots__/ProcessListTable.test.tsx.snap
+++ b/ui-packages/packages/management-console/src/components/Organisms/ProcessListTable/tests/__snapshots__/ProcessListTable.test.tsx.snap
@@ -1080,7 +1080,7 @@ exports[`ProcessListPage tests snapshot test for disabled process and non "error
                             <time
                               dateTime={"2019-10-22T03:40:44.089Z"}
                             >
-                              a year ago
+                              8 months ago
                             </time>
                           </t>
                         </td>
@@ -1144,7 +1144,7 @@ exports[`ProcessListPage tests snapshot test for disabled process and non "error
                               <time
                                 dateTime={"2019-10-22T03:40:44.089Z"}
                               >
-                                a year ago
+                                8 months ago
                               </time>
                             </t>
                           </span>
@@ -1721,7 +1721,7 @@ exports[`ProcessListPage tests snapshot test for disabled process and non "error
                             <time
                               dateTime={"2019-10-22T03:40:44.089Z"}
                             >
-                              a year ago
+                              8 months ago
                             </time>
                           </t>
                         </td>
@@ -1785,7 +1785,7 @@ exports[`ProcessListPage tests snapshot test for disabled process and non "error
                               <time
                                 dateTime={"2019-10-22T03:40:44.089Z"}
                               >
-                                a year ago
+                                8 months ago
                               </time>
                             </t>
                           </span>
@@ -3111,7 +3111,7 @@ exports[`ProcessListPage tests snapshot test for process list - without expanded
                             <time
                               dateTime={"2019-10-22T03:40:44.089Z"}
                             >
-                              a year ago
+                              8 months ago
                             </time>
                           </t>
                         </td>
@@ -3175,7 +3175,7 @@ exports[`ProcessListPage tests snapshot test for process list - without expanded
                               <time
                                 dateTime={"2019-10-22T03:40:44.089Z"}
                               >
-                                a year ago
+                                8 months ago
                               </time>
                             </t>
                           </span>
@@ -3756,7 +3756,7 @@ exports[`ProcessListPage tests snapshot test for process list - without expanded
                             <time
                               dateTime={"2019-10-22T03:40:44.089Z"}
                             >
-                              a year ago
+                              8 months ago
                             </time>
                           </t>
                         </td>
@@ -3820,7 +3820,7 @@ exports[`ProcessListPage tests snapshot test for process list - without expanded
                               <time
                                 dateTime={"2019-10-22T03:40:44.089Z"}
                               >
-                                a year ago
+                                8 months ago
                               </time>
                             </t>
                           </span>


### PR DESCRIPTION
Mocked date-time in tests of ProcessListTable and ProcessListChildTable to prevent snapshot failures.