### PR TITLE
KOGITO-5176 - Retrieved decision input components set to null in case of unit type

### DIFF
--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/AbstractTrustyServiceIT.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/AbstractTrustyServiceIT.java
@@ -430,6 +430,7 @@ public abstract class AbstractTrustyServiceIT {
         decision.setInputs(Collections.singletonList(decisionInput));
 
         trustyService.storeDecision(decision.getExecutionId(), decision);
+        return decision;
     }
 
     private void storeModel(String model) {

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/main/java/org/kie/kogito/trusty/storage/infinispan/TypedVariableWithValueMarshaller.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/main/java/org/kie/kogito/trusty/storage/infinispan/TypedVariableWithValueMarshaller.java
@@ -31,12 +31,15 @@ public class TypedVariableWithValueMarshaller extends AbstractModelMarshaller<Ty
 
     @Override
     public TypedVariableWithValue readFrom(ProtoStreamReader reader) throws IOException {
+        Kind kind = enumFromString(reader.readString(TypedVariableWithValue.KIND_FIELD), Kind.class);
+        ArrayList<TypedVariableWithValue> components = reader.readCollection(TypedVariableWithValue.COMPONENTS_FIELD, new ArrayList<>(), TypedVariableWithValue.class);
+
         return new TypedVariableWithValue(
-                enumFromString(reader.readString(TypedVariableWithValue.KIND_FIELD), Kind.class),
+                kind,
                 reader.readString(TypedVariableWithValue.NAME_FIELD),
                 reader.readString(TypedVariableWithValue.TYPE_REF_FIELD),
                 jsonFromString(reader.readString(TypedVariableWithValue.VALUE_FIELD)),
-                reader.readCollection(TypedVariableWithValue.COMPONENTS_FIELD, new ArrayList<>(), TypedVariableWithValue.class));
+                Kind.UNIT.equals(kind) ? null : components);
     }
 
     @Override

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/TypedVariableWithValueMarshallerTest.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/TypedVariableWithValueMarshallerTest.java
@@ -15,7 +15,6 @@
  */
 package org.kie.kogito.trusty.storage.infinispan;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.infinispan.protostream.MessageMarshaller;
@@ -42,7 +41,7 @@ public class TypedVariableWithValueMarshallerTest extends MarshallerTestTemplate
             new StringTestField<>(NAME_FIELD, "testName", TypedVariableWithValue::getName, TypedVariableWithValue::setName),
             new StringTestField<>(TYPE_REF_FIELD, "testTypeRef", TypedVariableWithValue::getTypeRef, TypedVariableWithValue::setTypeRef),
             new JsonNodeTestField<>(VALUE_FIELD, null, TypedVariableWithValue::getValue, TypedVariableWithValue::setValue),
-            new CollectionTestField<>(COMPONENTS_FIELD, Collections.emptyList(), TypedVariableWithValue::getComponents, TypedVariableWithValue::setComponents, TypedVariableWithValue.class));
+            new CollectionTestField<>(COMPONENTS_FIELD, null, TypedVariableWithValue::getComponents, TypedVariableWithValue::setComponents, TypedVariableWithValue.class));
 
     public TypedVariableWithValueMarshallerTest() {
         super(TypedVariableWithValue.class);


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5176

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>