### PR TITLE
[KOGITO-5251] - (Apps) Upgrade to SpringBoot 2.4.3

### DIFF
--- a/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-springboot/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/integration-tests-trusty-service-springboot/pom.xml
@@ -16,6 +16,23 @@
     <version.jib-maven-plugin>2.5.2</version.jib-maven-plugin>
   </properties>
 
+  <!-- The BOM guarantees the transitive dependencies -->
+  <!-- in this case, Spring Kafka brings a different context version other defined in the SB:
+  https://github.com/spring-projects/spring-kafka/blob/v2.6.6/build.gradle#L69
+  Added after SB upgrade: https://issues.redhat.com/browse/KOGITO-5251
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${version.org.springframework.boot}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.kie.kogito</groupId>


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-5251

Related PRs:
https://github.com/kiegroup/kogito-examples/pull/757
https://github.com/kiegroup/kogito-runtimes/pull/1407

I've added the missing SB BOM to Trusty SB integration test. The upgraded Kafka client was bringing the wrong Spring Context dependency, the BOM fixes the version alignment. Please see my comment in the changed POM.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
