### PR TITLE
FAI-499: Trusty UI - fix regular Red Hat Text font usage

### DIFF
--- a/ui-packages/packages/trusty/src/index.css
+++ b/ui-packages/packages/trusty/src/index.css
@@ -1,15 +1,7 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
 }
 
 #root {

--- a/ui-packages/packages/trusty/src/index.html
+++ b/ui-packages/packages/trusty/src/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
-  <body class="pf-m-redhat-font">
+  <body>
     <noscript>Enabling JavaScript is required to run this app.</noscript>
     <div id="root"></div>
   </body>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/FAI-499

This is barely noticeable but I realized we are not using Red Hat Text across trusty.
Some CSS carried over from CRA (used in the original PoC) is preventing it. Now removed.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>