### PR TITLE
FAI-557: CF score calculator should explicitly states which feature caused a type mismatch error

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
@@ -53,7 +53,8 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
         final Type bType = b.getType();
 
         if (aType != bType) {
-            String message = "Features must have the same type, got " + aType.toString() + " and " + bType.toString();
+            String message = String.format("Features must have the same type. Feature '%s', has type '%s' and '%s'",
+                    a.getName(), aType.toString(), bType.toString());
             logger.error(message);
             throw new IllegalArgumentException(message);
         }
@@ -63,7 +64,7 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
         } else if (a.getType() == Type.CATEGORICAL || a.getType() == Type.BOOLEAN) {
             distance = a.getValue().getUnderlyingObject().equals(b.getValue().getUnderlyingObject()) ? 0.0 : 1.0;
         } else {
-            String message = "Feature type " + aType.toString() + " not supported";
+            String message = String.format("Feature '%s' has unsupported type '%s'", a.getName(), aType.toString());
             logger.error(message);
             throw new IllegalArgumentException(message);
         }

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -215,7 +215,8 @@ class CounterfactualScoreCalculatorTest {
             CounterFactualScoreCalculator.outputDistance(ox, oy);
         });
 
-        assertEquals("Features must have the same type, got categorical and number", exception.getMessage());
+        assertEquals("Features must have the same type. Feature 'x', has type 'categorical' and 'number'",
+                exception.getMessage());
     }
 
     @Test
@@ -230,7 +231,7 @@ class CounterfactualScoreCalculatorTest {
             CounterFactualScoreCalculator.outputDistance(ox, oy);
         });
 
-        assertEquals("Feature type time not supported", exception.getMessage());
+        assertEquals("Feature 'x' has unsupported type 'time'", exception.getMessage());
     }
 
     /**


### PR DESCRIPTION
[FAI-557](https://issues.redhat.com/browse/FAI-557): CF score calculator should have a more informative message when a feature type mismatch error occurs (e.g. which feature caused the error).

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
