### PR TITLE
[KOGITO-5187] Group kie7 dependencies in a reusable internal BOM

### DIFF
--- a/explainability/explainability-integrationtests/explainability-integrationtests-pmml/pom.xml
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-pmml/pom.xml
@@ -9,7 +9,19 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>explainability-integrationtests-pmml</artifactId>
   <name>Kogito Apps :: Explainability Integration Tests PMML</name>
-  
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-kie7-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -20,7 +32,6 @@
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-mvel</artifactId>
-      <version>${version.org.kie7}</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/jitexecutor/jitexecutor-dmn/pom.xml
+++ b/jitexecutor/jitexecutor-dmn/pom.xml
@@ -10,6 +10,18 @@
   <artifactId>jitexecutor-dmn</artifactId>
   <name>Kogito Apps :: JIT Executor DMN</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.kie.kogito</groupId>
+        <artifactId>kogito-kie7-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5187

PRs:
- https://github.com/kiegroup/kogito-runtimes/pull/1329
- https://github.com/kiegroup/optaplanner/pull/1336
- https://github.com/kiegroup/kogito-apps/pull/840
- https://github.com/kiegroup/kogito-pipelines/pull/175

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>