### PR TITLE
[1.7.x] KOGITO-5176 - Retrieved decision input components set to null in case of unit type

### DIFF
--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/AbstractTrustyServiceIT.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/AbstractTrustyServiceIT.java
@@ -416,9 +416,6 @@ public abstract class AbstractTrustyServiceIT {
         Decision decision = new Decision();
         decision.setExecutionId(executionId);
         decision.setExecutionTimestamp(timestamp);
-        decision.setServiceUrl("serviceUrl");
-        decision.setExecutedModelNamespace("executedModelNamespace");
-        decision.setExecutedModelName("executedModelName");
         decision.setInputs(Collections.singletonList(decisionInput));
 
         trustyService.storeDecision(decision.getExecutionId(), decision);

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/AbstractTrustyServiceIT.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/AbstractTrustyServiceIT.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.tracing.typedvalue.TypedValue;
 import org.kie.kogito.trusty.service.common.messaging.incoming.ModelIdentifier;
 import org.kie.kogito.trusty.service.common.models.MatchedExecutionHeaders;
 import org.kie.kogito.trusty.storage.api.model.CounterfactualDomain;
@@ -39,6 +40,7 @@ import org.kie.kogito.trusty.storage.api.model.CounterfactualExplainabilityResul
 import org.kie.kogito.trusty.storage.api.model.CounterfactualSearchDomain;
 import org.kie.kogito.trusty.storage.api.model.DMNModelWithMetadata;
 import org.kie.kogito.trusty.storage.api.model.Decision;
+import org.kie.kogito.trusty.storage.api.model.DecisionInput;
 import org.kie.kogito.trusty.storage.api.model.ExplainabilityStatus;
 import org.kie.kogito.trusty.storage.api.model.FeatureImportanceModel;
 import org.kie.kogito.trusty.storage.api.model.LIMEExplainabilityResult;
@@ -48,6 +50,7 @@ import org.kie.kogito.trusty.storage.common.TrustyStorageService;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -113,6 +116,15 @@ public abstract class AbstractTrustyServiceIT {
 
         Decision result = trustyService.getDecisionById(executionId);
         Assertions.assertEquals(executionId, result.getExecutionId());
+    }
+
+    @Test
+    public void givenAnExecutionWhenGetDecisionByIdThenTheComponentsInUnitTypesIsNull() {
+        String executionId = "myExecution";
+        storeExecution(executionId, 1591692950000L);
+
+        Decision result = trustyService.getDecisionById(executionId);
+        Assertions.assertNull(result.getInputs().stream().findFirst().get().getValue().getComponents());
     }
 
     @Test
@@ -396,9 +408,19 @@ public abstract class AbstractTrustyServiceIT {
     }
 
     private Decision storeExecution(String executionId, Long timestamp) {
+        DecisionInput decisionInput = new DecisionInput();
+        decisionInput.setId("inputId");
+        decisionInput.setName("inputName");
+        decisionInput.setValue(new TypedVariableWithValue(TypedValue.Kind.UNIT, "test", "number", JsonNodeFactory.instance.numberNode(10), null));
+
         Decision decision = new Decision();
         decision.setExecutionId(executionId);
         decision.setExecutionTimestamp(timestamp);
+        decision.setServiceUrl("serviceUrl");
+        decision.setExecutedModelNamespace("executedModelNamespace");
+        decision.setExecutedModelName("executedModelName");
+        decision.setInputs(Collections.singletonList(decisionInput));
+
         trustyService.storeDecision(decision.getExecutionId(), decision);
         return decision;
     }

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/main/java/org/kie/kogito/trusty/storage/infinispan/TypedVariableWithValueMarshaller.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/main/java/org/kie/kogito/trusty/storage/infinispan/TypedVariableWithValueMarshaller.java
@@ -31,12 +31,15 @@ public class TypedVariableWithValueMarshaller extends AbstractModelMarshaller<Ty
 
     @Override
     public TypedVariableWithValue readFrom(ProtoStreamReader reader) throws IOException {
+        Kind kind = enumFromString(reader.readString(TypedVariableWithValue.KIND_FIELD), Kind.class);
+        ArrayList<TypedVariableWithValue> components = reader.readCollection(TypedVariableWithValue.COMPONENTS_FIELD, new ArrayList<>(), TypedVariableWithValue.class);
+
         return new TypedVariableWithValue(
-                enumFromString(reader.readString(TypedVariableWithValue.KIND_FIELD), Kind.class),
+                kind,
                 reader.readString(TypedVariableWithValue.NAME_FIELD),
                 reader.readString(TypedVariableWithValue.TYPE_REF_FIELD),
                 jsonFromString(reader.readString(TypedVariableWithValue.VALUE_FIELD)),
-                reader.readCollection(TypedVariableWithValue.COMPONENTS_FIELD, new ArrayList<>(), TypedVariableWithValue.class));
+                Kind.UNIT.equals(kind) ? null : components);
     }
 
     @Override

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/TypedVariableWithValueMarshallerTest.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/TypedVariableWithValueMarshallerTest.java
@@ -15,7 +15,6 @@
  */
 package org.kie.kogito.trusty.storage.infinispan;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.infinispan.protostream.MessageMarshaller;
@@ -42,7 +41,7 @@ public class TypedVariableWithValueMarshallerTest extends MarshallerTestTemplate
             new StringTestField<>(NAME_FIELD, "testName", TypedVariableWithValue::getName, TypedVariableWithValue::setName),
             new StringTestField<>(TYPE_REF_FIELD, "testTypeRef", TypedVariableWithValue::getTypeRef, TypedVariableWithValue::setTypeRef),
             new JsonNodeTestField<>(VALUE_FIELD, null, TypedVariableWithValue::getValue, TypedVariableWithValue::setValue),
-            new CollectionTestField<>(COMPONENTS_FIELD, Collections.emptyList(), TypedVariableWithValue::getComponents, TypedVariableWithValue::setComponents, TypedVariableWithValue.class));
+            new CollectionTestField<>(COMPONENTS_FIELD, null, TypedVariableWithValue::getComponents, TypedVariableWithValue::setComponents, TypedVariableWithValue.class));
 
     public TypedVariableWithValueMarshallerTest() {
         super(TypedVariableWithValue.class);


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5176

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>