### PR TITLE
FAI-512: Invalid size comparison between CF goals and model outputs

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
@@ -104,7 +104,7 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
 
                 final List<Output> outputs = predictionOutput.getOutputs();
 
-                if (outputs.size() != predictions.size()) {
+                if (goal.size() != outputs.size()) {
                     throw new IllegalArgumentException("Prediction size must be equal to goal size");
                 }
                 for (int i = 0; i < outputs.size(); i++) {

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/TestUtils.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/TestUtils.java
@@ -15,6 +15,7 @@
  */
 package org.kie.kogito.explainability;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -67,6 +68,31 @@ public class TestUtils {
                 }
                 PredictionOutput predictionOutput = new PredictionOutput(
                         List.of(new Output("sum-but" + skipFeatureIndex, Type.NUMBER, new Value(result), 1d)));
+                predictionOutputs.add(predictionOutput);
+            }
+            return predictionOutputs;
+        });
+    }
+
+    /**
+     * Test model which returns the inputs as outputs, except for a single specified feature
+     * 
+     * @param featureIndex Index of the input feature to omit from output
+     * @return A {@link PredictionProvider} model
+     */
+    public static PredictionProvider getFeatureSkipModel(int featureIndex) {
+        return inputs -> supplyAsync(() -> {
+            List<PredictionOutput> predictionOutputs = new LinkedList<>();
+            for (PredictionInput predictionInput : inputs) {
+                List<Feature> features = predictionInput.getFeatures();
+                List<Output> outputs = new ArrayList<>();
+                for (int i = 0; i < features.size(); i++) {
+                    if (i != featureIndex) {
+                        Feature feature = features.get(i);
+                        outputs.add(new Output(feature.getName(), feature.getType(), feature.getValue(), 1.0));
+                    }
+                }
+                PredictionOutput predictionOutput = new PredictionOutput(outputs);
                 predictionOutputs.add(predictionOutput);
             }
             return predictionOutputs;

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -1,0 +1,197 @@
+package org.kie.kogito.explainability.local.counterfactual;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.explainability.TestUtils;
+import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
+import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntityFactory;
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureFactory;
+import org.kie.kogito.explainability.model.Output;
+import org.kie.kogito.explainability.model.PredictionFeatureDomain;
+import org.kie.kogito.explainability.model.PredictionInput;
+import org.kie.kogito.explainability.model.PredictionOutput;
+import org.kie.kogito.explainability.model.PredictionProvider;
+import org.kie.kogito.explainability.model.Type;
+import org.kie.kogito.explainability.model.Value;
+import org.kie.kogito.explainability.model.domain.EmptyFeatureDomain;
+import org.kie.kogito.explainability.model.domain.FeatureDomain;
+import org.kie.kogito.explainability.model.domain.NumericalFeatureDomain;
+import org.optaplanner.core.api.score.buildin.bendablebigdecimal.BendableBigDecimalScore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CounterfactualScoreCalculatorTest {
+
+    /**
+     * If the goal and the model's output is the same, the distances should all be zero.
+     */
+    @Test
+    void testGoalSizeMatch() throws ExecutionException, InterruptedException {
+        final CounterFactualScoreCalculator scoreCalculator = new CounterFactualScoreCalculator();
+
+        PredictionProvider model = TestUtils.getFeatureSkipModel(0);
+
+        List<Feature> features = new ArrayList<>();
+        List<FeatureDomain> featureDomains = new ArrayList<>();
+        List<Boolean> constraints = new ArrayList<>();
+
+        // f-1
+        features.add(FeatureFactory.newNumericalFeature("f-1", 1.0));
+        featureDomains.add(NumericalFeatureDomain.create(0.0, 10.0));
+        constraints.add(false);
+
+        // f-2
+        features.add(FeatureFactory.newNumericalFeature("f-2", 2.0));
+        featureDomains.add(NumericalFeatureDomain.create(0.0, 10.0));
+        constraints.add(false);
+
+        // f-3
+        features.add(FeatureFactory.newBooleanFeature("f-3", true));
+        featureDomains.add(EmptyFeatureDomain.create());
+        constraints.add(false);
+
+        PredictionInput input = new PredictionInput(features);
+        PredictionFeatureDomain domains = new PredictionFeatureDomain(featureDomains);
+        List<CounterfactualEntity> entities = CounterfactualEntityFactory.createEntities(input, domains, constraints, null);
+
+        List<Output> goal = new ArrayList<>();
+        goal.add(new Output("f-2", Type.NUMBER, new Value(2.0), 0.0));
+        goal.add(new Output("f-3", Type.BOOLEAN, new Value(true), 0.0));
+
+        final CounterfactualSolution solution =
+                new CounterfactualSolution(entities, model, goal, UUID.randomUUID(), UUID.randomUUID());
+
+        BendableBigDecimalScore score = scoreCalculator.calculateScore(solution);
+
+        List<PredictionOutput> predictionOutputs = model.predictAsync(List.of(input)).get();
+
+        assertTrue(score.isFeasible());
+
+        assertEquals(2, goal.size());
+        assertEquals(1, predictionOutputs.size()); // A single prediction is expected
+        assertEquals(2, predictionOutputs.get(0).getOutputs().size()); // Single prediction with two features
+        assertEquals(score.getHardScore(0).compareTo(BigDecimal.ZERO), 0);
+        assertEquals(score.getHardScore(1).compareTo(BigDecimal.ZERO), 0);
+        assertEquals(score.getHardScore(2).compareTo(BigDecimal.ZERO), 0);
+        assertEquals(score.getSoftScore(0).compareTo(BigDecimal.ZERO), 0);
+        assertEquals(score.getSoftScore(1).compareTo(BigDecimal.ZERO), 0);
+        assertEquals(score.getHardLevelsSize(), 3);
+        assertEquals(score.getSoftLevelsSize(), 2);
+    }
+
+    /**
+     * Using a smaller number of features in the goals (1) than the model's output (2) should
+     * throw an {@link IllegalArgumentException} with the appropriate message.
+     */
+    @Test
+    void testGoalSizeSmaller() throws ExecutionException, InterruptedException {
+        final CounterFactualScoreCalculator scoreCalculator = new CounterFactualScoreCalculator();
+
+        PredictionProvider model = TestUtils.getFeatureSkipModel(0);
+
+        List<Feature> features = new ArrayList<>();
+        List<FeatureDomain> featureDomains = new ArrayList<>();
+        List<Boolean> constraints = new ArrayList<>();
+
+        // f-1
+        features.add(FeatureFactory.newNumericalFeature("f-1", 1.0));
+        featureDomains.add(NumericalFeatureDomain.create(0.0, 10.0));
+        constraints.add(false);
+
+        // f-2
+        features.add(FeatureFactory.newNumericalFeature("f-2", 2.0));
+        featureDomains.add(NumericalFeatureDomain.create(0.0, 10.0));
+        constraints.add(false);
+
+        // f-3
+        features.add(FeatureFactory.newBooleanFeature("f-3", true));
+        featureDomains.add(EmptyFeatureDomain.create());
+        constraints.add(false);
+
+        PredictionInput input = new PredictionInput(features);
+        PredictionFeatureDomain domains = new PredictionFeatureDomain(featureDomains);
+        List<CounterfactualEntity> entities = CounterfactualEntityFactory.createEntities(input, domains, constraints, null);
+
+        List<Output> goal = new ArrayList<>();
+        goal.add(new Output("f-2", Type.NUMBER, new Value(2.0), 0.0));
+
+        List<PredictionOutput> predictionOutputs = model.predictAsync(List.of(input)).get();
+
+        assertEquals(1, goal.size());
+        assertEquals(1, predictionOutputs.size()); // A single prediction is expected
+        assertEquals(2, predictionOutputs.get(0).getOutputs().size()); // Single prediction with two features
+
+        final CounterfactualSolution solution =
+                new CounterfactualSolution(entities, model, goal, UUID.randomUUID(), UUID.randomUUID());
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            scoreCalculator.calculateScore(solution);
+        });
+
+        assertEquals(exception.getMessage(), "Prediction size must be equal to goal size");
+
+    }
+
+    /**
+     * Using a larger number of features in the goals (3) than the model's output (2) should
+     * throw an {@link IllegalArgumentException} with the appropriate message.
+     */
+    @Test
+    void testGoalSizeLarger() throws ExecutionException, InterruptedException {
+        final CounterFactualScoreCalculator scoreCalculator = new CounterFactualScoreCalculator();
+
+        PredictionProvider model = TestUtils.getFeatureSkipModel(0);
+
+        List<Feature> features = new ArrayList<>();
+        List<FeatureDomain> featureDomains = new ArrayList<>();
+        List<Boolean> constraints = new ArrayList<>();
+
+        // f-1
+        features.add(FeatureFactory.newNumericalFeature("f-1", 1.0));
+        featureDomains.add(NumericalFeatureDomain.create(0.0, 10.0));
+        constraints.add(false);
+
+        // f-2
+        features.add(FeatureFactory.newNumericalFeature("f-2", 2.0));
+        featureDomains.add(NumericalFeatureDomain.create(0.0, 10.0));
+        constraints.add(false);
+
+        // f-3
+        features.add(FeatureFactory.newBooleanFeature("f-3", true));
+        featureDomains.add(EmptyFeatureDomain.create());
+        constraints.add(false);
+
+        PredictionInput input = new PredictionInput(features);
+        PredictionFeatureDomain domains = new PredictionFeatureDomain(featureDomains);
+        List<CounterfactualEntity> entities = CounterfactualEntityFactory.createEntities(input, domains, constraints, null);
+
+        List<Output> goal = new ArrayList<>();
+        goal.add(new Output("f-1", Type.NUMBER, new Value(1.0), 0.0));
+        goal.add(new Output("f-2", Type.NUMBER, new Value(2.0), 0.0));
+        goal.add(new Output("f-3", Type.BOOLEAN, new Value(true), 0.0));
+
+        List<PredictionOutput> predictionOutputs = model.predictAsync(List.of(input)).get();
+
+        assertEquals(3, goal.size());
+        assertEquals(1, predictionOutputs.size()); // A single prediction is expected
+        assertEquals(2, predictionOutputs.get(0).getOutputs().size()); // Single prediction with two features
+
+        final CounterfactualSolution solution =
+                new CounterfactualSolution(entities, model, goal, UUID.randomUUID(), UUID.randomUUID());
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            scoreCalculator.calculateScore(solution);
+        });
+
+        assertEquals(exception.getMessage(), "Prediction size must be equal to goal size");
+
+    }
+}

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CounterfactualScoreCalculatorTest {
+class CounterfactualScoreCalculatorTest {
 
     /**
      * If the goal and the model's output is the same, the distances should all be zero.
@@ -93,13 +93,13 @@ public class CounterfactualScoreCalculatorTest {
         assertEquals(2, goal.size());
         assertEquals(1, predictionOutputs.size()); // A single prediction is expected
         assertEquals(2, predictionOutputs.get(0).getOutputs().size()); // Single prediction with two features
-        assertEquals(score.getHardScore(0).compareTo(BigDecimal.ZERO), 0);
-        assertEquals(score.getHardScore(1).compareTo(BigDecimal.ZERO), 0);
-        assertEquals(score.getHardScore(2).compareTo(BigDecimal.ZERO), 0);
-        assertEquals(score.getSoftScore(0).compareTo(BigDecimal.ZERO), 0);
-        assertEquals(score.getSoftScore(1).compareTo(BigDecimal.ZERO), 0);
-        assertEquals(score.getHardLevelsSize(), 3);
-        assertEquals(score.getSoftLevelsSize(), 2);
+        assertEquals(0, score.getHardScore(0).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.getHardScore(1).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.getHardScore(2).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.getSoftScore(0).compareTo(BigDecimal.ZERO));
+        assertEquals(0, score.getSoftScore(1).compareTo(BigDecimal.ZERO));
+        assertEquals(3, score.getHardLevelsSize());
+        assertEquals(2, score.getSoftLevelsSize());
     }
 
     /**
@@ -151,7 +151,7 @@ public class CounterfactualScoreCalculatorTest {
             scoreCalculator.calculateScore(solution);
         });
 
-        assertEquals(exception.getMessage(), "Prediction size must be equal to goal size");
+        assertEquals("Prediction size must be equal to goal size", exception.getMessage());
 
     }
 
@@ -206,7 +206,7 @@ public class CounterfactualScoreCalculatorTest {
             scoreCalculator.calculateScore(solution);
         });
 
-        assertEquals(exception.getMessage(), "Prediction size must be equal to goal size");
+        assertEquals("Prediction size must be equal to goal size", exception.getMessage());
 
     }
 }

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.kogito.explainability.local.counterfactual;
 
 import java.math.BigDecimal;


### PR DESCRIPTION
[FAI-512](https://issues.redhat.com/browse/FAI-512):

The CF explainer score calculator compares the size of each prediction element to the specified goal to make sure they match. The score calculator was comparing the size of a `goal` with the whole prediction set (`predictions`) size.
This PR checks correctly the size of each of the model's output to the goal's size.

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
