### PR TITLE
KOGITO-5309: Fix for error in yarn build

### DIFF
--- a/ui-packages/package.json
+++ b/ui-packages/package.json
@@ -10,7 +10,7 @@
     "init": "lerna bootstrap",
     "build": "lerna run build --stream --",
     "build:fast": "lerna run build:fast --stream --",
-    "build:prod": "lerna run build:prod --stream --",
+    "build:prod": "lerna run build:prod --include-dependencies --stream --",
     "test": "lerna run test:coverage --stream --",
     "cypress:run": "lerna run cypress:run --",
     "cypress:run-management-console": "cypress run --project ./packages/management-console",


### PR DESCRIPTION
Hello,

Please review this PR intended to fix an error on yarn build, this happened because the 'mgmt-console-webapp' package started building before a dependency package hasn't finished.

Error in yarn build:
 {{[INFO] @kogito-apps/management-console-webapp: ERROR in /home/jenkins/workspace/KIE/kogito/nightly/master/kogito-apps-deploy/kogito-apps/ui-packages/node_modules/@kogito-apps/process-list/dist/envelope/components/ProcessListChildTable/ProcessListChildTable.js
[INFO] @kogito-apps/management-console-webapp: Module not found: Error: Can't resolve '../styles.css' in '/home/jenkins/workspace/KIE/kogito/nightly/master/kogito-apps-deploy/kogito-apps/ui-packages/node_modules/@kogito-apps/process-list/dist/envelope/components/ProcessListChildTable'
...}}