### PR TITLE
KOGITO-5896 Configure Cypress tests to be executed as part of ui-packages maven build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-it/
 node/
 coverage/
 target/

--- a/ui-packages/package.json
+++ b/ui-packages/package.json
@@ -84,7 +84,7 @@
     "concurrently": "^5.1.0",
     "copy-webpack-plugin": "^6.0.3",
     "css-loader": "^3.2.0",
-    "cypress": "^4.1.0",
+    "cypress": "^7.4.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "enzyme-to-json": "^3.4.4",
@@ -139,6 +139,7 @@
     "@patternfly/react-icons": "4.11.0",
     "@patternfly/react-styles": "4.11.0",
     "@patternfly/react-tokens": "4.12.0",
+    "@types/express-serve-static-core": "^4.17.21",
     "axios": "0.21.1"
   }
 }

--- a/ui-packages/package.json
+++ b/ui-packages/package.json
@@ -12,11 +12,7 @@
     "build:fast": "lerna run build:fast --stream --",
     "build:prod": "lerna run build:prod --include-dependencies --stream --",
     "test": "lerna run test:coverage --stream --",
-    "cypress:run": "lerna run cypress:run --",
-    "cypress:run-management-console": "cypress run --project ./packages/management-console",
-    "cypress:run-management-console-webapp": "cypress run --project ./packages/management-console-webapp",
-    "cypress:run-task-console-webapp": "cypress run --project ./packages/task-console-webapp",
-    "cypress:run-runtime-tools-dev-ui-webapp": "cypress run --project ./packages/runtime-tools-dev-ui-webapp",
+    "test:it": "lerna run test:it --stream --concurrency=1 --no-bail --",
     "locktt": "locktt",
     "postinstall": "patch-package"
   },

--- a/ui-packages/packages/cypress-ouia/package.json
+++ b/ui-packages/packages/cypress-ouia/package.json
@@ -22,9 +22,6 @@
     "format": "prettier --config ../../.prettierrc --check --write './src/**/*.{tsx,ts,js}'",
     "clean": "rimraf dist"
   },
-  "devDependencies": {
-    "@types/cypress": "^1.1.0"
-  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "yarn run format",

--- a/ui-packages/packages/management-console-webapp/cypress/integration/processes/page-initial-load.ts
+++ b/ui-packages/packages/management-console-webapp/cypress/integration/processes/page-initial-load.ts
@@ -39,8 +39,7 @@ describe('Process List Page test', () => {
         });
     });
     it('Check main content', () => {
-      cy.ouiaId('management-console', 'page')
-        .find('[data-ouia-main=true]')
+      cy.get('[data-ouia-main=true]')
         .should('exist')
         .within($main => {
           cy.ouiaType('page-section-header')
@@ -61,13 +60,11 @@ describe('Process List Page test', () => {
                     });
                 });
             });
-          cy.ouiaType('page-section-content')
+          cy.ouiaType('process-list-page')
             .should('exist')
