### PR TITLE
FAI-548: Return ShapResults from SHAP that contains model null along with shap values

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/shap/ShapResults.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/shap/ShapResults.java
@@ -19,11 +19,19 @@ package org.kie.kogito.explainability.local.shap;
 import org.kie.kogito.explainability.model.Saliency;
 
 public class ShapResults {
-    public final Saliency[] saliencies;
-    public final double[] fnull;
+    private final Saliency[] saliencies;
+    private final double[] fnull;
 
     public ShapResults(Saliency[] saliencies, double[] fnull) {
         this.saliencies = saliencies;
         this.fnull = fnull;
+    }
+
+    public Saliency[] getSaliencies() {
+        return saliencies;
+    }
+
+    public double[] getFnull() {
+        return fnull;
     }
 }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/shap/ShapResults.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/shap/ShapResults.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.explainability.local.shap;
+
+import org.kie.kogito.explainability.model.Saliency;
+
+public class ShapResults {
+    public final Saliency[] saliencies;
+    public final double[] fnull;
+
+    public ShapResults(Saliency[] saliencies, double[] fnull) {
+        this.saliencies = saliencies;
+        this.fnull = fnull;
+    }
+}

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/shap/ShapKernelExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/shap/ShapKernelExplainerTest.java
@@ -182,7 +182,7 @@ class ShapKernelExplainerTest {
         for (int i = 0; i < toExplain.size(); i++) {
             //explanations shape: outputSize x nfeatures
             Saliency[] explanationSaliencies = ske.explainAsync(predictions.get(i), model)
-                    .get(5, TimeUnit.SECONDS).saliencies;
+                    .get(5, TimeUnit.SECONDS).getSaliencies();
             double[][] explanations = saliencyToMatrix(explanationSaliencies)[0];
             for (int j = 0; j < explanations.length; j++) {
                 assertArrayEquals(expected[i][j], explanations[j], 1e-6);
@@ -213,7 +213,7 @@ class ShapKernelExplainerTest {
         for (int i = 0; i < toExplain.size(); i++) {
             //explanations shape: outputSize x nfeatures
             Saliency[] exlanationSaliencies = ske.explainAsync(predictions.get(i), model)
-                    .get(5, TimeUnit.SECONDS).saliencies;
+                    .get(5, TimeUnit.SECONDS).getSaliencies();
             double[][] explanations = saliencyToMatrix(exlanationSaliencies)[0];
             for (int j = 0; j < explanations.length; j++) {
                 assertArrayEquals(expected[i][j], explanations[j], 1e-6);
@@ -327,7 +327,7 @@ class ShapKernelExplainerTest {
         ShapKernelExplainer ske = new ShapKernelExplainer(skConfig);
         for (int i = 0; i < toExplain.size(); i++) {
             Saliency[] explanationSaliencies = ske.explainAsync(predictions.get(i), model)
-                    .get(5, TimeUnit.SECONDS).saliencies;
+                    .get(5, TimeUnit.SECONDS).getSaliencies();
             double[][][] explanationsAndConfs = saliencyToMatrix(explanationSaliencies);
             double[][] explanations = explanationsAndConfs[0];
 
@@ -374,7 +374,7 @@ class ShapKernelExplainerTest {
 
         ExecutorService executor = ForkJoinPool.commonPool();
         executor.submit(() -> {
-            Saliency[] explanationSaliencies = explanationsCF.join().saliencies;
+            Saliency[] explanationSaliencies = explanationsCF.join().getSaliencies();
             double[][] explanations = saliencyToMatrix(explanationSaliencies)[0];
             assertArrayEquals(expected[0][0], explanations[0], 1e-2);
         });
@@ -500,7 +500,7 @@ class ShapKernelExplainerTest {
                 ShapKernelExplainer ske = new ShapKernelExplainer(skConfig);
                 List<PredictionOutput> predictionOutputs = model.predictAsync(toExplain).get();
                 Prediction p = new SimplePrediction(toExplain.get(0), predictionOutputs.get(0));
-                Saliency[] saliencies = ske.explainAsync(p, model).get().saliencies;
+                Saliency[] saliencies = ske.explainAsync(p, model).get().getSaliencies();
                 double[][][] explanationsAndConfs = saliencyToMatrix(saliencies);
                 double[][] explanations = explanationsAndConfs[0];
 

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/shap/ShapKernelExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/shap/ShapKernelExplainerTest.java
@@ -181,7 +181,8 @@ class ShapKernelExplainerTest {
         ShapKernelExplainer ske = new ShapKernelExplainer(skConfig);
         for (int i = 0; i < toExplain.size(); i++) {
             //explanations shape: outputSize x nfeatures
-            Saliency[] explanationSaliencies = ske.explainAsync(predictions.get(i), model).get(5, TimeUnit.SECONDS);
+            Saliency[] explanationSaliencies = ske.explainAsync(predictions.get(i), model)
+                    .get(5, TimeUnit.SECONDS).saliencies;
             double[][] explanations = saliencyToMatrix(explanationSaliencies)[0];
             for (int j = 0; j < explanations.length; j++) {
                 assertArrayEquals(expected[i][j], explanations[j], 1e-6);
@@ -211,7 +212,8 @@ class ShapKernelExplainerTest {
         // evaluate if the explanations match the expected value
         for (int i = 0; i < toExplain.size(); i++) {
             //explanations shape: outputSize x nfeatures
-            Saliency[] exlanationSaliencies = ske.explainAsync(predictions.get(i), model).get(5, TimeUnit.SECONDS);
+            Saliency[] exlanationSaliencies = ske.explainAsync(predictions.get(i), model)
+                    .get(5, TimeUnit.SECONDS).saliencies;
             double[][] explanations = saliencyToMatrix(exlanationSaliencies)[0];
             for (int j = 0; j < explanations.length; j++) {
                 assertArrayEquals(expected[i][j], explanations[j], 1e-6);
@@ -324,7 +326,8 @@ class ShapKernelExplainerTest {
         // evaluate if the explanations match the expected value
         ShapKernelExplainer ske = new ShapKernelExplainer(skConfig);
         for (int i = 0; i < toExplain.size(); i++) {
-            Saliency[] explanationSaliencies = ske.explainAsync(predictions.get(i), model).get(5, TimeUnit.SECONDS);
+            Saliency[] explanationSaliencies = ske.explainAsync(predictions.get(i), model)
+                    .get(5, TimeUnit.SECONDS).saliencies;
             double[][][] explanationsAndConfs = saliencyToMatrix(explanationSaliencies);
             double[][] explanations = explanationsAndConfs[0];
 
@@ -367,11 +370,11 @@ class ShapKernelExplainerTest {
 
         // evaluate if the explanations match the expected value
         ShapKernelExplainer ske = new ShapKernelExplainer(skConfig);
-        CompletableFuture<Saliency[]> explanationsCF = ske.explainAsync(predictions.get(0), model);
+        CompletableFuture<ShapResults> explanationsCF = ske.explainAsync(predictions.get(0), model);
 
         ExecutorService executor = ForkJoinPool.commonPool();
         executor.submit(() -> {
-            Saliency[] explanationSaliencies = explanationsCF.join();
+            Saliency[] explanationSaliencies = explanationsCF.join().saliencies;
             double[][] explanations = saliencyToMatrix(explanationSaliencies)[0];
             assertArrayEquals(expected[0][0], explanations[0], 1e-2);
         });
@@ -497,7 +500,7 @@ class ShapKernelExplainerTest {
                 ShapKernelExplainer ske = new ShapKernelExplainer(skConfig);
                 List<PredictionOutput> predictionOutputs = model.predictAsync(toExplain).get();
                 Prediction p = new SimplePrediction(toExplain.get(0), predictionOutputs.get(0));
-                Saliency[] saliencies = ske.explainAsync(p, model).get();
+                Saliency[] saliencies = ske.explainAsync(p, model).get().saliencies;
                 double[][][] explanationsAndConfs = saliencyToMatrix(saliencies);
                 double[][] explanations = explanationsAndConfs[0];
 


### PR DESCRIPTION
https://issues.redhat.com/browse/FAI-548: Changes the ShapKernelExplainer output from an array of Saliencies to a ShapResults object, which lets a variety of things be reported as the explainer output. For now, it contains the original array of Saliencies and the model null, which wasn't previously reported but is necessary to be able to fully describe the linear explanation model. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
