### PR TITLE
FAI-547: Fix flaky test TrafficViolationDmnLimeExplainerTest.testExplanationWeightedStabilityWithOptimization

### DIFF
--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/TrafficViolationDmnLimeExplainerTest.java
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/TrafficViolationDmnLimeExplainerTest.java
@@ -154,11 +154,12 @@ class TrafficViolationDmnLimeExplainerTest {
         LimeConfigOptimizer limeConfigOptimizer = new LimeConfigOptimizer()
                 .withSampling(false)
                 .withWeighting(false)
+                .withTimeLimit(60)
                 .withWeightedStability(0.4, 0.6);
 
         Random random = new Random();
         random.setSeed(0);
-        PerturbationContext perturbationContext = new PerturbationContext(random, 1);
+        PerturbationContext perturbationContext = new PerturbationContext(random, 2);
         LimeConfig initialConfig = new LimeConfig()
                 .withSamples(10)
                 .withPerturbationContext(perturbationContext);


### PR DESCRIPTION
[FAI-547](https://issues.redhat.com/browse/FAI-547): Increase optimiser's running time and number of perturbations in order to prevent `testExplanationWeightedStabilityWithOptimization` failure.

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
