### PR TITLE
[FAI-493] Build trusty UI image during kogito-apps build

### DIFF
--- a/trusty-ui/pom.xml
+++ b/trusty-ui/pom.xml
@@ -18,6 +18,12 @@
   </properties>
 
   <dependencies>
+    <!-- Build container image -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-container-image-jib</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-web</artifactId>

--- a/trusty-ui/src/main/resources/application.properties
+++ b/trusty-ui/src/main/resources/application.properties
@@ -3,6 +3,10 @@ quarkus.package.type=uber-jar
 quarkus.http.cors=true
 kogito.trusty.http.url=${KOGITO_TRUSTY_HTTP_URL:http://localhost:8180}
 
+# Container image
+quarkus.container-image.build=${quarkus.build.image:true}
+quarkus.container-image.group=org.kie.kogito
+
 #oidc
 quarkus.oidc.enabled=true
 quarkus.oidc.tenant-enabled=false


### PR DESCRIPTION
As we are starting with implementation of POC of Cypress tests for Trusty GUI and it is planned to use real services and not only mocked data. We will need also container image for Tusty UI.