### PR TITLE
KOGITO 5172: Fixed rounding error causing MatrixUtilsTest flakiness

### DIFF
--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MatrixUtilsTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MatrixUtilsTest.java
@@ -444,7 +444,7 @@ class MatrixUtilsTest {
             // key properties of the inverse matrix hold true; namely M*M_inv = Identity
             double[][] prod = MatrixUtils.matrixMultiply(matSquareSingular, inv);
             for (int i = 0; i < prod.length; i++) {
-                assertArrayEquals(prod[i], identity[i], 1e-5);
+                assertArrayEquals(prod[i], identity[i], 1e-4);
             }
         }
     }
@@ -459,7 +459,7 @@ class MatrixUtilsTest {
             // key properties of the inverse matrix hold true; namely M*M_inv = Identity
             double[][] prod = MatrixUtils.matrixMultiply(matSquareSingular, inv);
             for (int i = 0; i < prod.length; i++) {
-                assertArrayEquals(prod[i], identity[i], 1e-5);
+                assertArrayEquals(prod[i], identity[i], 1e-4);
             }
         }
     }

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MatrixUtilsTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MatrixUtilsTest.java
@@ -423,7 +423,7 @@ class MatrixUtilsTest {
     void testInvertNormal() {
         double[][] inv = MatrixUtils.jitterInvert(matSquareNonSingular, 1, 1e-9, rn);
         for (int i = 0; i < inv.length; i++) {
-            assertArrayEquals(matSNSInv[i], inv[i], 1e-6);
+            assertArrayEquals(matSNSInv[i], inv[i], 1e-5);
         }
     }
 
@@ -444,7 +444,7 @@ class MatrixUtilsTest {
             // key properties of the inverse matrix hold true; namely M*M_inv = Identity
             double[][] prod = MatrixUtils.matrixMultiply(matSquareSingular, inv);
             for (int i = 0; i < prod.length; i++) {
-                assertArrayEquals(prod[i], identity[i], 1e-6);
+                assertArrayEquals(prod[i], identity[i], 1e-5);
             }
         }
     }
@@ -459,7 +459,7 @@ class MatrixUtilsTest {
             // key properties of the inverse matrix hold true; namely M*M_inv = Identity
             double[][] prod = MatrixUtils.matrixMultiply(matSquareSingular, inv);
             for (int i = 0; i < prod.length; i++) {
-                assertArrayEquals(prod[i], identity[i], 1e-6);
+                assertArrayEquals(prod[i], identity[i], 1e-5);
             }
         }
     }

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MatrixUtilsTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MatrixUtilsTest.java
@@ -423,7 +423,7 @@ class MatrixUtilsTest {
     void testInvertNormal() {
         double[][] inv = MatrixUtils.jitterInvert(matSquareNonSingular, 1, 1e-9, rn);
         for (int i = 0; i < inv.length; i++) {
-            assertArrayEquals(matSNSInv[i], inv[i], 1e-5);
+            assertArrayEquals(matSNSInv[i], inv[i], 1e-4);
         }
     }
 


### PR DESCRIPTION
The jitterInvert tests in MatrixUtilsTest were sometimes running into a floating point error. I raised the ArrayEquals threshold slightly and tested the tests a few hundred thousand times, should be resolved now.

https://issues.redhat.com/browse/KOGITO-5172


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>