### PR TITLE
KOGITO-5537 simplify sonar configuration

### DIFF
--- a/ui-packages/packages/common/package.json
+++ b/ui-packages/packages/common/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
@@ -62,6 +62,7 @@
       "./src/graphql",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/components-common/package.json
+++ b/ui-packages/packages/components-common/package.json
@@ -21,7 +21,7 @@
     "build:prod": "yarn run clean && yarn run lint && yarn run build",
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "update-snapshot": "jest --updateSnapshot",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
@@ -48,6 +48,7 @@
       "./src/graphql",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/consoles-common/package.json
+++ b/ui-packages/packages/consoles-common/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist",
@@ -53,6 +53,7 @@
       "./src/graphql",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/jobs-management/package.json
+++ b/ui-packages/packages/jobs-management/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}' --fix",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist"
@@ -56,6 +56,7 @@
       "./src/envelope/contexts/",
       "./src/envelope/index.ts"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/management-console-shared/package.json
+++ b/ui-packages/packages/management-console-shared/package.json
@@ -21,7 +21,7 @@
     "build:prod": "yarn run clean && yarn run lint && yarn run build",
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "update-snapshot": "jest --updateSnapshot",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
@@ -48,6 +48,7 @@
       "./src/graphql",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/management-console-webapp/package.json
+++ b/ui-packages/packages/management-console-webapp/package.json
@@ -15,7 +15,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "dev:restServer": "nodemon ./server/restServer.js",
     "dev:server": "nodemon ./server/app.js",
     "dev": "concurrently 'yarn  start' 'yarn run dev:server'",
@@ -54,6 +54,7 @@
       "./src/apis/index.ts",
       "./src/pages/index.ts"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/ui-packages/packages/management-console/package.json
+++ b/ui-packages/packages/management-console/package.json
@@ -15,7 +15,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "dev:restServer": "nodemon ./server/restServer.js",
     "dev:server": "nodemon ./server/app.js",
     "dev": "concurrently 'yarn  start' 'yarn run dev:server'",
@@ -52,6 +52,7 @@
     "coveragePathIgnorePatterns": [
       "./src/static"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "moduleFileExtensions": [
       "ts",
       "tsx",

--- a/ui-packages/packages/ouia-tools/package.json
+++ b/ui-packages/packages/ouia-tools/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist"
@@ -47,6 +47,7 @@
       "./src/graphql",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/process-details/package.json
+++ b/ui-packages/packages/process-details/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}' --fix",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist"
@@ -56,6 +56,7 @@
       "./src/envelope/contexts/",
       "./src/envelope/index.ts"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/process-list/package.json
+++ b/ui-packages/packages/process-list/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist"
@@ -52,6 +52,7 @@
       "dist/",
       "mocks/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/task-console-shared/package.json
+++ b/ui-packages/packages/task-console-shared/package.json
@@ -21,7 +21,7 @@
     "build:prod": "yarn run clean && yarn run lint && yarn run build",
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "update-snapshot": "jest --updateSnapshot",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
@@ -48,6 +48,7 @@
       "./src/graphql",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/task-console-webapp/package.json
+++ b/ui-packages/packages/task-console-webapp/package.json
@@ -15,7 +15,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}'",
     "dev": "concurrently 'yarn run   start  --define process.env.TEST_USER_SYSTEM_ENABLED=true' 'yarn run dev:server'",
     "dev-remote-dataindex": "yarn start --define process.env.KOGITO_DATAINDEX_HTTP_URL='\"http://localhost:8180/graphql\"' --define process.env.TEST_USER_SYSTEM_ENABLED=true",
