### PR TITLE
KOGITO-5332 ClasspathURLStreamHandlerProvider not found in Kogito applications

### DIFF
--- a/jobs-service/jobs-service-infinispan/pom.xml
+++ b/jobs-service/jobs-service-infinispan/pom.xml
@@ -36,6 +36,11 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-infinispan-client</artifactId>
         </dependency>
+        <!-- Needs to be declared as Jobs service doesn't leverage persistence-commons-infinispan. -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-commons-jdk11</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-query-dsl</artifactId>


### PR DESCRIPTION
Adding infinispan-commons-jdk11 to Jobs service as it doesn't leverage persistence-commons-infinispan.

Signed-off-by: Karel Suta <ksuta@redhat.com>

https://issues.redhat.com/browse/KOGITO-5332

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
