### PR TITLE
Prevent Maven looking for the specified parent in the parent dir of the root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-build-parent</artifactId>
     <version>2.0.0-SNAPSHOT</version>
+    <relativePath/>
   </parent>
   <artifactId>kogito-apps</artifactId>
   <packaging>pom</packaging>


### PR DESCRIPTION
This will remove this warning when testing kogito-runtimes

````
[kiegroup/kogito-apps]. Command: 'mvn -f kogito-apps/pom.xml clean install -Dvalidate-formatting ${{ env.BUILD_MVN_OPTS }}' in dir /home/runner/work/kogito-runtimes/kogito-runtimes/kiegroup_kogito_apps
  [INFO]  Execute command 'mvn -f kogito-apps/pom.xml clean install -Dvalidate-formatting -DskipUI -nsu -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B' in dir '/home/runner/work/kogito-runtimes/kogito-runtimes/kiegroup_kogito_apps'
  /usr/bin/mvn -f kogito-apps/pom.xml clean install -Dvalidate-formatting -DskipUI -nsu -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B
  [INFO] Error stacktraces are turned on.
  [INFO] Scanning for projects...
  Warning:  
  Warning:  Some problems were encountered while building the effective model for org.kie.kogito:kogito-apps:pom:2.0.0-SNAPSHOT
  Warning:  'parent.relativePath' of POM org.kie.kogito:kogito-apps:2.0.0-SNAPSHOT (/home/runner/work/kogito-runtimes/kogito-runtimes/kiegroup_kogito_apps/kogito-apps/pom.xml) points at org.kie.kogito:kogito-apps instead of org.kie.kogito:kogito-build-parent, please verify your project structure @ line 7, column 11
  Warning:  
  Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
  Warning:  
  Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
  Warning:  
  [INFO] ------------------------------------------------------------------------
  [INFO] Detecting the operating system and CPU architecture
````