@@ -49,6 +49,7 @@
       "tsx",
       "js"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "globals": {
       "ts-jest": {
         "isolatedModules": true

--- a/ui-packages/packages/task-details/package.json
+++ b/ui-packages/packages/task-details/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist"
@@ -51,6 +51,7 @@
       "./src/static",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/task-form/package.json
+++ b/ui-packages/packages/task-form/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist"
@@ -56,6 +56,7 @@
       "./src/static",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/task-inbox/package.json
+++ b/ui-packages/packages/task-inbox/package.json
@@ -22,7 +22,7 @@
     "test:report": "yarn test --ci --reporters=jest-junit",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
     "update-snapshot": "jest --updateSnapshot",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "lint": "eslint './src/**/*.ts{,x}'",
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist"
@@ -51,6 +51,7 @@
       "./src/static",
       "dist/"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/ui-packages/packages/trusty/package.json
+++ b/ui-packages/packages/trusty/package.json
@@ -25,7 +25,7 @@
     "start": "webpack-dev-server --hot --color --progress --info=true --config webpack.dev.js",
     "build:prod": "yarn lint && webpack --config webpack.prod.js",
     "test": "jest --runInBand --ci --reporters=default --reporters=jest-junit",
-    "test:coverage": "yarn test --coverage",
+    "test:coverage": "rimraf coverage && yarn test --coverage",
     "test:watch": "jest --watch",
     "lint": "eslint './src/**/*.ts{,x}'",
     "mock-server": "json-server --watch api-mock/db.js --routes api-mock/routes.json --port 1336 --delay 1000 --id executionId --middlewares api-mock/filterSingular.js",
@@ -55,6 +55,7 @@
       "tsx",
       "js"
     ],
+    "coverageReporters": [["lcov", { "projectRoot": "../../" }]],
     "globals": {
       "ts-jest": {
         "isolatedModules": true

--- a/ui-packages/pom.xml
+++ b/ui-packages/pom.xml
@@ -15,45 +15,27 @@
   <name>Kogito Apps :: UI Packages</name>
 
   <properties>
-    <path.to.root>${project.basedir}</path.to.root> <!-- package.json in root dir-->
-    <path.to.packages>${path.to.root}/packages</path.to.packages>
-    <sonar.sources>
-      ${path.to.packages}/common/src,
-      ${path.to.packages}/components-common/src,
-      ${path.to.packages}/consoles-common/src,
-      ${path.to.packages}/jobs-management/src,
-      ${path.to.packages}/management-console-shared/coverage/src,
-      ${path.to.packages}/management-console-webapp/src,
-      ${path.to.packages}/management-console/src,
-      ${path.to.packages}/ouia-tools/src,
-      ${path.to.packages}/process-details/src,
-      ${path.to.packages}/process-list/src,
-      ${path.to.packages}/task-console-shared/src,
-      ${path.to.packages}/task-console-webapp/src,
-      ${path.to.packages}/task-details/src,
-      ${path.to.packages}/task-form/src,
-      ${path.to.packages}/task-inbox/src,
-      ${path.to.packages}/trusty/src,
-    </sonar.sources>
-    <sonar.exclusions>**/__mocks__/**,**/mocks/**,**/tests/utils/**,**/*.stories.tsx,**/graphql/types.tsx,**/graphql/graphql.schema.json,**/index.tsx</sonar.exclusions>
+    <sonar.sources>${project.basedir}/packages</sonar.sources>
+    <sonar.inclusions>packages/*/src/**</sonar.inclusions>
+    <sonar.exclusions>**/__mocks__/**,**/mocks/**,**/tests/utils/**,**/*.stories.tsx,**/graphql/types.tsx,**/graphql/graphql.schema.json,**/index.tsx,*.js</sonar.exclusions>
     <sonar.test.inclusions>**/*test.ts,**/*test.tsx</sonar.test.inclusions>
     <sonar.javascript.lcov.reportPaths>
-      ${path.to.packages}/common/coverage/lcov.info,
-      ${path.to.packages}/components-common/coverage/lcov.info,
-      ${path.to.packages}/consoles-common/coverage/lcov.info,
-      ${path.to.packages}/jobs-management/coverage/lcov.info,
-      ${path.to.packages}/management-console-shared/coverage/lcov.info,
-      ${path.to.packages}/management-console-webapp/coverage/lcov.info,
-      ${path.to.packages}/management-console/coverage/lcov.info,
-      ${path.to.packages}/ouia-tools/coverage/lcov.info,
-      ${path.to.packages}/process-details/coverage/lcov.info,
-      ${path.to.packages}/process-list/coverage/lcov.info,
-      ${path.to.packages}/task-console-shared/coverage/lcov.info,
-      ${path.to.packages}/task-console-webapp/coverage/lcov.info,
-      ${path.to.packages}/task-details/coverage/lcov.info,
-      ${path.to.packages}/task-form/coverage/lcov.info,
-      ${path.to.packages}/task-inbox/coverage/lcov.info,
-      ${path.to.packages}/trusty/coverage/lcov.info,
+      packages/common/coverage/lcov.info,
+      packages/components-common/coverage/lcov.info,
+      packages/consoles-common/coverage/lcov.info,
+      packages/jobs-management/coverage/lcov.info,
+      packages/management-console-shared/coverage/lcov.info,
+      packages/management-console-webapp/coverage/lcov.info,
+      packages/management-console/coverage/lcov.info,
+      packages/ouia-tools/coverage/lcov.info,
+      packages/process-details/coverage/lcov.info,
+      packages/process-list/coverage/lcov.info,
+      packages/task-console-shared/coverage/lcov.info,
+      packages/task-console-webapp/coverage/lcov.info,
+      packages/task-details/coverage/lcov.info,
+      packages/task-form/coverage/lcov.info,
+      packages/task-inbox/coverage/lcov.info,
+      packages/trusty/coverage/lcov.info,
     </sonar.javascript.lcov.reportPaths>
   </properties>
   <build>


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5537

Simplify configuration:
* remove explicit packages naming from sonar.sources
* remove absolute path prefix from reportPaths - to shorten the property contents.
  * achieved by tweaking jest coverageReporters configuration
* removing coverage folders before test:coverage scripts to ensure current results being used.


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
