### PR TITLE
FAI-480: CF request/result/prediction: Do not abuse "inputs" and "outputs"

### DIFF
--- a/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/BaseExplainabilityRequestDto.java
+++ b/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/BaseExplainabilityRequestDto.java
@@ -15,14 +15,11 @@
  */
 package org.kie.kogito.explainability.api;
 
-import java.util.Map;
 import java.util.Objects;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-
-import org.kie.kogito.tracing.typedvalue.TypedValue;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -54,27 +51,15 @@ public abstract class BaseExplainabilityRequestDto {
     @Valid
     private ModelIdentifierDto modelIdentifier;
 
-    @JsonProperty("inputs")
-    @NotNull(message = "inputs object must be provided.")
-    private Map<String, TypedValue> inputs;
-
-    @JsonProperty("outputs")
-    @NotNull(message = "outputs object must be provided.")
-    private Map<String, TypedValue> outputs;
-
     protected BaseExplainabilityRequestDto() {
     }
 
     public BaseExplainabilityRequestDto(@NotNull String executionId,
             @NotBlank String serviceUrl,
-            @NotNull ModelIdentifierDto modelIdentifier,
-            @NotNull Map<String, TypedValue> inputs,
-            @NotNull Map<String, TypedValue> outputs) {
+            @NotNull ModelIdentifierDto modelIdentifier) {
         this.executionId = Objects.requireNonNull(executionId);
         this.serviceUrl = Objects.requireNonNull(serviceUrl);
         this.modelIdentifier = Objects.requireNonNull(modelIdentifier);
-        this.inputs = Objects.requireNonNull(inputs);
-        this.outputs = Objects.requireNonNull(outputs);
     }
 
     public String getExecutionId() {
@@ -89,11 +74,4 @@ public abstract class BaseExplainabilityRequestDto {
         return modelIdentifier;
     }
 
-    public Map<String, TypedValue> getInputs() {
-        return inputs;
-    }
-
-    public Map<String, TypedValue> getOutputs() {
-        return outputs;
-    }
 }

--- a/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/CounterfactualExplainabilityRequestDto.java
+++ b/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/CounterfactualExplainabilityRequestDto.java
@@ -39,6 +39,14 @@ public class CounterfactualExplainabilityRequestDto extends BaseExplainabilityRe
     @NotNull(message = "counterfactualId must be provided.")
     private String counterfactualId;
 
+    @JsonProperty("originalInputs")
+    @NotNull(message = "originalInputs object must be provided.")
+    private Map<String, TypedValue> originalInputs;
+
+    @JsonProperty("goals")
+    @NotNull(message = "goals object must be provided.")
+    private Map<String, TypedValue> goals;
+
     @JsonProperty(SEARCH_DOMAINS_FIELD)
     @NotNull(message = "searchDomains object must be provided.")
     private Map<String, CounterfactualSearchDomainDto> searchDomains;
@@ -51,16 +59,26 @@ public class CounterfactualExplainabilityRequestDto extends BaseExplainabilityRe
             @NotNull String counterfactualId,
             @NotBlank String serviceUrl,
             @NotNull ModelIdentifierDto modelIdentifier,
-            @NotNull Map<String, TypedValue> inputs,
-            @NotNull Map<String, TypedValue> outputs,
+            @NotNull Map<String, TypedValue> originalInputs,
+            @NotNull Map<String, TypedValue> goals,
             @NotNull Map<String, CounterfactualSearchDomainDto> searchDomains) {
-        super(executionId, serviceUrl, modelIdentifier, inputs, outputs);
+        super(executionId, serviceUrl, modelIdentifier);
         this.counterfactualId = Objects.requireNonNull(counterfactualId);
+        this.originalInputs = Objects.requireNonNull(originalInputs);
+        this.goals = Objects.requireNonNull(goals);
         this.searchDomains = Objects.requireNonNull(searchDomains);
     }
 
     public String getCounterfactualId() {
         return counterfactualId;
+    }
+
+    public Map<String, TypedValue> getOriginalInputs() {
+        return originalInputs;
+    }
+
+    public Map<String, TypedValue> getGoals() {
+        return goals;
     }
 
     public Map<String, CounterfactualSearchDomainDto> getSearchDomains() {

--- a/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/LIMEExplainabilityRequestDto.java
+++ b/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/LIMEExplainabilityRequestDto.java
@@ -16,15 +16,26 @@
 package org.kie.kogito.explainability.api;
 
 import java.util.Map;
+import java.util.Objects;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import org.kie.kogito.tracing.typedvalue.TypedValue;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class LIMEExplainabilityRequestDto extends BaseExplainabilityRequestDto {
 
     public static final String EXPLAINABILITY_TYPE_NAME = "LIME";
+
+    @JsonProperty("inputs")
+    @NotNull(message = "inputs object must be provided.")
+    private Map<String, TypedValue> inputs;
+
+    @JsonProperty("outputs")
+    @NotNull(message = "outputs object must be provided.")
+    private Map<String, TypedValue> outputs;
 
     private LIMEExplainabilityRequestDto() {
         super();
@@ -35,6 +46,17 @@ public class LIMEExplainabilityRequestDto extends BaseExplainabilityRequestDto {
             @NotNull ModelIdentifierDto modelIdentifier,
             @NotNull Map<String, TypedValue> inputs,
             @NotNull Map<String, TypedValue> outputs) {
-        super(executionId, serviceUrl, modelIdentifier, inputs, outputs);
+        super(executionId, serviceUrl, modelIdentifier);
+        this.inputs = Objects.requireNonNull(inputs);
+        this.outputs = Objects.requireNonNull(outputs);
     }
+
+    public Map<String, TypedValue> getInputs() {
+        return inputs;
+    }
+
+    public Map<String, TypedValue> getOutputs() {
+        return outputs;
+    }
+
 }

--- a/explainability/explainability-service-rest/src/test/java/org/kie/kogito/explainability/rest/PredictionProviderFactoryMock.java
+++ b/explainability/explainability-service-rest/src/test/java/org/kie/kogito/explainability/rest/PredictionProviderFactoryMock.java
@@ -15,11 +15,14 @@
  */
 package org.kie.kogito.explainability.rest;
 
+import java.util.Map;
+
 import javax.enterprise.context.ApplicationScoped;
 
 import org.kie.kogito.explainability.PredictionProviderFactory;
 import org.kie.kogito.explainability.model.PredictionProvider;
-import org.kie.kogito.explainability.models.BaseExplainabilityRequest;
+import org.kie.kogito.explainability.models.ModelIdentifier;
+import org.kie.kogito.tracing.typedvalue.TypedValue;
 
 import io.quarkus.test.Mock;
 
@@ -28,7 +31,9 @@ import io.quarkus.test.Mock;
 public class PredictionProviderFactoryMock implements PredictionProviderFactory {
 
     @Override
-    public PredictionProvider createPredictionProvider(BaseExplainabilityRequest request) {
+    public PredictionProvider createPredictionProvider(String serviceUrl,
+            ModelIdentifier modelIdentifier,
+            Map<String, TypedValue> predictionOutputs) {
         return new PredictionProviderMock();
     }
 }

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/PredictionProviderFactory.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/PredictionProviderFactory.java
@@ -16,10 +16,15 @@
 
 package org.kie.kogito.explainability;
 
+import java.util.Map;
+
 import org.kie.kogito.explainability.model.PredictionProvider;
-import org.kie.kogito.explainability.models.BaseExplainabilityRequest;
+import org.kie.kogito.explainability.models.ModelIdentifier;
+import org.kie.kogito.tracing.typedvalue.TypedValue;
 
 public interface PredictionProviderFactory {
 
-    PredictionProvider createPredictionProvider(BaseExplainabilityRequest request);
+    PredictionProvider createPredictionProvider(String serviceUrl,
+            ModelIdentifier modelIdentifier,
+            Map<String, TypedValue> predictionOutputs);
 }

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/PredictionProviderFactoryImpl.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/PredictionProviderFactoryImpl.java
@@ -16,13 +16,16 @@
 
 package org.kie.kogito.explainability;
 
+import java.util.Map;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.kie.kogito.explainability.model.PredictionProvider;
-import org.kie.kogito.explainability.models.BaseExplainabilityRequest;
+import org.kie.kogito.explainability.models.ModelIdentifier;
+import org.kie.kogito.tracing.typedvalue.TypedValue;
 
 import io.vertx.mutiny.core.Vertx;
 
@@ -45,7 +48,14 @@ public class PredictionProviderFactoryImpl implements PredictionProviderFactory 
     }
 
     @Override
-    public PredictionProvider createPredictionProvider(BaseExplainabilityRequest request) {
-        return new RemotePredictionProvider(request, vertx, threadContext, managedExecutor);
+    public PredictionProvider createPredictionProvider(String serviceUrl,
+            ModelIdentifier modelIdentifier,
+            Map<String, TypedValue> predictionOutputs) {
+        return new RemotePredictionProvider(serviceUrl,
+                modelIdentifier,
+                predictionOutputs,
+                vertx,
+                threadContext,
+                managedExecutor);
     }
 }

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerServiceHandler.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerServiceHandler.java
@@ -28,6 +28,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.kie.kogito.explainability.ConversionUtils;
+import org.kie.kogito.explainability.PredictionProviderFactory;
 import org.kie.kogito.explainability.api.BaseExplainabilityRequestDto;
 import org.kie.kogito.explainability.api.BaseExplainabilityResultDto;
 import org.kie.kogito.explainability.api.CounterfactualExplainabilityRequestDto;
@@ -63,10 +64,13 @@ public class CounterfactualExplainerServiceHandler
         implements LocalExplainerServiceHandler<CounterfactualResult, CounterfactualExplainabilityRequest, CounterfactualExplainabilityRequestDto> {
 
     private final CounterfactualExplainer explainer;
+    private final PredictionProviderFactory predictionProviderFactory;
 
     @Inject
-    public CounterfactualExplainerServiceHandler(CounterfactualExplainer explainer) {
+    public CounterfactualExplainerServiceHandler(CounterfactualExplainer explainer,
+            PredictionProviderFactory predictionProviderFactory) {
         this.explainer = explainer;
+        this.predictionProviderFactory = predictionProviderFactory;
     }
 
     @Override
@@ -86,25 +90,32 @@ public class CounterfactualExplainerServiceHandler
                 dto.getCounterfactualId(),
                 dto.getServiceUrl(),
                 ModelIdentifier.from(dto.getModelIdentifier()),
-                dto.getInputs(),
-                dto.getOutputs(),
+                dto.getOriginalInputs(),
+                dto.getGoals(),
                 dto.getSearchDomains());
     }
 
     @Override
+    public PredictionProvider getPredictionProvider(CounterfactualExplainabilityRequest request) {
+        return predictionProviderFactory.createPredictionProvider(request.getServiceUrl(),
+                request.getModelIdentifier(),
+                request.getGoals());
+    }
+
+    @Override
     public Prediction getPrediction(CounterfactualExplainabilityRequest request) {
-        Map<String, TypedValue> originalInputs = request.getInputs();
-        Map<String, TypedValue> requiredOutputs = request.getOutputs();
+        Map<String, TypedValue> originalInputs = request.getOriginalInputs();
+        Map<String, TypedValue> goals = request.getGoals();
         Map<String, CounterfactualSearchDomainDto> searchDomains = request.getSearchDomains();
 
         // If the incoming is not flat we cannot perform CF on it so fail fast
         // See https://issues.redhat.com/browse/FAI-473 and https://issues.redhat.com/browse/FAI-474
-        if (isUnsupportedModel(originalInputs, requiredOutputs, searchDomains)) {
+        if (isUnsupportedModel(originalInputs, goals, searchDomains)) {
             throw new IllegalArgumentException("Counterfactual explanations only support flat models.");
         }
 
         PredictionInput input = new PredictionInput(toFeatureList(originalInputs));
-        PredictionOutput output = new PredictionOutput(toOutputList(requiredOutputs));
+        PredictionOutput output = new PredictionOutput(toOutputList(goals));
         PredictionFeatureDomain featureDomain = new PredictionFeatureDomain(toFeatureDomainList(searchDomains));
         List<Boolean> featureConstraints = toFeatureConstraintList(searchDomains);
 

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/LimeExplainerServiceHandler.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/LimeExplainerServiceHandler.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.kie.kogito.explainability.PredictionProviderFactory;
 import org.kie.kogito.explainability.api.BaseExplainabilityRequestDto;
 import org.kie.kogito.explainability.api.BaseExplainabilityResultDto;
 import org.kie.kogito.explainability.api.FeatureImportanceDto;
@@ -48,10 +49,13 @@ import static org.kie.kogito.explainability.ConversionUtils.toOutputList;
 public class LimeExplainerServiceHandler implements LocalExplainerServiceHandler<Map<String, Saliency>, LIMEExplainabilityRequest, LIMEExplainabilityRequestDto> {
 
     private final LimeExplainer explainer;
+    private final PredictionProviderFactory predictionProviderFactory;
 
     @Inject
-    public LimeExplainerServiceHandler(LimeExplainer explainer) {
+    public LimeExplainerServiceHandler(LimeExplainer explainer,
+            PredictionProviderFactory predictionProviderFactory) {
         this.explainer = explainer;
+        this.predictionProviderFactory = predictionProviderFactory;
     }
 
     @Override
@@ -72,6 +76,13 @@ public class LimeExplainerServiceHandler implements LocalExplainerServiceHandler
                 ModelIdentifier.from(dto.getModelIdentifier()),
                 dto.getInputs(),
                 dto.getOutputs());
+    }
+
+    @Override
+    public PredictionProvider getPredictionProvider(LIMEExplainabilityRequest request) {
+        return predictionProviderFactory.createPredictionProvider(request.getServiceUrl(),
+                request.getModelIdentifier(),
+                request.getOutputs());
     }
 
     @Override

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/LocalExplainerServiceHandler.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/LocalExplainerServiceHandler.java
@@ -72,6 +72,14 @@ public interface LocalExplainerServiceHandler<T, R extends BaseExplainabilityReq
     Prediction getPrediction(R request);
 
     /**
+     * Gets a PredictionProvider object from the request for the LocalExplainer.
+     *
+     * @param request The explanation request.
+     * @return A PredictionProvider object.
+     */
+    PredictionProvider getPredictionProvider(R request);
+
+    /**
      * Requests calculation of an explanation decorated with both "success" and "failure" result handlers.
      * See:
      * - {@link LocalExplainer#explainAsync}
@@ -79,14 +87,13 @@ public interface LocalExplainerServiceHandler<T, R extends BaseExplainabilityReq
      * - {@link LocalExplainerServiceHandler#createFailedResultDto(BaseExplainabilityRequest, Throwable)}
      *
      * @param request The explanation request.
-     * @param predictionProvider The prediction model to explain. See {@link PredictionProvider}
      * @param intermediateResultsConsumer A consumer for intermediate results provided by the explainer.
      * @return
      */
     default CompletableFuture<BaseExplainabilityResultDto> explainAsyncWithResults(R request,
-            PredictionProvider predictionProvider,
             Consumer<BaseExplainabilityResultDto> intermediateResultsConsumer) {
         Prediction prediction = getPrediction(request);
+        PredictionProvider predictionProvider = getPredictionProvider(request);
         return explainAsync(prediction,
                 predictionProvider,
                 s -> intermediateResultsConsumer.accept(createIntermediateResultDto(request, s)))

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/LocalExplainerServiceHandlerRegistry.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/LocalExplainerServiceHandlerRegistry.java
@@ -24,11 +24,9 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
-import org.kie.kogito.explainability.PredictionProviderFactory;
 import org.kie.kogito.explainability.api.BaseExplainabilityRequestDto;
 import org.kie.kogito.explainability.api.BaseExplainabilityResultDto;
 import org.kie.kogito.explainability.local.LocalExplainer;
-import org.kie.kogito.explainability.model.PredictionProvider;
 import org.kie.kogito.explainability.models.BaseExplainabilityRequest;
 
 @ApplicationScoped
@@ -36,7 +34,6 @@ public class LocalExplainerServiceHandlerRegistry {
 
     public static final String SERVICE_HANDLER_NOT_FOUND_ERROR_MESSAGE = "LocalExplainerServiceHandler could not be found for '%s'";
 
-    private PredictionProviderFactory predictionProviderFactory;
     private Instance<LocalExplainerServiceHandler<?, ?, ?>> explanationHandlers;
 
     protected LocalExplainerServiceHandlerRegistry() {
@@ -44,9 +41,7 @@ public class LocalExplainerServiceHandlerRegistry {
     }
 
     @Inject
-    public LocalExplainerServiceHandlerRegistry(PredictionProviderFactory predictionProviderFactory,
-            @Any Instance<LocalExplainerServiceHandler<?, ?, ?>> explanationHandlers) {
-        this.predictionProviderFactory = predictionProviderFactory;
+    public LocalExplainerServiceHandlerRegistry(@Any Instance<LocalExplainerServiceHandler<?, ?, ?>> explanationHandlers) {
         this.explanationHandlers = explanationHandlers;
     }
 
@@ -81,9 +76,7 @@ public class LocalExplainerServiceHandlerRegistry {
                 .orElseThrow(() -> new IllegalArgumentException(String.format(SERVICE_HANDLER_NOT_FOUND_ERROR_MESSAGE, request.getClass().getName())));
 
         try {
-            PredictionProvider predictionProvider = predictionProviderFactory.createPredictionProvider(request);
             return explanationHandler.explainAsyncWithResults(cast(request),
-                    predictionProvider,
                     castConsumer(intermediateResultsConsumer));
         } catch (Exception e) {
             return CompletableFuture.completedFuture(explanationHandler.createFailedResultDto(cast(request), e));

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/models/BaseExplainabilityRequest.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/models/BaseExplainabilityRequest.java
@@ -16,28 +16,18 @@
 
 package org.kie.kogito.explainability.models;
 
-import java.util.Map;
-
-import org.kie.kogito.tracing.typedvalue.TypedValue;
-
 public abstract class BaseExplainabilityRequest {
 
     private final String executionId;
     private final String serviceUrl;
     private final ModelIdentifier modelIdentifier;
-    private final Map<String, TypedValue> inputs;
-    private final Map<String, TypedValue> outputs;
 
     protected BaseExplainabilityRequest(String executionId,
             String serviceUrl,
-            ModelIdentifier modelIdentifier,
-            Map<String, TypedValue> inputs,
-            Map<String, TypedValue> outputs) {
+            ModelIdentifier modelIdentifier) {
         this.executionId = executionId;
         this.serviceUrl = serviceUrl;
         this.modelIdentifier = modelIdentifier;
-        this.inputs = inputs;
-        this.outputs = outputs;
     }
 
     public String getExecutionId() {
@@ -52,11 +42,4 @@ public abstract class BaseExplainabilityRequest {
         return modelIdentifier;
     }
 
-    public Map<String, TypedValue> getInputs() {
-        return inputs;
-    }
-
-    public Map<String, TypedValue> getOutputs() {
-        return outputs;
-    }
 }

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/models/CounterfactualExplainabilityRequest.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/models/CounterfactualExplainabilityRequest.java
@@ -22,24 +22,35 @@ import org.kie.kogito.tracing.typedvalue.TypedValue;
 
 public class CounterfactualExplainabilityRequest extends BaseExplainabilityRequest {
 
-    private String counterfactualId;
-
-    private Map<String, CounterfactualSearchDomainDto> searchDomains;
+    private final String counterfactualId;
+    private final Map<String, TypedValue> originalInputs;
+    private final Map<String, TypedValue> goals;
+    private final Map<String, CounterfactualSearchDomainDto> searchDomains;
 
     public CounterfactualExplainabilityRequest(String executionId,
             String counterfactualId,
             String serviceUrl,
             ModelIdentifier modelIdentifier,
-            Map<String, TypedValue> inputs,
-            Map<String, TypedValue> outputs,
+            Map<String, TypedValue> originalInputs,
+            Map<String, TypedValue> goals,
             Map<String, CounterfactualSearchDomainDto> searchDomains) {
-        super(executionId, serviceUrl, modelIdentifier, inputs, outputs);
+        super(executionId, serviceUrl, modelIdentifier);
         this.counterfactualId = counterfactualId;
+        this.originalInputs = originalInputs;
+        this.goals = goals;
         this.searchDomains = searchDomains;
     }
 
     public String getCounterfactualId() {
         return counterfactualId;
+    }
+
+    public Map<String, TypedValue> getOriginalInputs() {
+        return originalInputs;
+    }
+
+    public Map<String, TypedValue> getGoals() {
+        return goals;
     }
 
     public Map<String, CounterfactualSearchDomainDto> getSearchDomains() {

--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/models/LIMEExplainabilityRequest.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/models/LIMEExplainabilityRequest.java
@@ -21,7 +21,21 @@ import org.kie.kogito.tracing.typedvalue.TypedValue;
 
 public class LIMEExplainabilityRequest extends BaseExplainabilityRequest {
 
+    private final Map<String, TypedValue> inputs;
+    private final Map<String, TypedValue> outputs;
+
     public LIMEExplainabilityRequest(String executionId, String serviceUrl, ModelIdentifier modelIdentifier, Map<String, TypedValue> inputs, Map<String, TypedValue> outputs) {
-        super(executionId, serviceUrl, modelIdentifier, inputs, outputs);
+        super(executionId, serviceUrl, modelIdentifier);
+        this.inputs = inputs;
+        this.outputs = outputs;
     }
+
+    public Map<String, TypedValue> getInputs() {
+        return inputs;
+    }
+
+    public Map<String, TypedValue> getOutputs() {
+        return outputs;
+    }
+
 }

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/ExplanationServiceImplTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/ExplanationServiceImplTest.java
@@ -81,15 +81,15 @@ class ExplanationServiceImplTest {
         instance = mock(Instance.class);
         limeExplainerMock = mock(LimeExplainer.class);
         cfExplainerMock = mock(CounterfactualExplainer.class);
-        limeExplainerServiceHandlerMock = spy(new LimeExplainerServiceHandler(limeExplainerMock));
-        cfExplainerServiceHandlerMock = spy(new CounterfactualExplainerServiceHandler(cfExplainerMock));
         PredictionProviderFactory predictionProviderFactory = mock(PredictionProviderFactory.class);
-        explainerServiceHandlerRegistryMock = new LocalExplainerServiceHandlerRegistry(predictionProviderFactory, instance);
+        explainerServiceHandlerRegistryMock = new LocalExplainerServiceHandlerRegistry(instance);
+        limeExplainerServiceHandlerMock = spy(new LimeExplainerServiceHandler(limeExplainerMock, predictionProviderFactory));
+        cfExplainerServiceHandlerMock = spy(new CounterfactualExplainerServiceHandler(cfExplainerMock, predictionProviderFactory));
 
         predictionProviderMock = mock(PredictionProvider.class);
         callbackMock = mock(Consumer.class);
         explanationService = new ExplanationServiceImpl(explainerServiceHandlerRegistryMock);
-        when(predictionProviderFactory.createPredictionProvider(any())).thenReturn(predictionProviderMock);
+        when(predictionProviderFactory.createPredictionProvider(any(), any(), any())).thenReturn(predictionProviderMock);
     }
 
     @Test

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/PredictionProviderFactoryImplTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/PredictionProviderFactoryImplTest.java
@@ -33,7 +33,9 @@ class PredictionProviderFactoryImplTest {
                 Vertx.vertx(),
                 ThreadContext.builder().build(),
                 ManagedExecutor.builder().build());
-        PredictionProvider predictionProvider = factory.createPredictionProvider(LIME_REQUEST);
+        PredictionProvider predictionProvider = factory.createPredictionProvider(LIME_REQUEST.getServiceUrl(),
+                LIME_REQUEST.getModelIdentifier(),
+                LIME_REQUEST.getOutputs());
         Assertions.assertNotNull(predictionProvider);
         Assertions.assertTrue(predictionProvider instanceof RemotePredictionProvider);
     }

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/RemotePredictionProviderTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/RemotePredictionProviderTest.java
@@ -42,7 +42,12 @@ import static org.kie.kogito.explainability.TestUtils.LIME_REQUEST;
 
 class RemotePredictionProviderTest {
 
-    RemotePredictionProvider predictionProvider = new RemotePredictionProvider(LIME_REQUEST, null, null, null) {
+    RemotePredictionProvider predictionProvider = new RemotePredictionProvider(LIME_REQUEST.getServiceUrl(),
+            LIME_REQUEST.getModelIdentifier(),
+            LIME_REQUEST.getOutputs(),
+            null,
+            null,
+            null) {
         @Override
         protected WebClient getClient(Vertx vertx, URI uri) {
             return null;

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/TestUtils.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/TestUtils.java
@@ -92,13 +92,13 @@ public class TestUtils {
                     OUTPUTS,
                     SEARCH_DOMAINS);
     public static final LIMEExplainabilityRequestDto LIME_REQUEST_DTO = new LIMEExplainabilityRequestDto(EXECUTION_ID,
-            SERVICE_URL,
+            SERVICE_URL, /**/
             MODEL_IDENTIFIER,
             INPUTS,
             OUTPUTS);
 
-    public static final LIMEExplainabilityRequest LIME_REQUEST = new LimeExplainerServiceHandler(null).explainabilityRequestFrom(LIME_REQUEST_DTO);
-    public static final CounterfactualExplainabilityRequest COUNTERFACTUAL_REQUEST = new CounterfactualExplainerServiceHandler(null).explainabilityRequestFrom(COUNTERFACTUAL_REQUEST_DTO);
+    public static final LIMEExplainabilityRequest LIME_REQUEST = new LimeExplainerServiceHandler(null, null).explainabilityRequestFrom(LIME_REQUEST_DTO);
+    public static final CounterfactualExplainabilityRequest COUNTERFACTUAL_REQUEST = new CounterfactualExplainerServiceHandler(null, null).explainabilityRequestFrom(COUNTERFACTUAL_REQUEST_DTO);
 
     public static final CounterfactualResult COUNTERFACTUAL_RESULT = new CounterfactualResult(Collections.emptyList(),
             List.of(new PredictionOutput(List.of(new Output("output1", Type.NUMBER, new Value(555.0d), 2.0)))),

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/TestUtils.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/TestUtils.java
@@ -92,7 +92,7 @@ public class TestUtils {
                     OUTPUTS,
                     SEARCH_DOMAINS);
     public static final LIMEExplainabilityRequestDto LIME_REQUEST_DTO = new LIMEExplainabilityRequestDto(EXECUTION_ID,
-            SERVICE_URL, /**/
+            SERVICE_URL,
             MODEL_IDENTIFIER,
             INPUTS,
             OUTPUTS);

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerServiceHandlerTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerServiceHandlerTest.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.explainability.PredictionProviderFactory;
 import org.kie.kogito.explainability.api.BaseExplainabilityRequestDto;
 import org.kie.kogito.explainability.api.BaseExplainabilityResultDto;
 import org.kie.kogito.explainability.api.CounterfactualDomainRangeDto;
@@ -85,8 +86,10 @@ public class CounterfactualExplainerServiceHandlerTest {
 
     @BeforeEach
     public void setup() {
+        PredictionProviderFactory predictionProviderFactory = mock(PredictionProviderFactory.class);
+
         this.explainer = mock(CounterfactualExplainer.class);
-        this.handler = new CounterfactualExplainerServiceHandler(explainer);
+        this.handler = new CounterfactualExplainerServiceHandler(explainer, predictionProviderFactory);
     }
 
     @Test
@@ -118,8 +121,8 @@ public class CounterfactualExplainerServiceHandlerTest {
         assertEquals(requestDto.getServiceUrl(), request.getServiceUrl());
         assertEquals(requestDto.getModelIdentifier().getResourceId(), request.getModelIdentifier().getResourceId());
         assertEquals(requestDto.getModelIdentifier().getResourceType(), request.getModelIdentifier().getResourceType());
-        assertEquals(requestDto.getInputs(), request.getInputs());
-        assertEquals(requestDto.getOutputs(), request.getOutputs());
+        assertEquals(requestDto.getOriginalInputs(), request.getOriginalInputs());
+        assertEquals(requestDto.getGoals(), request.getGoals());
         assertEquals(requestDto.getSearchDomains(), request.getSearchDomains());
     }
 

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/LimeExplainerServiceHandlerTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/LimeExplainerServiceHandlerTest.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.explainability.PredictionProviderFactory;
 import org.kie.kogito.explainability.api.BaseExplainabilityRequestDto;
 import org.kie.kogito.explainability.api.BaseExplainabilityResultDto;
 import org.kie.kogito.explainability.api.ExplainabilityStatus;
@@ -74,8 +75,10 @@ public class LimeExplainerServiceHandlerTest {
 
     @BeforeEach
     public void setup() {
+        PredictionProviderFactory predictionProviderFactory = mock(PredictionProviderFactory.class);
+
         this.explainer = mock(LimeExplainer.class);
-        this.handler = new LimeExplainerServiceHandler(explainer);
+        this.handler = new LimeExplainerServiceHandler(explainer, predictionProviderFactory);
     }
 
     @Test

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/LocalExplainerServiceHandlerRegistryTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/LocalExplainerServiceHandlerRegistryTest.java
@@ -67,16 +67,16 @@ public class LocalExplainerServiceHandlerRegistryTest {
     public void setup() {
         LimeExplainer limeExplainer = mock(LimeExplainer.class);
         CounterfactualExplainer counterfactualExplainer = mock(CounterfactualExplainer.class);
-        limeExplainerServiceHandler = spy(new LimeExplainerServiceHandler(limeExplainer));
-        counterfactualExplainerServiceHandler = spy(new CounterfactualExplainerServiceHandler(counterfactualExplainer));
         PredictionProviderFactory predictionProviderFactory = mock(PredictionProviderFactory.class);
+        limeExplainerServiceHandler = spy(new LimeExplainerServiceHandler(limeExplainer, predictionProviderFactory));
+        counterfactualExplainerServiceHandler = spy(new CounterfactualExplainerServiceHandler(counterfactualExplainer, predictionProviderFactory));
         predictionProvider = mock(PredictionProvider.class);
         callback = mock(Consumer.class);
 
-        when(predictionProviderFactory.createPredictionProvider(any())).thenReturn(predictionProvider);
+        when(predictionProviderFactory.createPredictionProvider(any(), any(), any())).thenReturn(predictionProvider);
         Instance<LocalExplainerServiceHandler<?, ?, ?>> explanationHandlers = mock(Instance.class);
         when(explanationHandlers.stream()).thenReturn(Stream.of(limeExplainerServiceHandler, counterfactualExplainerServiceHandler));
-        registry = new LocalExplainerServiceHandlerRegistry(predictionProviderFactory, explanationHandlers);
+        registry = new LocalExplainerServiceHandlerRegistry(explanationHandlers);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class LocalExplainerServiceHandlerRegistryTest {
 
         registry.explainAsyncWithResults(request, callback);
 
-        verify(limeExplainerServiceHandler).explainAsyncWithResults(eq(request), eq(predictionProvider), eq(callback));
+        verify(limeExplainerServiceHandler).explainAsyncWithResults(eq(request), eq(callback));
     }
 
     @Test
@@ -132,7 +132,7 @@ public class LocalExplainerServiceHandlerRegistryTest {
 
         registry.explainAsyncWithResults(request, callback);
 
-        verify(counterfactualExplainerServiceHandler).explainAsyncWithResults(eq(request), eq(predictionProvider), eq(callback));
+        verify(counterfactualExplainerServiceHandler).explainAsyncWithResults(eq(request), eq(callback));
     }
 
 }

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/TrustyServiceTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/TrustyServiceTest.java
@@ -473,16 +473,16 @@ public class TrustyServiceTest {
         assertEquals(TEST_SERVICE_URL, request.getServiceUrl());
 
         //Check original input value has been copied into CF request
-        assertEquals(1, request.getInputs().size());
-        assertTrue(request.getInputs().containsKey("yearsOfService"));
+        assertEquals(1, request.getOriginalInputs().size());
+        assertTrue(request.getOriginalInputs().containsKey("yearsOfService"));
         assertEquals(decision.getInputs().iterator().next().getValue().getValue().asInt(),
-                request.getInputs().get("yearsOfService").toUnit().getValue().asInt());
+                request.getOriginalInputs().get("yearsOfService").toUnit().getValue().asInt());
 
         //Check CF goals have been copied into CF request
-        assertEquals(1, request.getOutputs().size());
-        assertTrue(request.getOutputs().containsKey("salary"));
+        assertEquals(1, request.getGoals().size());
+        assertTrue(request.getGoals().containsKey("salary"));
         assertEquals(2000,
-                request.getOutputs().get("salary").toUnit().getValue().asInt());
+                request.getGoals().get("salary").toUnit().getValue().asInt());
 
         //Check CF search domains have been copied into CF request
         assertEquals(1, request.getSearchDomains().size());


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-480

Just a refactor to remove generic `inputs`/`outputs` from Counterfactuals; to more explicit `inputs`/`outputs` for LIME and `originalInputs`/`goals` for Counterfactuals. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>