-            .within($content => {
+            .within($page => {
               cy.ouiaType('process-list-toolbar').should('be.visible');
-              cy.ouiaType('process-list-table')
-                .should('be.visible')
-                .ouiaSafe();
+              cy.ouiaType('process-list-table').should('be.visible');
               cy.ouiaType('load-more')
                 .scrollIntoView()
                 .should('be.visible');
@@ -77,21 +74,20 @@ describe('Process List Page test', () => {
   });
   describe('Data presentation', () => {
     it('Table Layout', () => {
-      cy.ouiaType('page-section-content').within($page => {
+      cy.ouiaType('process-list-page').within($page => {
         cy.ouiaType('process-list-table')
           .ouiaSafe()
-          .ouiaType('process-list-table-item')
+          .ouiaType('process-list-row')
           .should('have.length', 10)
-          .eq(0)
+          .ouiaId('8035b580-6ae4-4aa8-9ec0-e18e19809e0b1')
           .within($item => {
-            cy.ouiaType('datalist-expand-toggle').should('be.visible');
-            cy.ouiaType('datalist-checkbox')
-              .should('be.visible')
-              .and('be.enabled');
-            cy.ouiaType('datalist-cell').then($cells => {
-              cy.wrap($cells)
-                .ouiaId('endpoint')
-                .should('be.visible');
+            cy.ouiaType('process-list-cell').then($cells => {
+              cy.ouiaId('__toggle').should('be.visible');
+              cy.ouiaId('__select')
+                .should('be.visible')
+                .find('input')
+                .should('be.enabled');
+              cy.ouiaId('id').should('be.visible');
               cy.wrap($cells)
                 .ouiaId('status')
                 .should('be.visible')
@@ -100,69 +96,67 @@ describe('Process List Page test', () => {
                 .ouiaId('created')
                 .should('be.visible');
               cy.wrap($cells)
-                .ouiaId('updated')
+                .ouiaId('last update')
+                .should('be.visible');
+              cy.wrap($cells)
+                .ouiaId('__actions')
                 .should('be.visible');
             });
           });
       });
     });
     it('Process-list-item expanded.', () => {
-      cy.ouiaType('page-section-content').within($page => {
+      cy.ouiaType('process-list-page').within($page => {
+        cy.ouiaType('load-more')
+          .scrollIntoView()
+          .should('be.visible')
+          .ouiaType('PF4/Dropdown')
+          .click();
         cy.ouiaType('process-list-table')
           .ouiaSafe()
-          .ouiaType('process-list-table-item')
-          .ouiaId('process-8035b580-6ae4-4aa8-9ec0-e18e19809e0b')
-          .within($item => {
-            cy.ouiaType('process-list-table-item-expand').should(
-              'not.be.visible'
-            );
-            cy.ouiaType('datalist-expand-toggle')
+          .within($table => {
+            cy.ouiaId(
+              '8035b580-6ae4-4aa8-9ec0-e18e19809e0b',
+              'process-list-row-expanded'
+            )
+              .scrollIntoView()
+              .should('not.be.visible');
+            cy.ouiaId(
+              '8035b580-6ae4-4aa8-9ec0-e18e19809e0b',
+              'process-list-row'
+            )
               .scrollIntoView()
               .should('be.visible')
-              .click({ force: true });
-            cy.ouiaType('process-list-table-item-expand')
-              .should('be.visible')
-              .within($expanded => {
-                cy.ouiaType('process-list-table-item').should('have.length', 4);
-                cy.ouiaId(
-                  'process-c54ca5b0-b975-46e2-a9a0-6a86bf7ac21e',
-                  'process-list-table-item'
-                )
+              .within($row => {
+                cy.ouiaId('__toggle', 'process-list-cell')
+                  .scrollIntoView()
                   .should('be.visible')
-                  .within($it => {
-                    cy.ouiaType('datalist-expand-toggle').should('not.exist');
-                    cy.ouiaType('datalist-checkbox').should('not.be.visible');
-                    cy.ouiaId('endpoint', 'datalist-cell')
-                      .should('be.visible')
-                      .and('contain.text', 'FlightBooking');
-                    cy.ouiaId('status', 'datalist-cell')
-                      .should('be.visible')
-                      .and('contain.text', 'Completed');
-                  });
+                  .ouiaType('PF4/Button')
+                  .click();
               });
             cy.ouiaId(
-              'process-c54ca5b0-b975-46e2-a9a0-6a86bf7ac21eaccd',
-              'process-list-table-item'
+              '8035b580-6ae4-4aa8-9ec0-e18e19809e0b',
+              'process-list-row-expanded'
             )
+              .scrollIntoView()
               .should('be.visible')
-              .within($it => {
-                cy.ouiaType('datalist-expand-toggle').should('not.exist');
-                cy.ouiaType('datalist-checkbox').should('not.be.visible');
-                cy.ouiaId('endpoint', 'datalist-cell')
-                  .should('be.visible')
-                  .and('contain.text', 'FlightBooking test 1');
-                cy.ouiaId('status', 'datalist-cell')
-                  .should('be.visible')
-                  .and('contain.text', 'Suspended');
+              .ouiaId(
+                '8035b580-6ae4-4aa8-9ec0-e18e19809e0b',
+                'process-list-child-table'
+              )
+              .should('be.visible')
+              .within($childTable => {
+                // 1 header and 4 items, better selectors would require major refactoring of process-list/ProcessListChildTable component.
+                cy.ouiaType('PF4/TableRow').should('have.length', 5);
               });
           });
       });
     });
     it('Load More', () => {
-      cy.ouiaType('page-section-content').within($page => {
+      cy.ouiaType('process-list-page').within($page => {
         cy.ouiaType('process-list-table')
           .ouiaSafe()
-          .ouiaType('process-list-table-item')
+          .ouiaType('process-list-row')
           .should('have.length', 10);
         cy.ouiaType('load-more')
           .scrollIntoView()
@@ -170,7 +164,7 @@ describe('Process List Page test', () => {
           .ouiaType('PF4/Dropdown')
           .click();
         cy.ouiaType('process-list-table')
-          .ouiaType('process-list-table-item')
+          .ouiaType('process-list-row')
           .should('have.length', 13);
       });
     });

--- a/ui-packages/packages/management-console-webapp/cypress/integration/spec.ts
+++ b/ui-packages/packages/management-console-webapp/cypress/integration/spec.ts
@@ -1,6 +1,0 @@
-/// <reference types="Cypress" />
-describe('Management Console First Test', function() {
-  it('Does not do much!', function() {
-    expect(true).to.equal(true);
-  });
-});

--- a/ui-packages/packages/management-console-webapp/package.json
+++ b/ui-packages/packages/management-console-webapp/package.json
@@ -28,7 +28,8 @@
     "codegen": "graphql-codegen",
     "cypress:run": "cypress run",
     "cypress:open": "cypress open",
-    "test:it": "start-server-and-test 'yarn dev' 9000 'yarn cypress:run'"
+    "start:it": "concurrently 'webpack --config webpack.it.js && yarn serve -p 9000 -c ../serve.json ./dist-it/' 'yarn run dev:server'",
+    "test:it": "start-server-and-test 'yarn start:it' 9000 'yarn cypress:run' && echo"
   },
   "dependencies": {
     "@kogito-apps/components-common": "^1.0.0",
@@ -40,7 +41,8 @@
   "devDependencies": {
     "@kogito-apps/cypress-ouia": "^1.0.0",
     "@kogito-apps/ouia-tools": "^1.0.0",
-    "core-js": "3.6.5"
+    "core-js": "3.6.5",
+    "serve": "^12.0.1"
   },
   "jest": {
     "preset": "ts-jest/presets/js-with-ts",

--- a/ui-packages/packages/management-console-webapp/serve.json
+++ b/ui-packages/packages/management-console-webapp/serve.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "**/*", "destination": "/index.html" }
+  ]
+}

--- a/ui-packages/packages/management-console-webapp/webpack.it.js
+++ b/ui-packages/packages/management-console-webapp/webpack.it.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const merge = require('webpack-merge');
+const common = require('./webpack.dev.js');
+const webpack = require('webpack');
+
+const HOST = process.env.HOST || 'localhost';
+const PORT = process.env.PORT || '9000';
+
+module.exports = merge(common, {
+  output: {
+      path: path.resolve(__dirname, 'dist-it'),
+  }
+});

--- a/ui-packages/packages/management-console/cypress/integration/spec.ts
+++ b/ui-packages/packages/management-console/cypress/integration/spec.ts
@@ -1,6 +1,0 @@
-/// <reference types="Cypress" />
-describe('Management Console First Test', function() {
-  it('Does not do much!', function() {
-    expect(true).to.equal(true);
-  });
-});

--- a/ui-packages/packages/management-console/package.json
+++ b/ui-packages/packages/management-console/package.json
@@ -28,7 +28,8 @@
     "codegen": "graphql-codegen",
     "cypress:run": "cypress run",
     "cypress:open": "cypress open",
-    "test:it": "start-server-and-test 'yarn dev' 9000 'yarn cypress:run'"
+    "start:it": "concurrently 'webpack --config webpack.it.js && yarn serve -p 9000 -c ../serve.json ./dist-it/' 'yarn run dev:server'",
+    "test:it": "start-server-and-test 'yarn start:it' 9000 'yarn cypress:run' && echo"
   },
   "dependencies": {
     "@kogito-apps/common": "1.0.0",
@@ -40,7 +41,8 @@
   "devDependencies": {
     "@kogito-apps/cypress-ouia": "^1.0.0",
     "@kogito-apps/ouia-tools": "^1.0.0",
-    "core-js": "3.6.5"
+    "core-js": "3.6.5",
+    "serve": "^12.0.1"
   },
   "jest": {
     "preset": "ts-jest/presets/js-with-ts",

--- a/ui-packages/packages/management-console/serve.json
+++ b/ui-packages/packages/management-console/serve.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "**/*", "destination": "/index.html" }
+  ]
+}

--- a/ui-packages/packages/management-console/webpack.it.js
+++ b/ui-packages/packages/management-console/webpack.it.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const merge = require('webpack-merge');
+const common = require('./webpack.dev.js');
+const webpack = require('webpack');
+
+const HOST = process.env.HOST || 'localhost';
+const PORT = process.env.PORT || '9000';
+
+module.exports = merge(common, {
+  output: {
+      path: path.resolve(__dirname, 'dist-it'),
+  }
+});

--- a/ui-packages/packages/ouia-tools/tsconfig.json
+++ b/ui-packages/packages/ouia-tools/tsconfig.json
@@ -12,8 +12,6 @@
     ],
     "exclude": [
         "src/**/*.test.ts",
-        "src/**/*.test.tsx",
-        "../../node_modules",
-        "node_modules"
+        "src/**/*.test.tsx"
     ]
 }

--- a/ui-packages/packages/process-list/src/envelope/components/ProcessListChildTable/ProcessListChildTable.tsx
+++ b/ui-packages/packages/process-list/src/envelope/components/ProcessListChildTable/ProcessListChildTable.tsx
@@ -15,7 +15,14 @@
  */
 
 import { ProcessListDriver } from '../../../api';
-import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import {
+  ICell,
+  IRow,
+  IRowCell,
+  Table,
+  TableBody,
+  TableHeader
+} from '@patternfly/react-table';
 import React, { useEffect, useState } from 'react';
 import {
   ProcessInstance,
@@ -75,26 +82,17 @@ const ProcessListChildTable: React.FC<ProcessListChildTableProps &
     false
   );
   const [error, setError] = useState<string>(undefined);
-  const columns = [
-    {
-      title: ''
-    },
-    {
-      title: 'Id'
-    },
-    {
-      title: 'Status'
-    },
-    {
-      title: 'Created'
-    },
-    {
-      title: 'Last update'
-    },
-    {
-      title: ''
-    }
+  const columnNames: string[] = [
+    '__Select',
+    'Id',
+    'Status',
+    'Created',
+    'Last update',
+    '__Actions'
   ];
+  const columns: ICell[] = columnNames.map(it => ({
+    title: it.startsWith('__') ? '' : it
+  }));
 
   const handleClick = (childProcessInstance: ProcessInstance): void => {
     driver.openProcess(childProcessInstance);
@@ -128,106 +126,116 @@ const ProcessListChildTable: React.FC<ProcessListChildTableProps &
 
   const createRows = (childProcessInstances: ProcessInstance[]): void => {
     if (!_.isEmpty(childProcessInstances)) {
-      const tempRows = [];
+      const tempRows: IRow[] = [];
       childProcessInstances.forEach((child: ProcessInstance) => {
-        tempRows.push({
-          cells: [
-            {
-              title: (
-                <>
-                  {child.addons.includes('process-management') &&
-                  child.serviceUrl !== null ? (
-                    <Checkbox
-                      isChecked={child.isSelected}
-                      onChange={() => {
-                        checkBoxSelect(child);
-                      }}
-                      aria-label="process-list-checkbox"
-                      id={`checkbox-${child.id}`}
-                      name={`checkbox-${child.id}`}
-                    />
-                  ) : (
-                    <DisablePopup
-                      processInstanceData={child}
-                      component={
-                        <Checkbox
-                          aria-label="process-list-checkbox-disabled"
-                          id={`checkbox-${child.id}`}
-                          isDisabled={true}
-                        />
-                      }
-                    />
-                  )}
-                </>
-              )
-            },
-            {
-              title: (
-                <>
-                  <a
-                    className="kogito-process-list__link"
-                    onClick={() => handleClick(child)}
-                    {...componentOuiaProps(
-                      ouiaId,
-                      'process-description',
-                      ouiaSafe
-                    )}
-                  >
-                    <strong>
-                      <ItemDescriptor
-                        itemDescription={getProcessInstanceDescription(child)}
-                      />
-                    </strong>
-                  </a>
-                  <EndpointLink
-                    serviceUrl={child.serviceUrl}
-                    isLinkShown={false}
-                  />
-                </>
-              )
-            },
-            {
-              title:
-                child.state === ProcessInstanceState.Error ? (
-                  <ErrorPopover
-                    processInstanceData={child}
-                    onSkipClick={onSkipClick}
-                    onRetryClick={onRetryClick}
+        const cells: IRowCell[] = [
+          {
+            title: (
+              <>
+                {child.addons.includes('process-management') &&
+                child.serviceUrl !== null ? (
+                  <Checkbox
+                    isChecked={child.isSelected}
+                    onChange={() => {
+                      checkBoxSelect(child);
+                    }}
+                    aria-label="process-list-checkbox"
+                    id={`checkbox-${child.id}`}
+                    name={`checkbox-${child.id}`}
                   />
                 ) : (
-                  ProcessInstanceIconCreator(child.state)
-                )
-            },
-            {
-              title: child.start ? (
-                <Moment fromNow>{new Date(`${child.start}`)}</Moment>
-              ) : (
-                ''
-              )
-            },
-            {
-              title: child.lastUpdate ? (
-                <span>
-                  {' '}
-                  <HistoryIcon className="pf-u-mr-sm" /> Updated{' '}
-                  <Moment fromNow>{new Date(`${child.lastUpdate}`)}</Moment>
-                </span>
-              ) : (
-                ''
-              )
-            },
-            {
-              title: (
-                <ProcessListActionsKebab
-                  processInstance={child}
+                  <DisablePopup
+                    processInstanceData={child}
+                    component={
+                      <Checkbox
+                        aria-label="process-list-checkbox-disabled"
+                        id={`checkbox-${child.id}`}
+                        isDisabled={true}
+                      />
+                    }
+                  />
+                )}
+              </>
+            )
+          },
+          {
+            title: (
+              <>
+                <a
+                  className="kogito-process-list__link"
+                  onClick={() => handleClick(child)}
+                  {...componentOuiaProps(
+                    ouiaId,
+                    'process-description',
+                    ouiaSafe
+                  )}
+                >
+                  <strong>
+                    <ItemDescriptor
+                      itemDescription={getProcessInstanceDescription(child)}
+                    />
+                  </strong>
+                </a>
+                <EndpointLink
+                  serviceUrl={child.serviceUrl}
+                  isLinkShown={false}
+                />
+              </>
+            )
+          },
+          {
+            title:
+              child.state === ProcessInstanceState.Error ? (
+                <ErrorPopover
+                  processInstanceData={child}
                   onSkipClick={onSkipClick}
                   onRetryClick={onRetryClick}
-                  onAbortClick={onAbortClick}
-                  key={child.id}
                 />
+              ) : (
+                ProcessInstanceIconCreator(child.state)
               )
-            }
-          ]
+          },
+          {
+            title: child.start ? (
+              <Moment fromNow>{new Date(`${child.start}`)}</Moment>
+            ) : (
+              ''
+            )
+          },
+          {
+            title: child.lastUpdate ? (
+              <span>
+                {' '}
+                <HistoryIcon className="pf-u-mr-sm" /> Updated{' '}
+                <Moment fromNow>{new Date(`${child.lastUpdate}`)}</Moment>
+              </span>
+            ) : (
+              ''
+            )
+          },
+          {
+            title: (
+              <ProcessListActionsKebab
+                processInstance={child}
+                onSkipClick={onSkipClick}
+                onRetryClick={onRetryClick}
+                onAbortClick={onAbortClick}
+                key={child.id}
+              />
+            )
+          }
+        ];
+        cells.forEach((cellInRow, index) => {
+          cellInRow.props = componentOuiaProps(
+            columnNames[index].toLowerCase(),
+            'process-list-cell',
+            true
+          );
+        });
+        tempRows.push({
+          // props are not passed to the actual <tr> element (to set OUIA attributes).
+          // Seems that only solution is to use TableComposable instead.
+          cells: cells
         });
       });
       setRows(tempRows);

--- a/ui-packages/packages/process-list/src/envelope/components/ProcessListChildTable/tests/__snapshots__/ProcessListChildTable.test.tsx.snap
+++ b/ui-packages/packages/process-list/src/envelope/components/ProcessListChildTable/tests/__snapshots__/ProcessListChildTable.test.tsx.snap
@@ -382,6 +382,11 @@ exports[`ProcessListChildTable test render table 1`] = `
         Object {
           "cells": Array [
             Object {
+              "props": Object {
+                "data-ouia-component-id": "__select",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <React.Fragment>
                 <Checkbox
                   aria-label="process-list-checkbox"
@@ -396,6 +401,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </React.Fragment>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "id",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <React.Fragment>
                 <a
                   className="kogito-process-list__link"
@@ -422,6 +432,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </React.Fragment>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "status",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <ErrorPopover
                 onRetryClick={[MockFunction]}
                 onSkipClick={[MockFunction]}
@@ -490,6 +505,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "created",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <t
                 ago={false}
                 calendar={false}
@@ -511,6 +531,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </t>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "last update",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <span>
                  
                 <HistoryIcon
@@ -543,6 +568,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </span>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "__actions",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <ProcessListActionsKebab
                 onAbortClick={[MockFunction]}
                 onRetryClick={[MockFunction]}
@@ -616,6 +646,11 @@ exports[`ProcessListChildTable test render table 1`] = `
         Object {
           "cells": Array [
             Object {
+              "props": Object {
+                "data-ouia-component-id": "__select",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <React.Fragment>
                 <Checkbox
                   aria-label="process-list-checkbox"
@@ -630,6 +665,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </React.Fragment>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "id",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <React.Fragment>
                 <a
                   className="kogito-process-list__link"
@@ -656,6 +696,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </React.Fragment>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "status",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <ErrorPopover
                 onRetryClick={[MockFunction]}
                 onSkipClick={[MockFunction]}
@@ -723,6 +768,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "created",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <t
                 ago={false}
                 calendar={false}
@@ -744,6 +794,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </t>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "last update",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <span>
                  
                 <HistoryIcon
@@ -776,6 +831,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </span>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "__actions",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <ProcessListActionsKebab
                 onAbortClick={[MockFunction]}
                 onRetryClick={[MockFunction]}
@@ -848,6 +908,11 @@ exports[`ProcessListChildTable test render table 1`] = `
         Object {
           "cells": Array [
             Object {
+              "props": Object {
+                "data-ouia-component-id": "__select",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <React.Fragment>
                 <Checkbox
                   aria-label="process-list-checkbox"
@@ -862,6 +927,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </React.Fragment>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "id",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <React.Fragment>
                 <a
                   className="kogito-process-list__link"
@@ -888,6 +958,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </React.Fragment>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "status",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <ErrorPopover
                 onRetryClick={[MockFunction]}
                 onSkipClick={[MockFunction]}
@@ -1046,6 +1121,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               />,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "created",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <t
                 ago={false}
                 calendar={false}
@@ -1067,6 +1147,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </t>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "last update",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <span>
                  
                 <HistoryIcon
@@ -1099,6 +1184,11 @@ exports[`ProcessListChildTable test render table 1`] = `
               </span>,
             },
             Object {
+              "props": Object {
+                "data-ouia-component-id": "__actions",
+                "data-ouia-component-type": "process-list-cell",
+                "data-ouia-safe": true,
+              },
               "title": <ProcessListActionsKebab
                 onAbortClick={[MockFunction]}
                 onRetryClick={[MockFunction]}
@@ -2800,6 +2890,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                     Object {
                       "cells": Array [
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <React.Fragment>
                             <Checkbox
                               aria-label="process-list-checkbox"
@@ -2814,6 +2909,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </React.Fragment>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <React.Fragment>
                             <a
                               className="kogito-process-list__link"
@@ -2840,6 +2940,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </React.Fragment>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <ErrorPopover
                             onRetryClick={[MockFunction]}
                             onSkipClick={[MockFunction]}
@@ -2908,6 +3013,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           />,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <t
                             ago={false}
                             calendar={false}
@@ -2929,6 +3039,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </t>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <span>
                              
                             <HistoryIcon
@@ -2961,6 +3076,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </span>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <ProcessListActionsKebab
                             onAbortClick={[MockFunction]}
                             onRetryClick={[MockFunction]}
@@ -3034,6 +3154,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                     Object {
                       "cells": Array [
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <React.Fragment>
                             <Checkbox
                               aria-label="process-list-checkbox"
@@ -3048,6 +3173,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </React.Fragment>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <React.Fragment>
                             <a
                               className="kogito-process-list__link"
@@ -3074,6 +3204,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </React.Fragment>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <ErrorPopover
                             onRetryClick={[MockFunction]}
                             onSkipClick={[MockFunction]}
@@ -3141,6 +3276,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           />,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <t
                             ago={false}
                             calendar={false}
@@ -3162,6 +3302,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </t>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <span>
                              
                             <HistoryIcon
@@ -3194,6 +3339,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </span>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <ProcessListActionsKebab
                             onAbortClick={[MockFunction]}
                             onRetryClick={[MockFunction]}
@@ -3266,6 +3416,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                     Object {
                       "cells": Array [
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <React.Fragment>
                             <Checkbox
                               aria-label="process-list-checkbox"
@@ -3280,6 +3435,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </React.Fragment>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <React.Fragment>
                             <a
                               className="kogito-process-list__link"
@@ -3306,6 +3466,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </React.Fragment>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <ErrorPopover
                             onRetryClick={[MockFunction]}
                             onSkipClick={[MockFunction]}
@@ -3464,6 +3629,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           />,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <t
                             ago={false}
                             calendar={false}
@@ -3485,6 +3655,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </t>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <span>
                              
                             <HistoryIcon
@@ -3517,6 +3692,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           </span>,
                         },
                         Object {
+                          "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
+                          },
                           "title": <ProcessListActionsKebab
                             onAbortClick={[MockFunction]}
                             onRetryClick={[MockFunction]}
@@ -3688,6 +3868,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                       Object {
                         "cells": Array [
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <Checkbox
                                 aria-label="process-list-checkbox"
@@ -3702,6 +3887,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <a
                                 className="kogito-process-list__link"
@@ -3728,6 +3918,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ErrorPopover
                               onRetryClick={[MockFunction]}
                               onSkipClick={[MockFunction]}
@@ -3796,6 +3991,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             />,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <t
                               ago={false}
                               calendar={false}
@@ -3817,6 +4017,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </t>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <span>
                                
                               <HistoryIcon
@@ -3849,6 +4054,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </span>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ProcessListActionsKebab
                               onAbortClick={[MockFunction]}
                               onRetryClick={[MockFunction]}
@@ -3921,6 +4131,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-0": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -3939,6 +4152,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-5": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ProcessListActionsKebab
@@ -4012,6 +4228,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "created": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <t
@@ -4037,6 +4256,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "id": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -4073,6 +4295,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "last-update": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <span>
@@ -4110,6 +4335,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "status": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ErrorPopover
@@ -4183,6 +4411,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                       Object {
                         "cells": Array [
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <Checkbox
                                 aria-label="process-list-checkbox"
@@ -4197,6 +4430,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <a
                                 className="kogito-process-list__link"
@@ -4223,6 +4461,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ErrorPopover
                               onRetryClick={[MockFunction]}
                               onSkipClick={[MockFunction]}
@@ -4290,6 +4533,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             />,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <t
                               ago={false}
                               calendar={false}
@@ -4311,6 +4559,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </t>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <span>
                                
                               <HistoryIcon
@@ -4343,6 +4596,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </span>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ProcessListActionsKebab
                               onAbortClick={[MockFunction]}
                               onRetryClick={[MockFunction]}
@@ -4414,6 +4672,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-0": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -4432,6 +4693,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-5": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ProcessListActionsKebab
@@ -4504,6 +4768,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "created": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <t
@@ -4529,6 +4796,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "id": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -4565,6 +4835,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "last-update": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <span>
@@ -4602,6 +4875,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "status": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ErrorPopover
@@ -4674,6 +4950,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                       Object {
                         "cells": Array [
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <Checkbox
                                 aria-label="process-list-checkbox"
@@ -4688,6 +4969,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <a
                                 className="kogito-process-list__link"
@@ -4714,6 +5000,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ErrorPopover
                               onRetryClick={[MockFunction]}
                               onSkipClick={[MockFunction]}
@@ -4872,6 +5163,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             />,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <t
                               ago={false}
                               calendar={false}
@@ -4893,6 +5189,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </t>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <span>
                                
                               <HistoryIcon
@@ -4925,6 +5226,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </span>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ProcessListActionsKebab
                               onAbortClick={[MockFunction]}
                               onRetryClick={[MockFunction]}
@@ -5087,6 +5393,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-0": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -5105,6 +5414,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-5": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ProcessListActionsKebab
@@ -5268,6 +5580,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "created": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <t
@@ -5293,6 +5608,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "id": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -5329,6 +5647,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "last-update": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <span>
@@ -5366,6 +5687,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "status": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ErrorPopover
@@ -5535,6 +5859,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                       Object {
                         "cells": Array [
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <Checkbox
                                 aria-label="process-list-checkbox"
@@ -5549,6 +5878,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <a
                                 className="kogito-process-list__link"
@@ -5575,6 +5909,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ErrorPopover
                               onRetryClick={[MockFunction]}
                               onSkipClick={[MockFunction]}
@@ -5643,6 +5982,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             />,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <t
                               ago={false}
                               calendar={false}
@@ -5664,6 +6008,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </t>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <span>
                                
                               <HistoryIcon
@@ -5696,6 +6045,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </span>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ProcessListActionsKebab
                               onAbortClick={[MockFunction]}
                               onRetryClick={[MockFunction]}
@@ -5768,6 +6122,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-0": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -5786,6 +6143,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-5": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ProcessListActionsKebab
@@ -5859,6 +6219,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "created": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <t
@@ -5884,6 +6247,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "id": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -5920,6 +6286,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "last-update": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <span>
@@ -5957,6 +6326,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "status": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ErrorPopover
@@ -6030,6 +6402,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                       Object {
                         "cells": Array [
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <Checkbox
                                 aria-label="process-list-checkbox"
@@ -6044,6 +6421,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <a
                                 className="kogito-process-list__link"
@@ -6070,6 +6452,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ErrorPopover
                               onRetryClick={[MockFunction]}
                               onSkipClick={[MockFunction]}
@@ -6137,6 +6524,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             />,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <t
                               ago={false}
                               calendar={false}
@@ -6158,6 +6550,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </t>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <span>
                                
                               <HistoryIcon
@@ -6190,6 +6587,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </span>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ProcessListActionsKebab
                               onAbortClick={[MockFunction]}
                               onRetryClick={[MockFunction]}
@@ -6261,6 +6663,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-0": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -6279,6 +6684,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-5": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ProcessListActionsKebab
@@ -6351,6 +6759,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "created": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <t
@@ -6376,6 +6787,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "id": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -6412,6 +6826,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "last-update": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <span>
@@ -6449,6 +6866,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "status": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ErrorPopover
@@ -6521,6 +6941,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                       Object {
                         "cells": Array [
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <Checkbox
                                 aria-label="process-list-checkbox"
@@ -6535,6 +6960,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <React.Fragment>
                               <a
                                 className="kogito-process-list__link"
@@ -6561,6 +6991,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </React.Fragment>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ErrorPopover
                               onRetryClick={[MockFunction]}
                               onSkipClick={[MockFunction]}
@@ -6719,6 +7154,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             />,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <t
                               ago={false}
                               calendar={false}
@@ -6740,6 +7180,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </t>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <span>
                                
                               <HistoryIcon
@@ -6772,6 +7217,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                             </span>,
                           },
                           Object {
+                            "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
+                            },
                             "title": <ProcessListActionsKebab
                               onAbortClick={[MockFunction]}
                               onRetryClick={[MockFunction]}
@@ -6934,6 +7384,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-0": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__select",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -6952,6 +7405,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "column-5": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "__actions",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ProcessListActionsKebab
@@ -7115,6 +7571,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "created": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "created",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <t
@@ -7140,6 +7599,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "id": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "id",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <React.Fragment>
@@ -7176,6 +7638,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "last-update": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "last update",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <span>
@@ -7213,6 +7678,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                         "status": Object {
                           "formatters": Array [],
                           "props": Object {
+                            "data-ouia-component-id": "status",
+                            "data-ouia-component-type": "process-list-cell",
+                            "data-ouia-safe": true,
                             "isVisible": true,
                           },
                           "title": <ErrorPopover
@@ -7670,6 +8138,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                         Object {
                           "cells": Array [
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <Checkbox
                                   aria-label="process-list-checkbox"
@@ -7684,6 +8157,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <a
                                   className="kogito-process-list__link"
@@ -7710,6 +8188,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ErrorPopover
                                 onRetryClick={[MockFunction]}
                                 onSkipClick={[MockFunction]}
@@ -7778,6 +8261,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               />,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <t
                                 ago={false}
                                 calendar={false}
@@ -7799,6 +8287,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </t>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <span>
                                  
                                 <HistoryIcon
@@ -7831,6 +8324,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </span>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ProcessListActionsKebab
                                 onAbortClick={[MockFunction]}
                                 onRetryClick={[MockFunction]}
@@ -7903,6 +8401,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-0": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -7921,6 +8422,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-5": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ProcessListActionsKebab
@@ -7994,6 +8498,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "created": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <t
@@ -8019,6 +8526,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "id": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -8055,6 +8565,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "last-update": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <span>
@@ -8092,6 +8605,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "status": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ErrorPopover
@@ -8165,6 +8681,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                         Object {
                           "cells": Array [
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <Checkbox
                                   aria-label="process-list-checkbox"
@@ -8179,6 +8700,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <a
                                   className="kogito-process-list__link"
@@ -8205,6 +8731,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ErrorPopover
                                 onRetryClick={[MockFunction]}
                                 onSkipClick={[MockFunction]}
@@ -8272,6 +8803,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               />,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <t
                                 ago={false}
                                 calendar={false}
@@ -8293,6 +8829,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </t>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <span>
                                  
                                 <HistoryIcon
@@ -8325,6 +8866,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </span>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ProcessListActionsKebab
                                 onAbortClick={[MockFunction]}
                                 onRetryClick={[MockFunction]}
@@ -8396,6 +8942,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-0": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -8414,6 +8963,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-5": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ProcessListActionsKebab
@@ -8486,6 +9038,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "created": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <t
@@ -8511,6 +9066,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "id": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -8547,6 +9105,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "last-update": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <span>
@@ -8584,6 +9145,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "status": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ErrorPopover
@@ -8656,6 +9220,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                         Object {
                           "cells": Array [
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <Checkbox
                                   aria-label="process-list-checkbox"
@@ -8670,6 +9239,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <a
                                   className="kogito-process-list__link"
@@ -8696,6 +9270,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ErrorPopover
                                 onRetryClick={[MockFunction]}
                                 onSkipClick={[MockFunction]}
@@ -8854,6 +9433,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               />,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <t
                                 ago={false}
                                 calendar={false}
@@ -8875,6 +9459,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </t>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <span>
                                  
                                 <HistoryIcon
@@ -8907,6 +9496,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </span>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ProcessListActionsKebab
                                 onAbortClick={[MockFunction]}
                                 onRetryClick={[MockFunction]}
@@ -9069,6 +9663,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-0": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -9087,6 +9684,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-5": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ProcessListActionsKebab
@@ -9250,6 +9850,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "created": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <t
@@ -9275,6 +9878,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "id": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -9311,6 +9917,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "last-update": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <span>
@@ -9348,6 +9957,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "status": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ErrorPopover
@@ -9544,6 +10156,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                         Object {
                           "cells": Array [
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <Checkbox
                                   aria-label="process-list-checkbox"
@@ -9558,6 +10175,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <a
                                   className="kogito-process-list__link"
@@ -9584,6 +10206,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ErrorPopover
                                 onRetryClick={[MockFunction]}
                                 onSkipClick={[MockFunction]}
@@ -9652,6 +10279,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               />,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <t
                                 ago={false}
                                 calendar={false}
@@ -9673,6 +10305,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </t>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <span>
                                  
                                 <HistoryIcon
@@ -9705,6 +10342,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </span>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ProcessListActionsKebab
                                 onAbortClick={[MockFunction]}
                                 onRetryClick={[MockFunction]}
@@ -9777,6 +10419,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-0": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -9795,6 +10440,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-5": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ProcessListActionsKebab
@@ -9868,6 +10516,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "created": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <t
@@ -9893,6 +10544,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "id": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -9929,6 +10583,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "last-update": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <span>
@@ -9966,6 +10623,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "status": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ErrorPopover
@@ -10039,6 +10699,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                         Object {
                           "cells": Array [
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <Checkbox
                                   aria-label="process-list-checkbox"
@@ -10053,6 +10718,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <a
                                   className="kogito-process-list__link"
@@ -10079,6 +10749,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ErrorPopover
                                 onRetryClick={[MockFunction]}
                                 onSkipClick={[MockFunction]}
@@ -10146,6 +10821,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               />,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <t
                                 ago={false}
                                 calendar={false}
@@ -10167,6 +10847,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </t>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <span>
                                  
                                 <HistoryIcon
@@ -10199,6 +10884,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </span>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ProcessListActionsKebab
                                 onAbortClick={[MockFunction]}
                                 onRetryClick={[MockFunction]}
@@ -10270,6 +10960,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-0": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -10288,6 +10981,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-5": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ProcessListActionsKebab
@@ -10360,6 +11056,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "created": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <t
@@ -10385,6 +11084,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "id": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -10421,6 +11123,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "last-update": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <span>
@@ -10458,6 +11163,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "status": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ErrorPopover
@@ -10530,6 +11238,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                         Object {
                           "cells": Array [
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <Checkbox
                                   aria-label="process-list-checkbox"
@@ -10544,6 +11257,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <React.Fragment>
                                 <a
                                   className="kogito-process-list__link"
@@ -10570,6 +11288,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </React.Fragment>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ErrorPopover
                                 onRetryClick={[MockFunction]}
                                 onSkipClick={[MockFunction]}
@@ -10728,6 +11451,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               />,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <t
                                 ago={false}
                                 calendar={false}
@@ -10749,6 +11477,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </t>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <span>
                                  
                                 <HistoryIcon
@@ -10781,6 +11514,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                               </span>,
                             },
                             Object {
+                              "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
+                              },
                               "title": <ProcessListActionsKebab
                                 onAbortClick={[MockFunction]}
                                 onRetryClick={[MockFunction]}
@@ -10943,6 +11681,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-0": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__select",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -10961,6 +11702,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "column-5": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "__actions",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ProcessListActionsKebab
@@ -11124,6 +11868,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "created": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "created",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <t
@@ -11149,6 +11896,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "id": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "id",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <React.Fragment>
@@ -11185,6 +11935,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "last-update": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "last update",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <span>
@@ -11222,6 +11975,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                           "status": Object {
                             "formatters": Array [],
                             "props": Object {
+                              "data-ouia-component-id": "status",
+                              "data-ouia-component-type": "process-list-cell",
+                              "data-ouia-safe": true,
                               "isVisible": true,
                             },
                             "title": <ErrorPopover
@@ -11393,6 +12149,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           Object {
                             "cells": Array [
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "__select",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <React.Fragment>
                                   <Checkbox
                                     aria-label="process-list-checkbox"
@@ -11407,6 +12168,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </React.Fragment>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "id",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <React.Fragment>
                                   <a
                                     className="kogito-process-list__link"
@@ -11433,6 +12199,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </React.Fragment>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "status",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <ErrorPopover
                                   onRetryClick={[MockFunction]}
                                   onSkipClick={[MockFunction]}
@@ -11501,6 +12272,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 />,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "created",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <t
                                   ago={false}
                                   calendar={false}
@@ -11522,6 +12298,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </t>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "last update",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <span>
                                    
                                   <HistoryIcon
@@ -11554,6 +12335,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </span>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "__actions",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <ProcessListActionsKebab
                                   onAbortClick={[MockFunction]}
                                   onRetryClick={[MockFunction]}
@@ -11626,6 +12412,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "column-0": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <React.Fragment>
@@ -11644,6 +12433,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "column-5": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <ProcessListActionsKebab
@@ -11717,6 +12509,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "created": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <t
@@ -11742,6 +12537,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "id": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <React.Fragment>
@@ -11778,6 +12576,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "last-update": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <span>
@@ -11815,6 +12616,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "status": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <ErrorPopover
@@ -11888,6 +12692,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           Object {
                             "cells": Array [
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "__select",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <React.Fragment>
                                   <Checkbox
                                     aria-label="process-list-checkbox"
@@ -11902,6 +12711,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </React.Fragment>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "id",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <React.Fragment>
                                   <a
                                     className="kogito-process-list__link"
@@ -11928,6 +12742,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </React.Fragment>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "status",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <ErrorPopover
                                   onRetryClick={[MockFunction]}
                                   onSkipClick={[MockFunction]}
@@ -11995,6 +12814,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 />,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "created",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <t
                                   ago={false}
                                   calendar={false}
@@ -12016,6 +12840,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </t>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "last update",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <span>
                                    
                                   <HistoryIcon
@@ -12048,6 +12877,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </span>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "__actions",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <ProcessListActionsKebab
                                   onAbortClick={[MockFunction]}
                                   onRetryClick={[MockFunction]}
@@ -12119,6 +12953,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "column-0": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <React.Fragment>
@@ -12137,6 +12974,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "column-5": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <ProcessListActionsKebab
@@ -12209,6 +13049,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "created": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <t
@@ -12234,6 +13077,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "id": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <React.Fragment>
@@ -12270,6 +13116,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "last-update": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <span>
@@ -12307,6 +13156,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "status": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <ErrorPopover
@@ -12379,6 +13231,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                           Object {
                             "cells": Array [
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "__select",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <React.Fragment>
                                   <Checkbox
                                     aria-label="process-list-checkbox"
@@ -12393,6 +13250,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </React.Fragment>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "id",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <React.Fragment>
                                   <a
                                     className="kogito-process-list__link"
@@ -12419,6 +13281,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </React.Fragment>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "status",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <ErrorPopover
                                   onRetryClick={[MockFunction]}
                                   onSkipClick={[MockFunction]}
@@ -12577,6 +13444,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 />,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "created",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <t
                                   ago={false}
                                   calendar={false}
@@ -12598,6 +13470,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </t>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "last update",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <span>
                                    
                                   <HistoryIcon
@@ -12630,6 +13507,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 </span>,
                               },
                               Object {
+                                "props": Object {
+                                  "data-ouia-component-id": "__actions",
+                                  "data-ouia-component-type": "process-list-cell",
+                                  "data-ouia-safe": true,
+                                },
                                 "title": <ProcessListActionsKebab
                                   onAbortClick={[MockFunction]}
                                   onRetryClick={[MockFunction]}
@@ -12792,6 +13674,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "column-0": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "__select",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <React.Fragment>
@@ -12810,6 +13695,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "column-5": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "__actions",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <ProcessListActionsKebab
@@ -12973,6 +13861,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "created": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "created",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <t
@@ -12998,6 +13889,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "id": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "id",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <React.Fragment>
@@ -13034,6 +13928,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "last-update": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "last update",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <span>
@@ -13071,6 +13968,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                             "status": Object {
                               "formatters": Array [],
                               "props": Object {
+                                "data-ouia-component-id": "status",
+                                "data-ouia-component-type": "process-list-cell",
+                                "data-ouia-safe": true,
                                 "isVisible": true,
                               },
                               "title": <ErrorPopover
@@ -13545,6 +14445,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 Object {
                                   "cells": Array [
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "__select",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <React.Fragment>
                                         <Checkbox
                                           aria-label="process-list-checkbox"
@@ -13559,6 +14464,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </React.Fragment>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "id",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <React.Fragment>
                                         <a
                                           className="kogito-process-list__link"
@@ -13585,6 +14495,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </React.Fragment>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "status",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <ErrorPopover
                                         onRetryClick={[MockFunction]}
                                         onSkipClick={[MockFunction]}
@@ -13653,6 +14568,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       />,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "created",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <t
                                         ago={false}
                                         calendar={false}
@@ -13674,6 +14594,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </t>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "last update",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <span>
                                          
                                         <HistoryIcon
@@ -13706,6 +14631,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </span>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "__actions",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <ProcessListActionsKebab
                                         onAbortClick={[MockFunction]}
                                         onRetryClick={[MockFunction]}
@@ -13778,6 +14708,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "column-0": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "__select",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <React.Fragment>
@@ -13796,6 +14729,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "column-5": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "__actions",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <ProcessListActionsKebab
@@ -13869,6 +14805,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "created": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "created",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <t
@@ -13894,6 +14833,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "id": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "id",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <React.Fragment>
@@ -13930,6 +14872,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "last-update": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "last update",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <span>
@@ -13967,6 +14912,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "status": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "status",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <ErrorPopover
@@ -14048,6 +14996,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   Object {
                                     "cells": Array [
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "__select",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <React.Fragment>
                                           <Checkbox
                                             aria-label="process-list-checkbox"
@@ -14062,6 +15015,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </React.Fragment>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "id",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <React.Fragment>
                                           <a
                                             className="kogito-process-list__link"
@@ -14088,6 +15046,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </React.Fragment>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "status",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <ErrorPopover
                                           onRetryClick={[MockFunction]}
                                           onSkipClick={[MockFunction]}
@@ -14156,6 +15119,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         />,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "created",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <t
                                           ago={false}
                                           calendar={false}
@@ -14177,6 +15145,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </t>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "last update",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <span>
                                            
                                           <HistoryIcon
@@ -14209,6 +15182,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </span>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "__actions",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <ProcessListActionsKebab
                                           onAbortClick={[MockFunction]}
                                           onRetryClick={[MockFunction]}
@@ -14281,6 +15259,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "column-0": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "__select",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <React.Fragment>
@@ -14299,6 +15280,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "column-5": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "__actions",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <ProcessListActionsKebab
@@ -14372,6 +15356,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "created": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "created",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <t
@@ -14397,6 +15384,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "id": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "id",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <React.Fragment>
@@ -14433,6 +15423,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "last-update": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "last update",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <span>
@@ -14470,6 +15463,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "status": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "status",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <ErrorPopover
@@ -14568,6 +15564,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={0}
                                         data-label=""
+                                        data-ouia-component-id="__select"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-0-row-0"
                                       >
@@ -14575,6 +15574,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={0}
+                                          data-ouia-component-id="__select"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel={null}
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -14583,6 +15585,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={0}
+                                            data-ouia-component-id="__select"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel={null}
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -14592,6 +15597,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={0}
                                               data-label={null}
+                                              data-ouia-component-id="__select"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <Checkbox
@@ -14627,6 +15635,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={1}
                                         data-label="Id"
+                                        data-ouia-component-id="id"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-1-row-0"
                                       >
@@ -14634,6 +15645,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={1}
+                                          data-ouia-component-id="id"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Id"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -14642,6 +15656,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={1}
+                                            data-ouia-component-id="id"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Id"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -14651,6 +15668,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={1}
                                               data-label="Id"
+                                              data-ouia-component-id="id"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <a
@@ -14686,6 +15706,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={2}
                                         data-label="Status"
+                                        data-ouia-component-id="status"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-2-row-0"
                                       >
@@ -14693,6 +15716,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={2}
+                                          data-ouia-component-id="status"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Status"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -14701,6 +15727,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={2}
+                                            data-ouia-component-id="status"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Status"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -14710,6 +15739,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={2}
                                               data-label="Status"
+                                              data-ouia-component-id="status"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <ErrorPopover
@@ -14999,6 +16031,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={3}
                                         data-label="Created"
+                                        data-ouia-component-id="created"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-3-row-0"
                                       >
@@ -15006,6 +16041,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={3}
+                                          data-ouia-component-id="created"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Created"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -15014,6 +16052,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={3}
+                                            data-ouia-component-id="created"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Created"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -15023,6 +16064,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={3}
                                               data-label="Created"
+                                              data-ouia-component-id="created"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <t
@@ -15055,6 +16099,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={4}
                                         data-label="Last update"
+                                        data-ouia-component-id="last update"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-4-row-0"
                                       >
@@ -15062,6 +16109,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={4}
+                                          data-ouia-component-id="last update"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Last update"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -15070,6 +16120,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={4}
+                                            data-ouia-component-id="last update"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Last update"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -15079,6 +16132,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={4}
                                               data-label="Last update"
+                                              data-ouia-component-id="last update"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <span>
@@ -15142,6 +16198,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={5}
                                         data-label=""
+                                        data-ouia-component-id="__actions"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-5-row-0"
                                       >
@@ -15149,6 +16208,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={5}
+                                          data-ouia-component-id="__actions"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel={null}
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -15157,6 +16219,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={5}
+                                            data-ouia-component-id="__actions"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel={null}
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -15166,6 +16231,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={5}
                                               data-label={null}
+                                              data-ouia-component-id="__actions"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <ProcessListActionsKebab
@@ -15769,6 +16837,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 Object {
                                   "cells": Array [
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "__select",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <React.Fragment>
                                         <Checkbox
                                           aria-label="process-list-checkbox"
@@ -15783,6 +16856,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </React.Fragment>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "id",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <React.Fragment>
                                         <a
                                           className="kogito-process-list__link"
@@ -15809,6 +16887,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </React.Fragment>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "status",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <ErrorPopover
                                         onRetryClick={[MockFunction]}
                                         onSkipClick={[MockFunction]}
@@ -15876,6 +16959,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       />,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "created",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <t
                                         ago={false}
                                         calendar={false}
@@ -15897,6 +16985,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </t>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "last update",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <span>
                                          
                                         <HistoryIcon
@@ -15929,6 +17022,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </span>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "__actions",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <ProcessListActionsKebab
                                         onAbortClick={[MockFunction]}
                                         onRetryClick={[MockFunction]}
@@ -16000,6 +17098,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "column-0": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "__select",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <React.Fragment>
@@ -16018,6 +17119,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "column-5": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "__actions",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <ProcessListActionsKebab
@@ -16090,6 +17194,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "created": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "created",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <t
@@ -16115,6 +17222,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "id": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "id",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <React.Fragment>
@@ -16151,6 +17261,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "last-update": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "last update",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <span>
@@ -16188,6 +17301,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "status": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "status",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <ErrorPopover
@@ -16268,6 +17384,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   Object {
                                     "cells": Array [
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "__select",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <React.Fragment>
                                           <Checkbox
                                             aria-label="process-list-checkbox"
@@ -16282,6 +17403,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </React.Fragment>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "id",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <React.Fragment>
                                           <a
                                             className="kogito-process-list__link"
@@ -16308,6 +17434,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </React.Fragment>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "status",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <ErrorPopover
                                           onRetryClick={[MockFunction]}
                                           onSkipClick={[MockFunction]}
@@ -16375,6 +17506,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         />,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "created",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <t
                                           ago={false}
                                           calendar={false}
@@ -16396,6 +17532,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </t>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "last update",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <span>
                                            
                                           <HistoryIcon
@@ -16428,6 +17569,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </span>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "__actions",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <ProcessListActionsKebab
                                           onAbortClick={[MockFunction]}
                                           onRetryClick={[MockFunction]}
@@ -16499,6 +17645,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "column-0": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "__select",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <React.Fragment>
@@ -16517,6 +17666,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "column-5": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "__actions",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <ProcessListActionsKebab
@@ -16589,6 +17741,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "created": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "created",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <t
@@ -16614,6 +17769,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "id": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "id",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <React.Fragment>
@@ -16650,6 +17808,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "last-update": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "last update",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <span>
@@ -16687,6 +17848,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "status": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "status",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <ErrorPopover
@@ -16784,6 +17948,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={0}
                                         data-label=""
+                                        data-ouia-component-id="__select"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-0-row-1"
                                       >
@@ -16791,6 +17958,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={0}
+                                          data-ouia-component-id="__select"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel={null}
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -16799,6 +17969,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={0}
+                                            data-ouia-component-id="__select"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel={null}
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -16808,6 +17981,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={0}
                                               data-label={null}
+                                              data-ouia-component-id="__select"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <Checkbox
@@ -16843,6 +18019,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={1}
                                         data-label="Id"
+                                        data-ouia-component-id="id"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-1-row-1"
                                       >
@@ -16850,6 +18029,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={1}
+                                          data-ouia-component-id="id"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Id"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -16858,6 +18040,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={1}
+                                            data-ouia-component-id="id"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Id"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -16867,6 +18052,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={1}
                                               data-label="Id"
+                                              data-ouia-component-id="id"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <a
@@ -16902,6 +18090,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={2}
                                         data-label="Status"
+                                        data-ouia-component-id="status"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-2-row-1"
                                       >
@@ -16909,6 +18100,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={2}
+                                          data-ouia-component-id="status"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Status"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -16917,6 +18111,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={2}
+                                            data-ouia-component-id="status"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Status"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -16926,6 +18123,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={2}
                                               data-label="Status"
+                                              data-ouia-component-id="status"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <ErrorPopover
@@ -17214,6 +18414,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={3}
                                         data-label="Created"
+                                        data-ouia-component-id="created"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-3-row-1"
                                       >
@@ -17221,6 +18424,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={3}
+                                          data-ouia-component-id="created"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Created"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -17229,6 +18435,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={3}
+                                            data-ouia-component-id="created"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Created"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -17238,6 +18447,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={3}
                                               data-label="Created"
+                                              data-ouia-component-id="created"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <t
@@ -17270,6 +18482,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={4}
                                         data-label="Last update"
+                                        data-ouia-component-id="last update"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-4-row-1"
                                       >
@@ -17277,6 +18492,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={4}
+                                          data-ouia-component-id="last update"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Last update"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -17285,6 +18503,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={4}
+                                            data-ouia-component-id="last update"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Last update"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -17294,6 +18515,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={4}
                                               data-label="Last update"
+                                              data-ouia-component-id="last update"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <span>
@@ -17357,6 +18581,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={5}
                                         data-label=""
+                                        data-ouia-component-id="__actions"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-5-row-1"
                                       >
@@ -17364,6 +18591,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={5}
+                                          data-ouia-component-id="__actions"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel={null}
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -17372,6 +18602,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={5}
+                                            data-ouia-component-id="__actions"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel={null}
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -17381,6 +18614,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={5}
                                               data-label={null}
+                                              data-ouia-component-id="__actions"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <ProcessListActionsKebab
@@ -17983,6 +19219,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                 Object {
                                   "cells": Array [
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "__select",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <React.Fragment>
                                         <Checkbox
                                           aria-label="process-list-checkbox"
@@ -17997,6 +19238,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </React.Fragment>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "id",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <React.Fragment>
                                         <a
                                           className="kogito-process-list__link"
@@ -18023,6 +19269,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </React.Fragment>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "status",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <ErrorPopover
                                         onRetryClick={[MockFunction]}
                                         onSkipClick={[MockFunction]}
@@ -18181,6 +19432,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       />,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "created",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <t
                                         ago={false}
                                         calendar={false}
@@ -18202,6 +19458,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </t>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "last update",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <span>
                                          
                                         <HistoryIcon
@@ -18234,6 +19495,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       </span>,
                                     },
                                     Object {
+                                      "props": Object {
+                                        "data-ouia-component-id": "__actions",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
+                                      },
                                       "title": <ProcessListActionsKebab
                                         onAbortClick={[MockFunction]}
                                         onRetryClick={[MockFunction]}
@@ -18396,6 +19662,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "column-0": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "__select",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <React.Fragment>
@@ -18414,6 +19683,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "column-5": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "__actions",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <ProcessListActionsKebab
@@ -18577,6 +19849,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "created": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "created",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <t
@@ -18602,6 +19877,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "id": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "id",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <React.Fragment>
@@ -18638,6 +19916,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "last-update": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "last update",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <span>
@@ -18675,6 +19956,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   "status": Object {
                                     "formatters": Array [],
                                     "props": Object {
+                                      "data-ouia-component-id": "status",
+                                      "data-ouia-component-type": "process-list-cell",
+                                      "data-ouia-safe": true,
                                       "isVisible": true,
                                     },
                                     "title": <ErrorPopover
@@ -18846,6 +20130,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                   Object {
                                     "cells": Array [
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "__select",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <React.Fragment>
                                           <Checkbox
                                             aria-label="process-list-checkbox"
@@ -18860,6 +20149,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </React.Fragment>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "id",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <React.Fragment>
                                           <a
                                             className="kogito-process-list__link"
@@ -18886,6 +20180,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </React.Fragment>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "status",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <ErrorPopover
                                           onRetryClick={[MockFunction]}
                                           onSkipClick={[MockFunction]}
@@ -19044,6 +20343,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         />,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "created",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <t
                                           ago={false}
                                           calendar={false}
@@ -19065,6 +20369,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </t>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "last update",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <span>
                                            
                                           <HistoryIcon
@@ -19097,6 +20406,11 @@ exports[`ProcessListChildTable test render table 1`] = `
                                         </span>,
                                       },
                                       Object {
+                                        "props": Object {
+                                          "data-ouia-component-id": "__actions",
+                                          "data-ouia-component-type": "process-list-cell",
+                                          "data-ouia-safe": true,
+                                        },
                                         "title": <ProcessListActionsKebab
                                           onAbortClick={[MockFunction]}
                                           onRetryClick={[MockFunction]}
@@ -19259,6 +20573,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "column-0": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "__select",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <React.Fragment>
@@ -19277,6 +20594,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "column-5": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "__actions",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <ProcessListActionsKebab
@@ -19440,6 +20760,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "created": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "created",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <t
@@ -19465,6 +20788,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "id": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "id",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <React.Fragment>
@@ -19501,6 +20827,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "last-update": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "last update",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <span>
@@ -19538,6 +20867,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                     "status": Object {
                                       "formatters": Array [],
                                       "props": Object {
+                                        "data-ouia-component-id": "status",
+                                        "data-ouia-component-type": "process-list-cell",
+                                        "data-ouia-safe": true,
                                         "isVisible": true,
                                       },
                                       "title": <ErrorPopover
@@ -19726,6 +21058,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={0}
                                         data-label=""
+                                        data-ouia-component-id="__select"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-0-row-2"
                                       >
@@ -19733,6 +21068,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={0}
+                                          data-ouia-component-id="__select"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel={null}
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -19741,6 +21079,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={0}
+                                            data-ouia-component-id="__select"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel={null}
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -19750,6 +21091,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={0}
                                               data-label={null}
+                                              data-ouia-component-id="__select"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <Checkbox
@@ -19785,6 +21129,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={1}
                                         data-label="Id"
+                                        data-ouia-component-id="id"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-1-row-2"
                                       >
@@ -19792,6 +21139,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={1}
+                                          data-ouia-component-id="id"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Id"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -19800,6 +21150,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={1}
+                                            data-ouia-component-id="id"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Id"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -19809,6 +21162,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={1}
                                               data-label="Id"
+                                              data-ouia-component-id="id"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <a
@@ -19844,6 +21200,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={2}
                                         data-label="Status"
+                                        data-ouia-component-id="status"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-2-row-2"
                                       >
@@ -19851,6 +21210,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={2}
+                                          data-ouia-component-id="status"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Status"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -19859,6 +21221,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={2}
+                                            data-ouia-component-id="status"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Status"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -19868,6 +21233,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={2}
                                               data-label="Status"
+                                              data-ouia-component-id="status"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <ErrorPopover
@@ -20247,6 +21615,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={3}
                                         data-label="Created"
+                                        data-ouia-component-id="created"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-3-row-2"
                                       >
@@ -20254,6 +21625,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={3}
+                                          data-ouia-component-id="created"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Created"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -20262,6 +21636,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={3}
+                                            data-ouia-component-id="created"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Created"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -20271,6 +21648,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={3}
                                               data-label="Created"
+                                              data-ouia-component-id="created"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <t
@@ -20303,6 +21683,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={4}
                                         data-label="Last update"
+                                        data-ouia-component-id="last update"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-4-row-2"
                                       >
@@ -20310,6 +21693,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={4}
+                                          data-ouia-component-id="last update"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel="Last update"
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -20318,6 +21704,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={4}
+                                            data-ouia-component-id="last update"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel="Last update"
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -20327,6 +21716,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={4}
                                               data-label="Last update"
+                                              data-ouia-component-id="last update"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <span>
@@ -20390,6 +21782,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                       <BodyCell
                                         data-key={5}
                                         data-label=""
+                                        data-ouia-component-id="__actions"
+                                        data-ouia-component-type="process-list-cell"
+                                        data-ouia-safe={true}
                                         isVisible={true}
                                         key="col-5-row-2"
                                       >
@@ -20397,6 +21792,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                           className=""
                                           component="td"
                                           data-key={5}
+                                          data-ouia-component-id="__actions"
+                                          data-ouia-component-type="process-list-cell"
+                                          data-ouia-safe={true}
                                           dataLabel={null}
                                           onMouseEnter={[Function]}
                                           textCenter={false}
@@ -20405,6 +21803,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                             className=""
                                             component="td"
                                             data-key={5}
+                                            data-ouia-component-id="__actions"
+                                            data-ouia-component-type="process-list-cell"
+                                            data-ouia-safe={true}
                                             dataLabel={null}
                                             innerRef={null}
                                             onMouseEnter={[Function]}
@@ -20414,6 +21815,9 @@ exports[`ProcessListChildTable test render table 1`] = `
                                               className=""
                                               data-key={5}
                                               data-label={null}
+                                              data-ouia-component-id="__actions"
+                                              data-ouia-component-type="process-list-cell"
+                                              data-ouia-safe={true}
                                               onMouseEnter={[Function]}
                                             >
                                               <ProcessListActionsKebab

--- a/ui-packages/packages/process-list/src/envelope/components/ProcessListTable/ProcessListTable.tsx
+++ b/ui-packages/packages/process-list/src/envelope/components/ProcessListTable/ProcessListTable.tsx
@@ -96,7 +96,15 @@ const ProcessListTable: React.FC<ProcessListTableProps & OUIAProps> = ({
   ouiaSafe
 }) => {
   const [rowPairs, setRowPairs] = useState<any>([]);
-  const columns: string[] = ['Id', 'Status', 'Created', 'Last update'];
+  const columns: string[] = [
+    '__Toggle',
+    '__Select',
+    'Id',
+    'Status',
+    'Created',
+    'Last update',
+    '__Actions'
+  ];
   const [modalTitle, setModalTitle] = useState<string>('');
   const [modalContent, setModalContent] = useState<string>('');
   const [titleType, setTitleType] = useState<string>('');
@@ -309,6 +317,7 @@ const ProcessListTable: React.FC<ProcessListTableProps & OUIAProps> = ({
           onSkipClick={onSkipClick}
           onRetryClick={onRetryClick}
           onAbortClick={onAbortClick}
+          ouiaId={parentId}
         />
       );
     }
@@ -413,42 +422,48 @@ const ProcessListTable: React.FC<ProcessListTableProps & OUIAProps> = ({
         )}
       >
         <Thead>
-          <Tr>
-            <Th
-              style={{
-                width: '72px'
-              }}
-            />
-            <Th
-              style={{
-                width: '86px'
-              }}
-            />
+          <Tr ouiaId="process-list-table-header">
             {columns.map((column, columnIndex) => {
-              const sortParams = {
-                sort: {
-                  sortBy,
-                  onSort,
-                  columnIndex
-                }
-              };
+              let sortParams = {};
               if (!isLoading && rowPairs.length > 0) {
-                return (
-                  <Th key={columnIndex} {...sortParams}>
-                    {column}
-                  </Th>
-                );
-              } else {
-                return <Th key={columnIndex}>{column}</Th>;
+                sortParams = {
+                  sort: {
+                    sortBy,
+                    onSort,
+                    columnIndex
+                  }
+                };
               }
+              let styleParams = undefined;
+              switch (columnIndex) {
+                case 0:
+                  styleParams = { width: '72px' };
+                  sortParams = {};
+                  break;
+                case 1:
+                  styleParams = { width: '86px' };
+                  sortParams = {};
+                  break;
+                case columns.length - 1:
+                  styleParams = { width: '188px' };
+                  sortParams = {};
+                  break;
+              }
+              return (
+                <Th style={styleParams} key={columnIndex} {...sortParams}>
+                  {column.startsWith('__') ? '' : column}
+                </Th>
+              );
             })}
-            <Th style={{ width: '188px' }}></Th>
           </Tr>
         </Thead>
         {!isLoading && !_.isEmpty(rowPairs) ? (
           rowPairs.map((pair, pairIndex) => {
             const parentRow = (
-              <Tr key={`${pairIndex}-parent`}>
+              <Tr
+                key={`${pairIndex}-parent`}
+                {...componentOuiaProps(pair.id, 'process-list-row', true)}
+              >
                 <Td
                   key={`${pairIndex}-parent-0`}
                   expand={{
@@ -456,11 +471,21 @@ const ProcessListTable: React.FC<ProcessListTableProps & OUIAProps> = ({
                     isExpanded: expanded[pairIndex],
                     onToggle: () => onToggle(pairIndex, pair)
                   }}
+                  {...componentOuiaProps(
+                    columns[0].toLowerCase(),
+                    'process-list-cell',
+                    true
+                  )}
                 />
                 {pair.parent.map((cell, cellIndex) => (
                   <Td
                     key={`${pairIndex}-parent-${++cellIndex}`}
                     dataLabel={columns[cellIndex]}
+                    {...componentOuiaProps(
+                      columns[cellIndex].toLowerCase(),
+                      'process-list-cell',
+                      true
+                    )}
                   >
                     {cell}
                   </Td>
@@ -471,6 +496,11 @@ const ProcessListTable: React.FC<ProcessListTableProps & OUIAProps> = ({
               <Tr
                 key={`${pairIndex}-child`}
                 isExpanded={expanded[pairIndex] === true}
+                {...componentOuiaProps(
+                  pair.id,
+                  'process-list-row-expanded',
+                  true
+                )}
               >
                 <Td key={`${pairIndex}-child-0`} />
                 {rowPairs[pairIndex].child.map((cell, cellIndex) => (

--- a/ui-packages/packages/process-list/src/envelope/components/ProcessListTable/tests/__snapshots__/ProcessListTable.test.tsx.snap
+++ b/ui-packages/packages/process-list/src/envelope/components/ProcessListTable/tests/__snapshots__/ProcessListTable.test.tsx.snap
@@ -280,18 +280,22 @@ exports[`ProcessListTable test initial render with data 1`] = `
             <thead
               className=""
             >
-              <Tr>
+              <Tr
+                ouiaId="process-list-table-header"
+              >
                 <TrBase
                   innerRef={null}
+                  ouiaId="process-list-table-header"
                 >
                   <tr
                     className=""
-                    data-ouia-component-id="OUIA-Generated-TableRow-19"
+                    data-ouia-component-id="process-list-table-header"
                     data-ouia-component-type="PF4/TableRow"
                     data-ouia-safe={true}
                     hidden={false}
                   >
                     <Th
+                      key="0"
                       style={
                         Object {
                           "width": "72px",
@@ -319,6 +323,7 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </ThBase>
                     </Th>
                     <Th
+                      key="1"
                       style={
                         Object {
                           "width": "86px",
@@ -343,176 +348,6 @@ exports[`ProcessListTable test initial render with data 1`] = `
                             }
                           }
                         />
-                      </ThBase>
-                    </Th>
-                    <Th
-                      key="0"
-                      sort={
-                        Object {
-                          "columnIndex": 0,
-                          "onSort": [MockFunction],
-                          "sortBy": Object {
-                            "lastUpdate": "DESC",
-                          },
-                        }
-                      }
-                    >
-                      <ThBase
-                        innerRef={null}
-                        sort={
-                          Object {
-                            "columnIndex": 0,
-                            "onSort": [MockFunction],
-                            "sortBy": Object {
-                              "lastUpdate": "DESC",
-                            },
-                          }
-                        }
-                      >
-                        <th
-                          aria-sort="none"
-                          className="pf-c-table__sort"
-                          onMouseEnter={[Function]}
-                          scope="col"
-                        >
-                          <SortColumn
-                            isSortedBy={false}
-                            onSort={[Function]}
-                            sortDirection=""
-                          >
-                            <button
-                              className="pf-c-table__button"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <div
-                                className="pf-c-table__button-content"
-                              >
-                                <TableText>
-                                  <span
-                                    className="pf-c-table__text"
-                                    onMouseEnter={[Function]}
-                                  >
-                                    Id
-                                  </span>
-                                </TableText>
-                                <span
-                                  className="pf-c-table__sort-indicator"
-                                >
-                                  <ArrowsAltVIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                      />
-                                    </svg>
-                                  </ArrowsAltVIcon>
-                                </span>
-                              </div>
-                            </button>
-                          </SortColumn>
-                        </th>
-                      </ThBase>
-                    </Th>
-                    <Th
-                      key="1"
-                      sort={
-                        Object {
-                          "columnIndex": 1,
-                          "onSort": [MockFunction],
-                          "sortBy": Object {
-                            "lastUpdate": "DESC",
-                          },
-                        }
-                      }
-                    >
-                      <ThBase
-                        innerRef={null}
-                        sort={
-                          Object {
-                            "columnIndex": 1,
-                            "onSort": [MockFunction],
-                            "sortBy": Object {
-                              "lastUpdate": "DESC",
-                            },
-                          }
-                        }
-                      >
-                        <th
-                          aria-sort="none"
-                          className="pf-c-table__sort"
-                          onMouseEnter={[Function]}
-                          scope="col"
-                        >
-                          <SortColumn
-                            isSortedBy={false}
-                            onSort={[Function]}
-                            sortDirection=""
-                          >
-                            <button
-                              className="pf-c-table__button"
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <div
-                                className="pf-c-table__button-content"
-                              >
-                                <TableText>
-                                  <span
-                                    className="pf-c-table__text"
-                                    onMouseEnter={[Function]}
-                                  >
-                                    Status
-                                  </span>
-                                </TableText>
-                                <span
-                                  className="pf-c-table__sort-indicator"
-                                >
-                                  <ArrowsAltVIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      aria-labelledby={null}
-                                      fill="currentColor"
-                                      height="1em"
-                                      role="img"
-                                      style={
-                                        Object {
-                                          "verticalAlign": "-0.125em",
-                                        }
-                                      }
-                                      viewBox="0 0 256 512"
-                                      width="1em"
-                                    >
-                                      <path
-                                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                                      />
-                                    </svg>
-                                  </ArrowsAltVIcon>
-                                </span>
-                              </div>
-                            </button>
-                          </SortColumn>
-                        </th>
                       </ThBase>
                     </Th>
                     <Th
@@ -563,7 +398,7 @@ exports[`ProcessListTable test initial render with data 1`] = `
                                     className="pf-c-table__text"
                                     onMouseEnter={[Function]}
                                   >
-                                    Created
+                                    Id
                                   </span>
                                 </TableText>
                                 <span
@@ -648,6 +483,176 @@ exports[`ProcessListTable test initial render with data 1`] = `
                                     className="pf-c-table__text"
                                     onMouseEnter={[Function]}
                                   >
+                                    Status
+                                  </span>
+                                </TableText>
+                                <span
+                                  className="pf-c-table__sort-indicator"
+                                >
+                                  <ArrowsAltVIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                      />
+                                    </svg>
+                                  </ArrowsAltVIcon>
+                                </span>
+                              </div>
+                            </button>
+                          </SortColumn>
+                        </th>
+                      </ThBase>
+                    </Th>
+                    <Th
+                      key="4"
+                      sort={
+                        Object {
+                          "columnIndex": 4,
+                          "onSort": [MockFunction],
+                          "sortBy": Object {
+                            "lastUpdate": "DESC",
+                          },
+                        }
+                      }
+                    >
+                      <ThBase
+                        innerRef={null}
+                        sort={
+                          Object {
+                            "columnIndex": 4,
+                            "onSort": [MockFunction],
+                            "sortBy": Object {
+                              "lastUpdate": "DESC",
+                            },
+                          }
+                        }
+                      >
+                        <th
+                          aria-sort="none"
+                          className="pf-c-table__sort"
+                          onMouseEnter={[Function]}
+                          scope="col"
+                        >
+                          <SortColumn
+                            isSortedBy={false}
+                            onSort={[Function]}
+                            sortDirection=""
+                          >
+                            <button
+                              className="pf-c-table__button"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <div
+                                className="pf-c-table__button-content"
+                              >
+                                <TableText>
+                                  <span
+                                    className="pf-c-table__text"
+                                    onMouseEnter={[Function]}
+                                  >
+                                    Created
+                                  </span>
+                                </TableText>
+                                <span
+                                  className="pf-c-table__sort-indicator"
+                                >
+                                  <ArrowsAltVIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                                      />
+                                    </svg>
+                                  </ArrowsAltVIcon>
+                                </span>
+                              </div>
+                            </button>
+                          </SortColumn>
+                        </th>
+                      </ThBase>
+                    </Th>
+                    <Th
+                      key="5"
+                      sort={
+                        Object {
+                          "columnIndex": 5,
+                          "onSort": [MockFunction],
+                          "sortBy": Object {
+                            "lastUpdate": "DESC",
+                          },
+                        }
+                      }
+                    >
+                      <ThBase
+                        innerRef={null}
+                        sort={
+                          Object {
+                            "columnIndex": 5,
+                            "onSort": [MockFunction],
+                            "sortBy": Object {
+                              "lastUpdate": "DESC",
+                            },
+                          }
+                        }
+                      >
+                        <th
+                          aria-sort="none"
+                          className="pf-c-table__sort"
+                          onMouseEnter={[Function]}
+                          scope="col"
+                        >
+                          <SortColumn
+                            isSortedBy={false}
+                            onSort={[Function]}
+                            sortDirection=""
+                          >
+                            <button
+                              className="pf-c-table__button"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <div
+                                className="pf-c-table__button-content"
+                              >
+                                <TableText>
+                                  <span
+                                    className="pf-c-table__text"
+                                    onMouseEnter={[Function]}
+                                  >
                                     Last update
                                   </span>
                                 </TableText>
@@ -686,6 +691,7 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </ThBase>
                     </Th>
                     <Th
+                      key="6"
                       style={
                         Object {
                           "width": "188px",
@@ -729,19 +735,28 @@ exports[`ProcessListTable test initial render with data 1`] = `
               role="rowgroup"
             >
               <Tr
+                data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                data-ouia-component-type="process-list-row"
+                data-ouia-safe={true}
                 key="0-parent"
               >
                 <TrBase
+                  data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                  data-ouia-component-type="process-list-row"
+                  data-ouia-safe={true}
                   innerRef={null}
                 >
                   <tr
                     className=""
-                    data-ouia-component-id="OUIA-Generated-TableRow-21"
-                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                    data-ouia-component-type="process-list-row"
                     data-ouia-safe={true}
                     hidden={false}
                   >
                     <Td
+                      data-ouia-component-id="__toggle"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
                       expand={
                         Object {
                           "isExpanded": false,
@@ -752,6 +767,9 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       key="0-parent-0"
                     >
                       <TdBase
+                        data-ouia-component-id="__toggle"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
                         expand={
                           Object {
                             "isExpanded": false,
@@ -763,6 +781,9 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       >
                         <td
                           className="pf-c-table__toggle"
+                          data-ouia-component-id="__toggle"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <CollapseColumn
                             aria-labelledby="simple-node0 expand-toggle0"
@@ -840,16 +861,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
-                      dataLabel="Status"
+                      data-ouia-component-id="__select"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="__Select"
                       key="0-parent-1"
                     >
                       <TdBase
-                        dataLabel="Status"
+                        data-ouia-component-id="__select"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="__Select"
                         innerRef={null}
                       >
                         <td
                           className=""
-                          data-label="Status"
+                          data-label="__Select"
+                          data-ouia-component-id="__select"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <Checkbox
                             aria-label="process-list-checkbox"
@@ -881,16 +911,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
-                      dataLabel="Created"
+                      data-ouia-component-id="id"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="Id"
                       key="0-parent-2"
                     >
                       <TdBase
-                        dataLabel="Created"
+                        data-ouia-component-id="id"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="Id"
                         innerRef={null}
                       >
                         <td
                           className=""
-                          data-label="Created"
+                          data-label="Id"
+                          data-ouia-component-id="id"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <a
                             className="kogito-process-list__link"
@@ -1075,16 +1114,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
-                      dataLabel="Last update"
+                      data-ouia-component-id="status"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="Status"
                       key="0-parent-3"
                     >
                       <TdBase
-                        dataLabel="Last update"
+                        data-ouia-component-id="status"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="Status"
                         innerRef={null}
                       >
                         <td
                           className=""
-                          data-label="Last update"
+                          data-label="Status"
+                          data-ouia-component-id="status"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <MockedErrorPopover
                             onRetryClick={[Function]}
@@ -1155,13 +1203,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
+                      data-ouia-component-id="created"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="Created"
                       key="0-parent-4"
                     >
                       <TdBase
+                        data-ouia-component-id="created"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="Created"
                         innerRef={null}
                       >
                         <td
                           className=""
+                          data-label="Created"
+                          data-ouia-component-id="created"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <t
                             ago={false}
@@ -1190,13 +1250,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
+                      data-ouia-component-id="last update"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="Last update"
                       key="0-parent-5"
                     >
                       <TdBase
+                        data-ouia-component-id="last update"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="Last update"
                         innerRef={null}
                       >
                         <td
                           className=""
+                          data-label="Last update"
+                          data-ouia-component-id="last update"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <span>
                             <HistoryIcon
@@ -1255,13 +1327,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
+                      data-ouia-component-id="__actions"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="__Actions"
                       key="0-parent-6"
                     >
                       <TdBase
+                        data-ouia-component-id="__actions"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="__Actions"
                         innerRef={null}
                       >
                         <td
                           className=""
+                          data-label="__Actions"
+                          data-ouia-component-id="__actions"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <MockedProcessListActionsKebab
                             key="538f9feb-5a14-4096-b791-2055b38da7c6"
@@ -1337,17 +1421,23 @@ exports[`ProcessListTable test initial render with data 1`] = `
                 </TrBase>
               </Tr>
               <Tr
+                data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                data-ouia-component-type="process-list-row-expanded"
+                data-ouia-safe={true}
                 isExpanded={false}
                 key="0-child"
               >
                 <TrBase
+                  data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                  data-ouia-component-type="process-list-row-expanded"
+                  data-ouia-safe={true}
                   innerRef={null}
                   isExpanded={false}
                 >
                   <tr
                     className="pf-c-table__expandable-row"
-                    data-ouia-component-id="OUIA-Generated-TableRow-22"
-                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                    data-ouia-component-type="process-list-row-expanded"
                     data-ouia-safe={true}
                     hidden={true}
                   >
@@ -1364,18 +1454,18 @@ exports[`ProcessListTable test initial render with data 1`] = `
                     </Td>
                     <Td
                       colSpan={6}
-                      dataLabel="Status"
+                      dataLabel="__Select"
                       key="0-child-1"
                     >
                       <TdBase
                         colSpan={6}
-                        dataLabel="Status"
+                        dataLabel="__Select"
                         innerRef={null}
                       >
                         <td
                           className=""
                           colSpan={6}
-                          data-label="Status"
+                          data-label="__Select"
                         >
                           <ExpandableRowContent>
                             <div
@@ -1402,19 +1492,28 @@ exports[`ProcessListTable test initial render with data 1`] = `
               role="rowgroup"
             >
               <Tr
+                data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                data-ouia-component-type="process-list-row"
+                data-ouia-safe={true}
                 key="1-parent"
               >
                 <TrBase
+                  data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                  data-ouia-component-type="process-list-row"
+                  data-ouia-safe={true}
                   innerRef={null}
                 >
                   <tr
                     className=""
-                    data-ouia-component-id="OUIA-Generated-TableRow-23"
-                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                    data-ouia-component-type="process-list-row"
                     data-ouia-safe={true}
                     hidden={false}
                   >
                     <Td
+                      data-ouia-component-id="__toggle"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
                       expand={
                         Object {
                           "isExpanded": undefined,
@@ -1425,6 +1524,9 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       key="1-parent-0"
                     >
                       <TdBase
+                        data-ouia-component-id="__toggle"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
                         expand={
                           Object {
                             "isExpanded": undefined,
@@ -1436,6 +1538,9 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       >
                         <td
                           className=""
+                          data-ouia-component-id="__toggle"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <CollapseColumn
                             aria-labelledby="simple-node1 expand-toggle1"
@@ -1446,16 +1551,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
-                      dataLabel="Status"
+                      data-ouia-component-id="__select"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="__Select"
                       key="1-parent-1"
                     >
                       <TdBase
-                        dataLabel="Status"
+                        data-ouia-component-id="__select"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="__Select"
                         innerRef={null}
                       >
                         <td
                           className=""
-                          data-label="Status"
+                          data-label="__Select"
+                          data-ouia-component-id="__select"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <Checkbox
                             aria-label="process-list-checkbox"
@@ -1487,16 +1601,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
-                      dataLabel="Created"
+                      data-ouia-component-id="id"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="Id"
                       key="1-parent-2"
                     >
                       <TdBase
-                        dataLabel="Created"
+                        data-ouia-component-id="id"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="Id"
                         innerRef={null}
                       >
                         <td
                           className=""
-                          data-label="Created"
+                          data-label="Id"
+                          data-ouia-component-id="id"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <a
                             className="kogito-process-list__link"
@@ -1681,16 +1804,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
-                      dataLabel="Last update"
+                      data-ouia-component-id="status"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="Status"
                       key="1-parent-3"
                     >
                       <TdBase
-                        dataLabel="Last update"
+                        data-ouia-component-id="status"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="Status"
                         innerRef={null}
                       >
                         <td
                           className=""
-                          data-label="Last update"
+                          data-label="Status"
+                          data-ouia-component-id="status"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <MockedErrorPopover
                             onRetryClick={[Function]}
@@ -1760,13 +1892,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
+                      data-ouia-component-id="created"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="Created"
                       key="1-parent-4"
                     >
                       <TdBase
+                        data-ouia-component-id="created"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="Created"
                         innerRef={null}
                       >
                         <td
                           className=""
+                          data-label="Created"
+                          data-ouia-component-id="created"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <t
                             ago={false}
@@ -1795,13 +1939,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
+                      data-ouia-component-id="last update"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="Last update"
                       key="1-parent-5"
                     >
                       <TdBase
+                        data-ouia-component-id="last update"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="Last update"
                         innerRef={null}
                       >
                         <td
                           className=""
+                          data-label="Last update"
+                          data-ouia-component-id="last update"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <span>
                             <HistoryIcon
@@ -1860,13 +2016,25 @@ exports[`ProcessListTable test initial render with data 1`] = `
                       </TdBase>
                     </Td>
                     <Td
+                      data-ouia-component-id="__actions"
+                      data-ouia-component-type="process-list-cell"
+                      data-ouia-safe={true}
+                      dataLabel="__Actions"
                       key="1-parent-6"
                     >
                       <TdBase
+                        data-ouia-component-id="__actions"
+                        data-ouia-component-type="process-list-cell"
+                        data-ouia-safe={true}
+                        dataLabel="__Actions"
                         innerRef={null}
                       >
                         <td
                           className=""
+                          data-label="__Actions"
+                          data-ouia-component-id="__actions"
+                          data-ouia-component-type="process-list-cell"
+                          data-ouia-safe={true}
                         >
                           <MockedProcessListActionsKebab
                             key="538f9feb-5a14-4096-b791-2055b38da7c6"
@@ -1941,17 +2109,23 @@ exports[`ProcessListTable test initial render with data 1`] = `
                 </TrBase>
               </Tr>
               <Tr
+                data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                data-ouia-component-type="process-list-row-expanded"
+                data-ouia-safe={true}
                 isExpanded={false}
                 key="1-child"
               >
                 <TrBase
+                  data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                  data-ouia-component-type="process-list-row-expanded"
+                  data-ouia-safe={true}
                   innerRef={null}
                   isExpanded={false}
                 >
                   <tr
                     className="pf-c-table__expandable-row"
-                    data-ouia-component-id="OUIA-Generated-TableRow-24"
-                    data-ouia-component-type="PF4/TableRow"
+                    data-ouia-component-id="538f9feb-5a14-4096-b791-2055b38da7c6"
+                    data-ouia-component-type="process-list-row-expanded"
                     data-ouia-safe={true}
                     hidden={true}
                   >
@@ -1968,18 +2142,18 @@ exports[`ProcessListTable test initial render with data 1`] = `
                     </Td>
                     <Td
                       colSpan={6}
-                      dataLabel="Status"
+                      dataLabel="__Select"
                       key="1-child-1"
                     >
                       <TdBase
                         colSpan={6}
-                        dataLabel="Status"
+                        dataLabel="__Select"
                         innerRef={null}
                       >
                         <td
                           className=""
                           colSpan={6}
-                          data-label="Status"
+                          data-label="__Select"
                         >
                           <ExpandableRowContent>
                             <div
@@ -2033,6 +2207,7 @@ exports[`ProcessListTable test snapshot test for process list - with expanded 1`
   onAbortClick={[Function]}
   onRetryClick={[Function]}
   onSkipClick={[Function]}
+  ouiaId="538f9feb-5a14-4096-b791-2055b38da7c6"
   parentProcessId="538f9feb-5a14-4096-b791-2055b38da7c6"
   processInstances={
     Array [

--- a/ui-packages/packages/runtime-tools-dev-ui-webapp/package.json
+++ b/ui-packages/packages/runtime-tools-dev-ui-webapp/package.json
@@ -29,8 +29,7 @@
     "clean": "rimraf dist",
     "codegen": "graphql-codegen",
     "cypress:run": "cypress run",
-    "cypress:open": "cypress open",
-    "test:it": "start-server-and-test 'yarn dev' 9000 'yarn cypress:run'"
+    "cypress:open": "cypress open"
   },
   "dependencies": {
     "@babel/standalone": "^7.15.3",

--- a/ui-packages/packages/trusty/it-tests/serve.json
+++ b/ui-packages/packages/trusty/it-tests/serve.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "**/*", "destination": "/index.html" }
+  ]
+}

--- a/ui-packages/packages/trusty/package.json
+++ b/ui-packages/packages/trusty/package.json
@@ -35,7 +35,7 @@
     "start:it": "concurrently 'yarn serve -p 9000 -c ../it-tests/serve.json ./dist/' 'yarn run mock-server'",
     "start:e2e": "./it-tests/docker-compose/start_docker.sh",
     "cypress:open:it": "yarn run cypress open --project it-tests --config-file cypress.it.json",
-    "cypress:run:it": "yarn run cypress run -b chrome --project it-tests --config-file cypress.it.json",
+    "cypress:run:it": "yarn run cypress run --project it-tests --config-file cypress.it.json",
     "cypress:open:e2e": "yarn run cypress open --project it-tests --config-file cypress.e2e.json",
     "cypress:run:e2e": "yarn run cypress run -b chrome --project it-tests --config-file cypress.e2e.json",
     "test:it": "start-server-and-test 'yarn start:it' http://0.0.0.0:9000 'yarn cypress:run:it' && echo",

--- a/ui-packages/packages/trusty/package.json
+++ b/ui-packages/packages/trusty/package.json
@@ -32,13 +32,13 @@
     "lint": "eslint './src/**/*.ts{,x}'",
     "mock-server": "json-server api-mock/db.js --routes api-mock/routes.json --port 1336 --delay 1000 --id executionId --middlewares api-mock/filterSingular.js  api-mock/counterfactualPoll.js",
     "build:services": "./it-tests/docker-compose/build.sh",
-    "start:it": "yarn run start & yarn run mock-server",
+    "start:it": "concurrently 'yarn start' 'yarn run mock-server'",
     "start:e2e": "./it-tests/docker-compose/start_docker.sh",
     "cypress:open:it": "yarn run cypress open --project it-tests --config-file cypress.it.json",
     "cypress:run:it": "yarn run cypress run -b chrome --project it-tests --config-file cypress.it.json",
     "cypress:open:e2e": "yarn run cypress open --project it-tests --config-file cypress.e2e.json",
     "cypress:run:e2e": "yarn run cypress run -b chrome --project it-tests --config-file cypress.e2e.json",
-    "test:it": "start-server-and-test start:it http://0.0.0.0:9000 cypress:run:it",
+    "test:it": "start-server-and-test 'yarn start:it' http://0.0.0.0:9000 'yarn cypress:run:it'",
     "test:e2e": "start-server-and-test start:e2e http://0.0.0.0:1338 cypress:run:e2e"
   },
   "devDependencies": {

--- a/ui-packages/packages/trusty/package.json
+++ b/ui-packages/packages/trusty/package.json
@@ -32,20 +32,21 @@
     "lint": "eslint './src/**/*.ts{,x}'",
     "mock-server": "json-server api-mock/db.js --routes api-mock/routes.json --port 1336 --delay 1000 --id executionId --middlewares api-mock/filterSingular.js  api-mock/counterfactualPoll.js",
     "build:services": "./it-tests/docker-compose/build.sh",
-    "start:it": "concurrently 'yarn start' 'yarn run mock-server'",
+    "start:it": "concurrently 'yarn serve -p 9000 -c ../it-tests/serve.json ./dist/' 'yarn run mock-server'",
     "start:e2e": "./it-tests/docker-compose/start_docker.sh",
     "cypress:open:it": "yarn run cypress open --project it-tests --config-file cypress.it.json",
     "cypress:run:it": "yarn run cypress run -b chrome --project it-tests --config-file cypress.it.json",
     "cypress:open:e2e": "yarn run cypress open --project it-tests --config-file cypress.e2e.json",
     "cypress:run:e2e": "yarn run cypress run -b chrome --project it-tests --config-file cypress.e2e.json",
-    "test:it": "start-server-and-test 'yarn start:it' http://0.0.0.0:9000 'yarn cypress:run:it'",
+    "test:it": "start-server-and-test 'yarn start:it' http://0.0.0.0:9000 'yarn cypress:run:it' && echo",
     "test:e2e": "start-server-and-test start:e2e http://0.0.0.0:1338 cypress:run:e2e"
   },
   "devDependencies": {
     "faker": "^4.1.0",
     "json-server": "^0.16.1",
     "@kogito-apps/cypress-ouia": "^1.0.0",
-    "@kogito-apps/ouia-tools": "^1.0.0"
+    "@kogito-apps/ouia-tools": "^1.0.0",
+    "serve": "^12.0.1"
   },
   "jest": {
     "preset": "ts-jest/presets/js-with-ts",

--- a/ui-packages/pom.xml
+++ b/ui-packages/pom.xml
@@ -179,7 +179,6 @@
             </goals>
             <configuration>
               <skip>${skip.ui.build}</skip>
-              <npmRegistryURL>${env.NPM_REGISTRY_URL}</npmRegistryURL>
               <arguments>run build:prod</arguments>
               <environmentVariables>
                 <KOGITO_APP_VERSION>${project.version}</KOGITO_APP_VERSION>
@@ -194,8 +193,18 @@
             <phase>test</phase>
             <configuration>
               <skip>${skip.ui.build}</skip>
-              <npmRegistryURL>${env.NPM_REGISTRY_URL}</npmRegistryURL>
               <arguments>run test</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>yarn-integration-test</id>
+            <goals>
+              <goal>yarn</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <skip>${skip.ui.build}</skip>
+              <arguments>run test:it</arguments>
             </configuration>
           </execution>
         </executions>

--- a/ui-packages/yarn.lock
+++ b/ui-packages/yarn.lock
@@ -4560,6 +4560,11 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
+"@zeit/schemas@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@zeit/schemas/-/schemas-2.6.0.tgz#004e8e553b4cd53d538bd38eac7bcbf58a867fe3"
+  integrity sha512-uUrgZ8AxS+Lio0fZKAipJjAh415JyrOZowliZAzmnJSsf7piVL5w+G0+gFJ0KSu3QRhvui/7zuvpLz03YjXAhg==
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -4740,6 +4745,16 @@ ajv@6.12.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@6.12.6, ajv@^6.12.5:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
@@ -4760,20 +4775,17 @@ ajv@^6.10.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.12.5:
-  version "6.12.6"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
-  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
+
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  integrity sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=
+  dependencies:
+    string-width "^2.0.0"
 
 ansi-align@^3.0.0:
   version "3.0.0"
@@ -5150,7 +5162,7 @@ aproba@^2.0.0:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
 
-arch@^2.1.2, arch@^2.2.0:
+arch@^2.1.1, arch@^2.1.2, arch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
@@ -5191,6 +5203,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-2.0.0.tgz#c06e7ff69ab05b3a4a03ebe0407fac4cba657545"
+  integrity sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -6016,6 +6033,19 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+boxen@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  integrity sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
+
 boxen@^4.1.0, boxen@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
@@ -6433,7 +6463,7 @@ camelcase@^2.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
   integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
-camelcase@^4.1.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -6484,6 +6514,15 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chalk@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
@@ -6654,6 +6693,11 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
+  integrity sha1-T6kXw+WclKAEzWH47lCdplFocUM=
+
 cli-boxes@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
@@ -6734,6 +6778,15 @@ clipboard@^2.0.0:
     good-listener "^1.2.2"
     select "^1.1.2"
     tiny-emitter "^2.0.0"
+
+clipboardy@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.3.0.tgz#3c2903650c68e46a91b388985bc2774287dba290"
+  integrity sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==
+  dependencies:
+    arch "^2.1.1"
+    execa "^1.0.0"
+    is-wsl "^2.1.1"
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -6955,12 +7008,25 @@ compress-commons@^4.1.0:
     normalize-path "^3.0.0"
     readable-stream "^3.6.0"
 
-compressible@~2.0.16:
+compressible@~2.0.14, compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
   integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
   dependencies:
     mime-db ">= 1.43.0 < 2"
+
+compression@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db"
+  integrity sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.14"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
 
 compression@^1.7.4:
   version "1.7.4"
@@ -7068,6 +7134,11 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
+
+content-disposition@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
+  integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -7395,6 +7466,15 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     nice-try "^1.0.4"
     path-key "^2.0.1"
     semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -9046,6 +9126,19 @@ execa@5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -9344,6 +9437,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-url-parser@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/fast-url-parser/-/fast-url-parser-1.1.3.tgz#f4af3ea9f34d8a271cf58ad2b3759f431f0b318d"
+  integrity sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=
+  dependencies:
+    punycode "^1.3.2"
 
 fast-xml-parser@^3.17.4:
   version "3.18.0"
@@ -9983,6 +10083,11 @@ get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
@@ -13166,6 +13271,14 @@ lowlight@~1.11.0:
     fault "^1.0.2"
     highlight.js "~9.13.0"
 
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^5.0.0, lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -13481,6 +13594,18 @@ mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+
+mime-db@~1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
+  integrity sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==
+
+mime-types@2.1.18:
+  version "2.1.18"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
+  integrity sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
+  dependencies:
+    mime-db "~1.33.0"
 
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.27"
@@ -14321,7 +14446,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.0.2:
+on-headers@~1.0.1, on-headers@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
@@ -14858,7 +14983,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-is-inside@^1.0.2:
+path-is-inside@1.0.2, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
@@ -14894,6 +15019,11 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
+  integrity sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==
 
 path-to-regexp@^1.0.3, path-to-regexp@^1.7.0:
   version "1.8.0"
@@ -15690,6 +15820,11 @@ ps-tree@1.2.0:
   dependencies:
     event-stream "=3.3.4"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -15742,7 +15877,7 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-punycode@^1.2.4:
+punycode@^1.2.4, punycode@^1.3.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
@@ -15867,6 +16002,11 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
+range-parser@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+  integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
+
 range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -15898,7 +16038,7 @@ raw-loader@^4.0.0:
     loader-utils "^2.0.0"
     schema-utils "^2.6.5"
 
-rc@^1.2.8:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -16722,12 +16862,27 @@ regexpu-core@^4.7.0:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.2.0"
 
+registry-auth-token@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
+  integrity sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
 registry-auth-token@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.0.tgz#1d37dffda72bbecd0f581e4715540213a65eb7da"
   integrity sha512-P+lWzPrsgfN+UEpDS3U8AQKg/UjZX6mQSJueZj3EK+vNESoqBSpBUD3gmu4sF9lOsjXWjF11dQKUqemf3veq1w==
   dependencies:
     rc "^1.2.8"
+
+registry-url@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
+  dependencies:
+    rc "^1.0.1"
 
 registry-url@^5.0.0:
   version "5.1.0"
@@ -17308,6 +17463,20 @@ serve-favicon@^2.5.0:
     parseurl "~1.3.2"
     safe-buffer "5.1.1"
 
+serve-handler@6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.3.tgz#1bf8c5ae138712af55c758477533b9117f6435e8"
+  integrity sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==
+  dependencies:
+    bytes "3.0.0"
+    content-disposition "0.5.2"
+    fast-url-parser "1.1.3"
+    mime-types "2.1.18"
+    minimatch "3.0.4"
+    path-is-inside "1.0.2"
+    path-to-regexp "2.2.1"
+    range-parser "1.2.0"
+
 serve-index@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -17330,6 +17499,21 @@ serve-static@1.14.1:
     escape-html "~1.0.3"
     parseurl "~1.3.3"
     send "0.17.1"
+
+serve@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/serve/-/serve-12.0.1.tgz#5b0e05849f5ed9b8aab0f30a298c3664bba052bb"
+  integrity sha512-CQ4ikLpxg/wmNM7yivulpS6fhjRiFG6OjmP8ty3/c1SBnSk23fpKmLAV4HboTA2KrZhkUPlDfjDhnRmAjQ5Phw==
+  dependencies:
+    "@zeit/schemas" "2.6.0"
+    ajv "6.12.6"
+    arg "2.0.0"
+    boxen "1.3.0"
+    chalk "2.4.1"
+    clipboardy "2.3.0"
+    compression "1.7.3"
+    serve-handler "6.1.3"
+    update-check "1.5.2"
 
 server-destroy@^1.0.1:
   version "1.0.1"
@@ -17953,7 +18137,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.1.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -18353,6 +18537,13 @@ temp-write@^3.4.0:
     pify "^3.0.0"
     temp-dir "^1.0.0"
     uuid "^3.0.1"
+
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
+  dependencies:
+    execa "^0.7.0"
 
 term-size@^2.1.0:
   version "2.2.0"
@@ -19089,6 +19280,14 @@ upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+update-check@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/update-check/-/update-check-1.5.2.tgz#2fe09f725c543440b3d7dabe8971f2d5caaedc28"
+  integrity sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==
+  dependencies:
+    registry-auth-token "3.3.2"
+    registry-url "3.1.0"
 
 update-input-width@^1.1.1:
   version "1.2.1"
@@ -19867,6 +20066,13 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
+widest-line@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
+  integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
+  dependencies:
+    string-width "^2.1.1"
+
 widest-line@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-3.1.0.tgz#8292333bbf66cb45ff0de1603b136b7ae1496eca"
@@ -20071,6 +20277,11 @@ yaeti@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
   integrity sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"

--- a/ui-packages/yarn.lock
+++ b/ui-packages/yarn.lock
@@ -1061,20 +1061,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cypress/listr-verbose-renderer@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
-  integrity sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
 "@cypress/request@^2.88.5":
-  version "2.88.5"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.5.tgz#8d7ecd17b53a849cfd5ab06d5abe7d84976375d7"
-  integrity sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==
+  version "2.88.6"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.6.tgz#a970dd675befc6bdf8a8921576c01f51cc5798e9"
+  integrity sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -1089,13 +1079,12 @@
     isstream "~0.1.2"
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
     performance-now "^2.1.0"
     qs "~6.5.2"
     safe-buffer "^5.1.2"
     tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
+    uuid "^8.3.2"
 
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
@@ -2962,9 +2951,9 @@
     react-lifecycles-compat "^3.0.4"
 
 "@samverschueren/stream-to-observable@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
-  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
+  integrity sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==
   dependencies:
     any-observable "^0.3.0"
 
@@ -3838,13 +3827,6 @@
   dependencies:
     "@types/express" "*"
 
-"@types/cypress@^1.1.0":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@types/cypress/-/cypress-1.1.3.tgz#0a700c040d53e9e12b5af98e41d4a88c39f39b6a"
-  integrity sha512-OXe0Gw8LeCflkG1oPgFpyrYWJmEKqYncBsD/J0r17r0ETx/TnIGDNLwXt/pFYSYuYTpzcq1q3g62M9DrfsBL4g==
-  dependencies:
-    cypress "*"
-
 "@types/enzyme@^3.10.5":
   version "3.10.5"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.5.tgz#fe7eeba3550369eed20e7fb565bfb74eec44f1f0"
@@ -3858,10 +3840,10 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/express-serve-static-core@*":
-  version "4.17.9"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz#2d7b34dcfd25ec663c25c85d76608f8b249667f1"
-  integrity sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.21":
+  version "4.17.24"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz#ea41f93bf7e0d59cd5a76665068ed6aab6815c07"
+  integrity sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -4035,7 +4017,12 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@>=6":
+"@types/node@*":
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz#5764ca9aa94470adb4e1185fe2e9f19458992b2e"
+  integrity sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==
+
+"@types/node@>= 8", "@types/node@>=6":
   version "14.0.26"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.26.tgz#22a3b8a46510da8944b67bfc27df02c34a35331c"
   integrity sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==
@@ -4046,9 +4033,9 @@
   integrity sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==
 
 "@types/node@^14.14.31":
-  version "14.17.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.2.tgz#1e94476db57ec93a372c7f7d29aa5707cfb92339"
-  integrity sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==
+  version "14.17.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.20.tgz#74cc80438fd0467dc4377ee5bbad89a886df3c10"
+  integrity sha512-gI5Sl30tmhXsqkNvopFydP7ASc4c2cLfGNQrVKN3X90ADFWFsPEsotm/8JHSUJQKTHbwowAHtcJPeyVhtKv0TQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4198,10 +4185,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@types/sinonjs__fake-timers@^6.0.1", "@types/sinonjs__fake-timers@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz#3a84cf5ec3249439015e14049bd3161419bf9eae"
-  integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
+"@types/sinonjs__fake-timers@^6.0.2":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz#0ecc1b9259b76598ef01942f547904ce61a6a77d"
+  integrity sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==
 
 "@types/sizzle@^2.3.2":
   version "2.3.3"
@@ -4297,9 +4284,9 @@
     "@types/yargs-parser" "*"
 
 "@types/yauzl@^2.9.1":
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
-  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.2.tgz#c48e5d56aff1444409e39fa164b0b4d4552a7b7a"
+  integrity sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
   dependencies:
     "@types/node" "*"
 
@@ -4745,7 +4732,7 @@ ajv@6.12.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@6.12.6, ajv@^6.12.5:
+ajv@6.12.6, ajv@^6.12.3, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -4755,7 +4742,7 @@ ajv@6.12.6, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.2:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
@@ -4841,6 +4828,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -4853,12 +4845,19 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   dependencies:
     "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
     color-convert "^2.0.1"
 
 ansi-to-html@^0.6.11:
@@ -5162,7 +5161,7 @@ aproba@^2.0.0:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
 
-arch@^2.1.1, arch@^2.1.2, arch@^2.2.0:
+arch@^2.1.1, arch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
@@ -5434,9 +5433,9 @@ async@^2.6.2:
     lodash "^4.17.14"
 
 async@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.1.tgz#d3274ec66d107a47476a4c49136aacdb00665fc8"
+  integrity sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -5489,9 +5488,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.0.tgz#a17b3a8ea811060e74d47d306122400ad4497ae2"
-  integrity sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 axe-core@^3.3.2:
   version "3.5.5"
@@ -5883,9 +5882,9 @@ backo2@^1.0.2:
   integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base16@^1.0.0:
   version "1.0.0"
@@ -6533,7 +6532,7 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@4.1.0, chalk@^4.0.0, chalk@^4.1.0:
+chalk@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -6556,6 +6555,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0, chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -6703,13 +6710,6 @@ cli-boxes@^2.2.0:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
   integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
 
-cli-cursor@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
-  integrity sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
-  dependencies:
-    restore-cursor "^1.0.1"
-
 cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -6724,7 +6724,7 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-table3@0.5.1, cli-table3@~0.5.1:
+cli-table3@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
   integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
@@ -6920,6 +6920,11 @@ colorette@^1.2.0:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
+colorette@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
+  integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+
 colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -7046,7 +7051,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@^1.6.2:
+concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -7716,12 +7721,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@*:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.4.0.tgz#679bfe75335b9a4873d44f0d989e9f0367f00665"
-  integrity sha512-+CmSoT5DS88e92YDfc6aDA3Zf3uCBRKVB92caWsjXMilz0tf6NpByFvIbLLVWXiYOwrhtWV0m/k93+rzodYwRQ==
+cypress@^7.4.0:
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.7.0.tgz#0839ae28e5520536f9667d6c9ae81496b3836e64"
+  integrity sha512-uYBYXNoI5ym0UxROwhQXWTi8JbUEjpC6l/bzoGZNxoKGsLrC1SDPgIDJMgLX/MeEdPL0UInXLDUWN/rSyZUCjQ==
   dependencies:
-    "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^14.14.31"
@@ -7733,21 +7737,24 @@ cypress@*:
     cachedir "^2.3.0"
     chalk "^4.1.0"
     check-more-types "^2.24.0"
+    cli-cursor "^3.1.0"
     cli-table3 "~0.6.0"
     commander "^5.1.0"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
-    debug "4.3.2"
+    debug "^4.3.2"
+    enquirer "^2.3.6"
     eventemitter2 "^6.4.3"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
+    figures "^3.2.0"
     fs-extra "^9.1.0"
     getos "^3.2.1"
     is-ci "^3.0.0"
     is-installed-globally "~0.4.0"
     lazy-ass "^1.6.0"
-    listr "^0.14.3"
+    listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
     minimist "^1.2.5"
@@ -7757,49 +7764,6 @@ cypress@*:
     request-progress "^3.0.0"
     supports-color "^8.1.1"
     tmp "~0.2.1"
-    untildify "^4.0.0"
-    url "^0.11.0"
-    yauzl "^2.10.0"
-
-cypress@^4.1.0:
-  version "4.12.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.12.1.tgz#0ead1b9f4c0917d69d8b57f996b6e01fe693b6ec"
-  integrity sha512-9SGIPEmqU8vuRA6xst2CMTYd9sCFCxKSzrHt0wr+w2iAQMCIIsXsQ5Gplns1sT6LDbZcmLv6uehabAOl3fhc9Q==
-  dependencies:
-    "@cypress/listr-verbose-renderer" "^0.4.1"
-    "@cypress/request" "^2.88.5"
-    "@cypress/xvfb" "^1.2.4"
-    "@types/sinonjs__fake-timers" "^6.0.1"
-    "@types/sizzle" "^2.3.2"
-    arch "^2.1.2"
-    bluebird "^3.7.2"
-    cachedir "^2.3.0"
-    chalk "^2.4.2"
-    check-more-types "^2.24.0"
-    cli-table3 "~0.5.1"
-    commander "^4.1.1"
-    common-tags "^1.8.0"
-    debug "^4.1.1"
-    eventemitter2 "^6.4.2"
-    execa "^1.0.0"
-    executable "^4.1.1"
-    extract-zip "^1.7.0"
-    fs-extra "^8.1.0"
-    getos "^3.2.1"
-    is-ci "^2.0.0"
-    is-installed-globally "^0.3.2"
-    lazy-ass "^1.6.0"
-    listr "^0.14.3"
-    lodash "^4.17.19"
-    log-symbols "^3.0.0"
-    minimist "^1.2.5"
-    moment "^2.27.0"
-    ospath "^1.2.2"
-    pretty-bytes "^5.3.0"
-    ramda "~0.26.1"
-    request-progress "^3.0.0"
-    supports-color "^7.1.0"
-    tmp "~0.1.0"
     untildify "^4.0.0"
     url "^0.11.0"
     yauzl "^2.10.0"
@@ -7930,9 +7894,9 @@ dateformat@^3.0.0:
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
 dayjs@^1.10.4:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.5.tgz#5600df4548fc2453b3f163ebb2abbe965ccfb986"
-  integrity sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
+  integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -7944,14 +7908,14 @@ debounce@1.2.0:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==
 
-debug@*, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@*, debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -7972,19 +7936,26 @@ debug@4.3.1:
   dependencies:
     ms "2.1.2"
 
-debug@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
-
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.1, debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -8628,7 +8599,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enquirer@^2.3.5:
+enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -9056,10 +9027,10 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-eventemitter2@^6.4.2, eventemitter2@^6.4.3:
-  version "6.4.4"
-  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.4.tgz#aa96e8275c4dbeb017a5d0e03780c65612a1202b"
-  integrity sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==
+eventemitter2@^6.4.3:
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.5.tgz#97380f758ae24ac15df8353e0cc27f8b95644655"
+  integrity sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -9194,11 +9165,6 @@ exenv@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
   integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
-  integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
 
 exit-on-epipe@~1.0.1:
   version "1.0.1"
@@ -9346,16 +9312,6 @@ extract-zip@2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
-
-extract-zip@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
-  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
-  dependencies:
-    concat-stream "^1.6.2"
-    debug "^2.6.9"
-    mkdirp "^0.5.4"
-    yauzl "^2.10.0"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -10097,9 +10053,9 @@ get-stream@^4.0.0, get-stream@^4.1.0:
     pump "^3.0.0"
 
 get-stream@^5.0.0, get-stream@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
-  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
 
@@ -10225,10 +10181,22 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@7.1.6, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -10419,10 +10387,15 @@ gql-query-builder@3.1.3:
   resolved "https://registry.yarnpkg.com/gql-query-builder/-/gql-query-builder-3.1.3.tgz#76ef5c210f7e7fc8244a0d9c7df3d7090c2d2f3f"
   integrity sha512-RjZbH5eeaEYz3XoVjfozP3RkkEZV/gOygNipX30ysukd9kENGljrPVagF71+0224uQd7WF9GTgo/qOfoFBSRcg==
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.9, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 graphql-config@^3.0.2:
   version "3.0.3"
@@ -10537,11 +10510,11 @@ har-schema@^2.0.0:
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
-  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   dependencies:
-    ajv "^6.5.5"
+    ajv "^6.12.3"
     har-schema "^2.0.0"
 
 hard-rejection@^2.1.0:
@@ -11569,7 +11542,7 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
-is-installed-globally@^0.3.1, is-installed-globally@^0.3.2:
+is-installed-globally@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz#fd3efa79ee670d1187233182d5b0a1dd00313141"
   integrity sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
@@ -11737,9 +11710,9 @@ is-stream@^1.0.1, is-stream@^1.1.0:
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
-  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-string@^1.0.4, is-string@^1.0.5:
   version "1.0.5"
@@ -11783,6 +11756,11 @@ is-unc-path@^1.0.0:
   integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
   dependencies:
     unc-path-regex "^0.1.2"
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -12531,11 +12509,11 @@ jsonfile@^4.0.0:
     graceful-fs "^4.1.6"
 
 jsonfile@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
-  integrity sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
   dependencies:
-    universalify "^1.0.0"
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -12863,7 +12841,20 @@ listr2@^2.1.0:
     rxjs "^6.6.0"
     through "^2.3.8"
 
-listr@0.14.3, listr@^0.14.3:
+listr2@^3.8.3:
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.12.2.tgz#2d55cc627111603ad4768a9e87c9c7bb9b49997e"
+  integrity sha512-64xC2CJ/As/xgVI3wbhlPWVPx0wfTqbUAkpb7bjDi0thSWMqrf07UFhrfsGoo8YSXmF049Rp9C0cjLC8rZxK9A==
+  dependencies:
+    cli-truncate "^2.1.0"
+    colorette "^1.4.0"
+    log-update "^4.0.0"
+    p-map "^4.0.0"
+    rxjs "^6.6.7"
+    through "^2.3.8"
+    wrap-ansi "^7.0.0"
+
+listr@0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
   integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
@@ -13143,7 +13134,7 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-log-symbols@4.0.0, log-symbols@^4.0.0:
+log-symbols@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
   integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
@@ -13164,12 +13155,13 @@ log-symbols@^2.1.0:
   dependencies:
     chalk "^2.0.1"
 
-log-symbols@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
-  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+log-symbols@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
   dependencies:
-    chalk "^2.4.2"
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 log-update@^2.3.0:
   version "2.3.0"
@@ -13595,6 +13587,11 @@ mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
 
+mime-db@1.50.0:
+  version "1.50.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
+  integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
+
 mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
@@ -13607,7 +13604,14 @@ mime-types@2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.33"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
+  integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
+  dependencies:
+    mime-db "1.50.0"
+
+mime-types@~2.1.17, mime-types@~2.1.24:
   version "2.1.27"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
@@ -13813,7 +13817,7 @@ mkdirp@*, mkdirp@1.0.4, mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
+mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -13829,11 +13833,6 @@ moment@2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
-moment@^2.27.0:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 monaco-editor-webpack-plugin@4.1.2:
   version "4.1.2"
@@ -13890,10 +13889,15 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.2, ms@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -14458,11 +14462,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
-  integrity sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
-
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
@@ -14470,14 +14469,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-onetime@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
-  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
-  dependencies:
-    mimic-fn "^2.1.0"
-
-onetime@^5.1.2:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -15589,7 +15581,7 @@ prettier@^1.16.4, prettier@^1.18.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-pretty-bytes@^5.3.0, pretty-bytes@^5.6.0:
+pretty-bytes@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
@@ -15968,11 +15960,6 @@ ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
   integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
-
-ramda@~0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 ramda@~0.27.1:
   version "0.27.1"
@@ -17126,14 +17113,6 @@ responselike@^1.0.2:
   dependencies:
     lowercase-keys "^1.0.0"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
-  integrity sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=
-  dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
-
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -17239,17 +17218,17 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.2, rxjs@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
-  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.6.3:
+rxjs@^6.3.3, rxjs@^6.6.3, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.4.0, rxjs@^6.5.2, rxjs@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
+  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
   dependencies:
     tslib "^1.9.0"
 
@@ -17641,10 +17620,15 @@ side-channel@^1.0.2:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
+signal-exit@^3.0.0, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+signal-exit@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
+  integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
 
 signedsource@^1.0.0:
   version "1.0.0"
@@ -18154,7 +18138,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.0.0, string-width@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -18162,6 +18146,15 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 "string.prototype.matchall@^4.0.0 || ^3.0.1", string.prototype.matchall@^4.0.2:
   version "4.0.2"
@@ -18266,6 +18259,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -18379,10 +18379,17 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
@@ -18717,13 +18724,6 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
-tmp@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
-  dependencies:
-    rimraf "^2.6.3"
-
 tmp@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -18946,10 +18946,15 @@ tsconfig-paths@^3.4.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.13.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@1.13.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^1.9.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0, tslib@~2.0.0:
   version "2.0.0"
@@ -19326,9 +19331,9 @@ upper-case@^1.1.1, upper-case@^1.1.3:
   integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
@@ -19464,6 +19469,11 @@ uuid@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.2.0.tgz#cb10dd6b118e2dada7d0cd9730ba7417c93d920e"
   integrity sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.1.1"
@@ -20111,7 +20121,7 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-wrap-ansi@7.0.0:
+wrap-ansi@7.0.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5896

* Adding cypress test execution into overall maven build.
* Removing cypress-related yarn scripts from parent package.json.
* Removed `test:it` script from `runtime-tools-dev-ui-webapp` package - no tests there.
* Removed passing of npmRegistryURL property in maven plugin executions where it is unnecessary (in all except install, will be validated by the PR check).
* Removed dummy cypress tests.
* Fixed failing cypress tests.
  * In a few cases new OUIA attributes were added. 
* Fixed trusty yarn scripts not to block overall build and clean up resources
  * using concurrently script
  * making sure start-server-and-test executes scripts using yarn.


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
