### PR TITLE
FAI-527: Fix string representation of CF entities

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/AbstractEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/AbstractEntity.java
@@ -55,7 +55,7 @@ public abstract class AbstractEntity<T> implements CounterfactualEntity {
 
     @Override
     public String toString() {
-        return originalValue.getClass().getName() + "Feature{"
+        return originalValue.getClass().getName() + "Entity{"
                 + "value="
                 + proposedValue
                 + ", id='"

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/AbstractNumericEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/AbstractNumericEntity.java
@@ -51,12 +51,12 @@ public abstract class AbstractNumericEntity<T extends Number> extends AbstractEn
 
     @Override
     public String toString() {
-        return originalValue.getClass().getName() + "Feature{"
+        return originalValue.getClass().getName() + "Entity{"
                 + "value="
                 + proposedValue
-                + ", intRangeMinimum="
+                + ", rangeMinimum="
                 + rangeMinimum
-                + ", intRangeMaximum="
+                + ", rangeMaximum="
                 + rangeMaximum
                 + ", id='"
                 + featureName


### PR DESCRIPTION
[FAI-527](https://issues.redhat.com/browse/FAI-527):

Fix string representation of CF entities:

- `intRange` was shown even when range not integer (e.g. `double`)
- `Feature` should be `Entity`

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting master: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket
> 

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
