### PR TITLE
KOGITO-6026 set encoding for protobuff cache as mentionned => https://infinispan.…

### DIFF
--- a/data-index/data-index-service/data-index-service-infinispan/src/main/resources/templates/kogito-cache-default.xml
+++ b/data-index/data-index-service/data-index-service-infinispan/src/main/resources/templates/kogito-cache-default.xml
@@ -2,12 +2,13 @@
   <cache-container shutdown-hook="DEFAULT">
     {#let template=config:property('kogito.cache.domain.template')}
       {#if template is null}
-    <local-cache name="{cache_name}">
+      <distributed-cache name="{cache_name}" mode="SYNC">
+      <encoding media-type="application/x-protostream"/>
       {#else}
     <local-cache name="{cache_name}" configuration="{template}">
       {/if}
     {/let}
-      <indexing storage="filesystem" path="data-index-{cache_name}">
+      <indexing enabled="true">
         <indexed-entities>
           <indexed-entity>org.kie.kogito.index.model.KogitoMetadata</indexed-entity>
           <indexed-entity>org.kie.kogito.index.model.ProcessInstanceMeta</indexed-entity>
@@ -16,10 +17,17 @@
           <indexed-entity>{index}</indexed-entity>
           {/for}
         </indexed-entities>
-      </indexing>
-      <persistence>
-        <file-store/>
+      </indexing>    
+      <persistence passivation="false" availability-interval="2000" connection-attempts="5" connection-interval="100">
+        <file-store fetch-state="true" preload="true" purge="false">
+        </file-store>
       </persistence>
-    </local-cache>
+    {#let template=config:property('kogito.cache.domain.template')}
+      {#if template is null}
+      </distributed-cache>
+      {#else}
+      </local-cache>
+      {/if}
+    {/let}
   </cache-container>
 </infinispan>

--- a/data-index/data-index-service/data-index-service-infinispan/src/main/resources/templates/kogito-cache-default.xml
+++ b/data-index/data-index-service/data-index-service-infinispan/src/main/resources/templates/kogito-cache-default.xml
@@ -2,13 +2,13 @@
   <cache-container shutdown-hook="DEFAULT">
     {#let template=config:property('kogito.cache.domain.template')}
       {#if template is null}
-      <distributed-cache name="{cache_name}" mode="SYNC">
-      <encoding media-type="application/x-protostream"/>
+    <local-cache name="{cache_name}">
+    <encoding media-type="application/x-protostream"/>
       {#else}
     <local-cache name="{cache_name}" configuration="{template}">
       {/if}
     {/let}
-      <indexing enabled="true">
+      <indexing storage="filesystem" path="data-index-{cache_name}">
         <indexed-entities>
           <indexed-entity>org.kie.kogito.index.model.KogitoMetadata</indexed-entity>
           <indexed-entity>org.kie.kogito.index.model.ProcessInstanceMeta</indexed-entity>
@@ -17,17 +17,10 @@
           <indexed-entity>{index}</indexed-entity>
           {/for}
         </indexed-entities>
-      </indexing>    
-      <persistence passivation="false" availability-interval="2000" connection-attempts="5" connection-interval="100">
-        <file-store fetch-state="true" preload="true" purge="false">
-        </file-store>
+      </indexing>
+      <persistence>
+        <file-store/>
       </persistence>
-    {#let template=config:property('kogito.cache.domain.template')}
-      {#if template is null}
-      </distributed-cache>
-      {#else}
-      </local-cache>
-      {/if}
-    {/let}
+    </local-cache>
   </cache-container>
 </infinispan>

--- a/data-index/data-index-service/data-index-service-infinispan/src/main/resources/templates/kogito-cache-default.xml
+++ b/data-index/data-index-service/data-index-service-infinispan/src/main/resources/templates/kogito-cache-default.xml
@@ -3,11 +3,11 @@
     {#let template=config:property('kogito.cache.domain.template')}
       {#if template is null}
     <local-cache name="{cache_name}">
-    <encoding media-type="application/x-protostream"/>
       {#else}
     <local-cache name="{cache_name}" configuration="{template}">
       {/if}
     {/let}
+      <encoding media-type="application/x-protostream"/>
       <indexing storage="filesystem" path="data-index-{cache_name}">
         <indexed-entities>
           <indexed-entity>org.kie.kogito.index.model.KogitoMetadata</indexed-entity>


### PR DESCRIPTION
Fix the encoding to infinispan protobuff cache

> https://issues.redhat.com/browse/KOGITO-6026

The path of cache persistance is set into infinispan as global :

```
<global-state>
      <!-- example with path /opt/infinispan/server/data --> 
       <persistent-location path="/opt/infinispan/server/data" />
</global-state>
```
