### PR TITLE
KOGITO-5053 Lower termination count

### DIFF
--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -660,7 +660,7 @@ class CounterfactualExplainerTest {
         PredictionProvider model = TestUtils.getSumThresholdModel(center, epsilon);
 
         final TerminationConfig terminationConfig =
-                new TerminationConfig().withBestScoreFeasible(true).withScoreCalculationCountLimit(100_000L);
+                new TerminationConfig().withBestScoreFeasible(true).withScoreCalculationCountLimit(1000L);
         final SolverConfig solverConfig = CounterfactualConfigurationFactory
                 .builder().withTerminationConfig(terminationConfig).build();
 

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualExplainerTest.java
@@ -660,7 +660,7 @@ class CounterfactualExplainerTest {
         PredictionProvider model = TestUtils.getSumThresholdModel(center, epsilon);
 
         final TerminationConfig terminationConfig =
-                new TerminationConfig().withBestScoreFeasible(true).withScoreCalculationCountLimit(1000L);
+                new TerminationConfig().withBestScoreFeasible(true).withScoreCalculationCountLimit(10_000L);
         final SolverConfig solverConfig = CounterfactualConfigurationFactory
                 .builder().withTerminationConfig(terminationConfig).build();
 


### PR DESCRIPTION
Current CF intermediate ids test termination steps were too conservative (too high in order to guarantee intermediate results being produced), but were causing timeouts. This new lower value should guarantee intermediate results and avoid timeouts.

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>