### PR TITLE
FAI-556: Increase CF test coverage by including DMN models

### DIFF
--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/ComplexEligibilityDmnCounterfactualExplainerTest.java
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/ComplexEligibilityDmnCounterfactualExplainerTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.explainability.explainability.integrationtests.dmn;
+
+import java.io.InputStreamReader;
+import java.math.BigDecimal;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Test;
+import org.kie.dmn.api.core.DMNRuntime;
+import org.kie.kogito.decision.DecisionModel;
+import org.kie.kogito.dmn.DMNKogito;
+import org.kie.kogito.dmn.DmnDecisionModel;
+import org.kie.kogito.explainability.Config;
+import org.kie.kogito.explainability.local.counterfactual.CounterfactualConfig;
+import org.kie.kogito.explainability.local.counterfactual.CounterfactualExplainer;
+import org.kie.kogito.explainability.local.counterfactual.CounterfactualResult;
+import org.kie.kogito.explainability.local.counterfactual.SolverConfigBuilder;
+import org.kie.kogito.explainability.local.counterfactual.entities.CounterfactualEntity;
+import org.kie.kogito.explainability.model.CounterfactualPrediction;
+import org.kie.kogito.explainability.model.Feature;
+import org.kie.kogito.explainability.model.FeatureFactory;
+import org.kie.kogito.explainability.model.Output;
+import org.kie.kogito.explainability.model.Prediction;
+import org.kie.kogito.explainability.model.PredictionFeatureDomain;
+import org.kie.kogito.explainability.model.PredictionInput;
+import org.kie.kogito.explainability.model.PredictionOutput;
+import org.kie.kogito.explainability.model.PredictionProvider;
+import org.kie.kogito.explainability.model.Type;
+import org.kie.kogito.explainability.model.Value;
+import org.kie.kogito.explainability.model.domain.EmptyFeatureDomain;
+import org.kie.kogito.explainability.model.domain.FeatureDomain;
+import org.kie.kogito.explainability.model.domain.NumericalFeatureDomain;
+import org.optaplanner.core.config.solver.EnvironmentMode;
+import org.optaplanner.core.config.solver.SolverConfig;
+import org.optaplanner.core.config.solver.termination.TerminationConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ComplexEligibilityDmnCounterfactualExplainerTest {
+
+    @Test
+    void testDMNValidCounterfactualExplanation() throws ExecutionException, InterruptedException, TimeoutException {
+        PredictionProvider model = getModel();
+
+        final List<Output> goal = generateGoal(true, true, 0.6);
+
+        List<Feature> features = new LinkedList<>();
+        List<FeatureDomain> featureBoundaries = new LinkedList<>();
+        List<Boolean> constraints = new LinkedList<>();
+        features.add(FeatureFactory.newNumericalFeature("age", 40));
+        constraints.add(true);
+        featureBoundaries.add(EmptyFeatureDomain.create());
+        features.add(FeatureFactory.newBooleanFeature("hasReferral", true));
+        constraints.add(true);
+        featureBoundaries.add(EmptyFeatureDomain.create());
+        features.add(FeatureFactory.newNumericalFeature("monthlySalary", 500));
+        featureBoundaries.add(NumericalFeatureDomain.create(10, 10_000));
+        constraints.add(false);
+
+        final TerminationConfig terminationConfig = new TerminationConfig().withScoreCalculationCountLimit(10_000L);
+        // for the purpose of this test, only a few steps are necessary
+        final SolverConfig solverConfig = SolverConfigBuilder
+                .builder().withTerminationConfig(terminationConfig).build();
+        solverConfig.setRandomSeed((long) 23);
+        solverConfig.setEnvironmentMode(EnvironmentMode.REPRODUCIBLE);
+
+        final CounterfactualConfig counterfactualConfig = new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
+        final CounterfactualExplainer counterfactualExplainer =
+                new CounterfactualExplainer(counterfactualConfig);
+
+        PredictionInput input = new PredictionInput(features);
+
+        PredictionOutput output = new PredictionOutput(goal);
+        Prediction prediction = new CounterfactualPrediction(input,
+                output,
+                new PredictionFeatureDomain(featureBoundaries),
+                constraints,
+                null,
+                UUID.randomUUID(), 60L);
+        final CounterfactualResult counterfactualResult =
+                counterfactualExplainer.explainAsync(prediction, model)
+                        .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+
+        List<Output> cfOutputs = counterfactualResult.getOutput().get(0).getOutputs();
+
+        assertTrue(counterfactualResult.isValid());
+        assertEquals("inputsAreValid", cfOutputs.get(0).getName());
+        assertTrue((Boolean) cfOutputs.get(0).getValue().getUnderlyingObject());
+        assertEquals("canRequestLoan", cfOutputs.get(1).getName());
+        assertTrue((Boolean) cfOutputs.get(1).getValue().getUnderlyingObject());
+        assertEquals("my-scoring-function", cfOutputs.get(2).getName());
+        assertEquals(0.6, ((BigDecimal) cfOutputs.get(2).getValue().getUnderlyingObject()).doubleValue(), 0.05);
+
+        List<CounterfactualEntity> entities = counterfactualResult.getEntities();
+        assertEquals("age", entities.get(0).asFeature().getName());
+        assertEquals(entities.get(0).asFeature().getValue().asNumber(), 40);
+        assertEquals("hasReferral", entities.get(1).asFeature().getName());
+        assertTrue((Boolean) entities.get(1).asFeature().getValue().getUnderlyingObject());
+        assertEquals("monthlySalary", entities.get(2).asFeature().getName());
+        assertTrue(entities.get(2).asFeature().getValue().asNumber() > 6000);
+    }
+
+    @Test
+    void testDMNScoringFunction() throws ExecutionException, InterruptedException, TimeoutException {
+        PredictionProvider model = getModel();
+
+        final List<Output> goal = generateGoal(true, true, 1.0);
+
+        List<Feature> features = new LinkedList<>();
+        List<FeatureDomain> featureBoundaries = new LinkedList<>();
+        List<Boolean> constraints = new LinkedList<>();
+        features.add(FeatureFactory.newNumericalFeature("age", 40));
+        constraints.add(false);
+        featureBoundaries.add(NumericalFeatureDomain.create(18, 60));
+        features.add(FeatureFactory.newBooleanFeature("hasReferral", true));
+        constraints.add(true);
+        featureBoundaries.add(EmptyFeatureDomain.create());
+        features.add(FeatureFactory.newNumericalFeature("monthlySalary", 500));
+        featureBoundaries.add(NumericalFeatureDomain.create(10, 100_000));
+        constraints.add(false);
+
+        final TerminationConfig terminationConfig = new TerminationConfig().withScoreCalculationCountLimit(10_000L);
+        // for the purpose of this test, only a few steps are necessary
+        final SolverConfig solverConfig = SolverConfigBuilder
+                .builder().withTerminationConfig(terminationConfig).build();
+        solverConfig.setRandomSeed((long) 23);
+        solverConfig.setEnvironmentMode(EnvironmentMode.REPRODUCIBLE);
+
+        final CounterfactualConfig counterfactualConfig = new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
+        final CounterfactualExplainer counterfactualExplainer =
+                new CounterfactualExplainer(counterfactualConfig);
+
+        PredictionInput input = new PredictionInput(features);
+
+        PredictionOutput output = new PredictionOutput(goal);
+        Prediction prediction = new CounterfactualPrediction(input,
+                output,
+                new PredictionFeatureDomain(featureBoundaries),
+                constraints,
+                null,
+                UUID.randomUUID(), 60L);
+        final CounterfactualResult counterfactualResult =
+                counterfactualExplainer.explainAsync(prediction, model)
+                        .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+
+        List<Output> cfOutputs = counterfactualResult.getOutput().get(0).getOutputs();
+
+        assertTrue(counterfactualResult.isValid());
+        assertEquals("inputsAreValid", cfOutputs.get(0).getName());
+        assertTrue((Boolean) cfOutputs.get(0).getValue().getUnderlyingObject());
+        assertEquals("canRequestLoan", cfOutputs.get(1).getName());
+        assertTrue((Boolean) cfOutputs.get(1).getValue().getUnderlyingObject());
+        assertEquals("my-scoring-function", cfOutputs.get(2).getName());
+        assertEquals(1.0, ((BigDecimal) cfOutputs.get(2).getValue().getUnderlyingObject()).doubleValue(), 0.01);
+
+        List<CounterfactualEntity> entities = counterfactualResult.getEntities();
+
+        assertEquals("age", entities.get(0).asFeature().getName());
+        assertEquals(18, entities.get(0).asFeature().getValue().asNumber());
+        assertEquals("hasReferral", entities.get(1).asFeature().getName());
+        assertTrue((Boolean) entities.get(1).asFeature().getValue().getUnderlyingObject());
+        assertEquals("monthlySalary", entities.get(2).asFeature().getName());
+        final double monthlySalary = entities.get(2).asFeature().getValue().asNumber();
+        assertEquals(7900, monthlySalary, 10);
+
+        // since the scoring function is ((0.6 * ((42 - age + 18)/42)) + (0.4 * (monthlySalary/8000)))
+        // for a result of 1.0 the relation must be age = (7*monthlySalary)/2000 - 10
+        assertEquals(18, (7*monthlySalary)/2000.0 - 10.0, 0.5);
+    }
+
+    @Test
+    void testDMNInvalidCounterfactualExplanation() throws ExecutionException, InterruptedException, TimeoutException {
+        PredictionProvider model = getModel();
+
+        final List<Output> goal = generateGoal(true, true, 0.6);
+
+        List<Feature> features = new LinkedList<>();
+        List<FeatureDomain> featureBoundaries = new LinkedList<>();
+        List<Boolean> constraints = new LinkedList<>();
+        // DMN model does not allow loans for age >= 60, so no CF will be possible
+        features.add(FeatureFactory.newNumericalFeature("age", 61));
+        constraints.add(true);
+        featureBoundaries.add(EmptyFeatureDomain.create());
+        features.add(FeatureFactory.newBooleanFeature("hasReferral", true));
+        constraints.add(true);
+        featureBoundaries.add(EmptyFeatureDomain.create());
+        features.add(FeatureFactory.newNumericalFeature("monthlySalary", 500));
+        featureBoundaries.add(NumericalFeatureDomain.create(10, 10_000));
+        constraints.add(false);
+
+        final TerminationConfig terminationConfig = new TerminationConfig().withScoreCalculationCountLimit(10_000L);
+        // for the purpose of this test, only a few steps are necessary
+        final SolverConfig solverConfig = SolverConfigBuilder
+                .builder().withTerminationConfig(terminationConfig).build();
+        solverConfig.setRandomSeed((long) 23);
+        solverConfig.setEnvironmentMode(EnvironmentMode.REPRODUCIBLE);
+
+        final CounterfactualConfig counterfactualConfig = new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
+        final CounterfactualExplainer counterfactualExplainer =
+                new CounterfactualExplainer(counterfactualConfig);
+
+        PredictionInput input = new PredictionInput(features);
+
+        PredictionOutput output = new PredictionOutput(goal);
+        Prediction prediction = new CounterfactualPrediction(input,
+                output,
+                new PredictionFeatureDomain(featureBoundaries),
+                constraints,
+                null,
+                UUID.randomUUID(), 60L);
+        final CounterfactualResult counterfactualResult =
+                counterfactualExplainer.explainAsync(prediction, model)
+                        .get(Config.INSTANCE.getAsyncTimeout(), Config.INSTANCE.getAsyncTimeUnit());
+
+        assertFalse(counterfactualResult.isValid());
+    }
+
+    private PredictionProvider getModel() {
+        DMNRuntime dmnRuntime = DMNKogito.createGenericDMNRuntime(new InputStreamReader(getClass().getResourceAsStream(
+                "/dmn/ComplexEligibility.dmn")));
+        assertEquals(1, dmnRuntime.getModels().size());
+        final String COMPLEX_ELIGIBILITY_NS = "https://kiegroup.org/dmn/_B305FE71-3B8C-48C5-B5B1-D9CC04825B16";
+        final String COMPLEX_ELIGIBILITY_NAME = "myComplexEligibility";
+        DecisionModel decisionModel = new DmnDecisionModel(dmnRuntime, COMPLEX_ELIGIBILITY_NS, COMPLEX_ELIGIBILITY_NAME);
+        return new DecisionModelWrapper(decisionModel, List.of());
+    }
+
+    private List<Output> generateGoal(boolean inputsAreValid, boolean canRequestLoan, double scoringFunction) {
+        return List.of(
+                new Output("inputsAreValid", Type.BOOLEAN, new Value(inputsAreValid), 0.0),
+                new Output("canRequestLoan", Type.BOOLEAN, new Value(canRequestLoan), 0.0),
+                new Output("my-scoring-function", Type.NUMBER, new Value(scoringFunction), 0.0));
+    }
+}

--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/ComplexEligibilityDmnCounterfactualExplainerTest.java
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/ComplexEligibilityDmnCounterfactualExplainerTest.java
@@ -84,7 +84,8 @@ class ComplexEligibilityDmnCounterfactualExplainerTest {
         solverConfig.setRandomSeed((long) 23);
         solverConfig.setEnvironmentMode(EnvironmentMode.REPRODUCIBLE);
 
-        final CounterfactualConfig counterfactualConfig = new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
+        final CounterfactualConfig counterfactualConfig =
+                new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
         final CounterfactualExplainer counterfactualExplainer =
                 new CounterfactualExplainer(counterfactualConfig);
 
@@ -146,7 +147,8 @@ class ComplexEligibilityDmnCounterfactualExplainerTest {
         solverConfig.setRandomSeed((long) 23);
         solverConfig.setEnvironmentMode(EnvironmentMode.REPRODUCIBLE);
 
-        final CounterfactualConfig counterfactualConfig = new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
+        final CounterfactualConfig counterfactualConfig =
+                new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
         final CounterfactualExplainer counterfactualExplainer =
                 new CounterfactualExplainer(counterfactualConfig);
 
@@ -185,7 +187,7 @@ class ComplexEligibilityDmnCounterfactualExplainerTest {
 
         // since the scoring function is ((0.6 * ((42 - age + 18)/42)) + (0.4 * (monthlySalary/8000)))
         // for a result of 1.0 the relation must be age = (7*monthlySalary)/2000 - 10
-        assertEquals(18, (7*monthlySalary)/2000.0 - 10.0, 0.5);
+        assertEquals(18, (7 * monthlySalary) / 2000.0 - 10.0, 0.5);
     }
 
     @Test
@@ -215,7 +217,8 @@ class ComplexEligibilityDmnCounterfactualExplainerTest {
         solverConfig.setRandomSeed((long) 23);
         solverConfig.setEnvironmentMode(EnvironmentMode.REPRODUCIBLE);
 
-        final CounterfactualConfig counterfactualConfig = new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
+        final CounterfactualConfig counterfactualConfig =
+                new CounterfactualConfig().withSolverConfig(solverConfig).withGoalThreshold(0.01);
         final CounterfactualExplainer counterfactualExplainer =
                 new CounterfactualExplainer(counterfactualConfig);
 

--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/DecisionModelWrapper.java
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/DecisionModelWrapper.java
@@ -69,8 +69,7 @@ class DecisionModelWrapper implements PredictionProvider {
                     Type type;
                     if (value.getUnderlyingObject() instanceof Boolean) {
                         type = Type.BOOLEAN;
-                    }
-                    else if (Double.isNaN(value.asNumber())) {
+                    } else if (Double.isNaN(value.asNumber())) {
                         type = Type.TEXT;
                     } else {
                         type = Type.NUMBER;

--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/DecisionModelWrapper.java
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/java/org/kie/kogito/explainability/explainability/integrationtests/dmn/DecisionModelWrapper.java
@@ -67,7 +67,10 @@ class DecisionModelWrapper implements PredictionProvider {
                 if (!skippedDecisions.contains(decisionName)) {
                     Value value = new Value(decisionResult.getResult());
                     Type type;
-                    if (Double.isNaN(value.asNumber())) {
+                    if (value.getUnderlyingObject() instanceof Boolean) {
+                        type = Type.BOOLEAN;
+                    }
+                    else if (Double.isNaN(value.asNumber())) {
                         type = Type.TEXT;
                     } else {
                         type = Type.NUMBER;

--- a/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/resources/dmn/ComplexEligibility.dmn
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-dmn/src/test/resources/dmn/ComplexEligibility.dmn
@@ -1,0 +1,298 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_B305FE71-3B8C-48C5-B5B1-D9CC04825B16" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_4FE90384-3FA4-4361-ABBA-CD722EDC8A2F" name="myComplexEligibility" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_B305FE71-3B8C-48C5-B5B1-D9CC04825B16">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_533D6B94-8571-4AB8-AD27-08E2804FCDC1" name="age">
+    <dmn:extensionElements/>
+    <dmn:variable id="_3BCA484F-1DD1-4B40-9187-5E23EEB57164" name="age" typeRef="number"/>
+  </dmn:inputData>
+  <dmn:inputData id="_F57061AB-AA10-483F-A611-E62E1E39D1D8" name="monthlySalary">
+    <dmn:extensionElements/>
+    <dmn:variable id="_61319719-1150-4C69-9AD9-C603B071C0D9" name="monthlySalary" typeRef="number"/>
+  </dmn:inputData>
+  <dmn:decision id="_047FFF53-0583-4FAD-B08F-8E1C077021D6" name="inputsAreValid">
+    <dmn:extensionElements/>
+    <dmn:variable id="_F5CC016E-9897-4CAB-B4CF-BACCBE024C0E" name="inputsAreValid" typeRef="boolean"/>
+    <dmn:informationRequirement id="_B021D25B-5ECC-4C6A-AD10-128699B5A3AE">
+      <dmn:requiredInput href="#_533D6B94-8571-4AB8-AD27-08E2804FCDC1"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_7633BF32-AB36-4CED-8750-103906C1A426">
+      <dmn:requiredInput href="#_F57061AB-AA10-483F-A611-E62E1E39D1D8"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_9D82929A-A302-4CBC-9922-C507C0BFB6C1" hitPolicy="FIRST" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_F72993A1-956E-48EC-B283-9E3A13173904">
+        <dmn:inputExpression id="_6C8326F1-7DA0-40EF-8290-E47F642BDB46" typeRef="number">
+          <dmn:text>age</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:input id="_5965195C-B128-4606-8724-8DD8CDDFB1D9">
+        <dmn:inputExpression id="_4595F74A-19DA-42EB-90A6-44EA13EFCB94" typeRef="number">
+          <dmn:text>monthlySalary</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_131A73BE-C8C4-491E-A3FA-6887F39A8676"/>
+      <dmn:annotation name="annotation-1"/>
+      <dmn:rule id="_E9EC1C9E-6BA2-473E-BC04-FAEADF73E50A">
+        <dmn:inputEntry id="_7DE99E4A-72B8-4305-8A5C-B9BADC4EA507">
+          <dmn:text>&gt; 60</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_D7F3D3CD-67D3-479A-B4FE-0052F80F36C0">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_7F401759-F08D-4E18-9606-C00B5F8D70EA">
+          <dmn:text>false</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_E0F9FE77-970A-476B-9C1A-7DD25F390032">
+        <dmn:inputEntry id="_D6824292-B0B5-4B7E-941B-8B0FB1926B99">
+          <dmn:text>&lt; 18</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_F292862A-2AD7-4990-80DA-2DD27CAE0D29">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_0A884882-37E3-4C40-8910-10B325903C6E">
+          <dmn:text>false</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_9EF1E509-A06E-415E-A9F5-DD61801969FB">
+        <dmn:inputEntry id="_FC58AD10-B489-4001-8E0D-CF4768911468">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_4227B780-0A0E-430A-8C6A-44802939249A">
+          <dmn:text>&lt;= 0</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_2737CEDC-E390-4305-83E7-4B983260A044">
+          <dmn:text>false</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_C14E39CF-CEF2-48FC-B4C6-9EFBA26C5148">
+        <dmn:inputEntry id="_32F728C7-4DC7-406F-9B30-D9BB19796AB6">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_F92584EE-0502-465E-8A6C-833ECF80C03A">
+          <dmn:text>&gt;= 8000</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_BADAAAC1-724C-4D05-99F2-B762A67C2832">
+          <dmn:text>false</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_0AB64278-7F47-447C-A79C-05ECA0935D44">
+        <dmn:inputEntry id="_71ACEFFE-04D8-4165-82B5-0851FB396B49">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_41F47ECA-8E44-4FEF-8D99-C75D64D81604">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_E14AB19C-8D66-4BAA-8147-9DAC2B4EA66D">
+          <dmn:text>true</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:decision id="_EB4C6678-E2A9-4479-BC65-B9D538B3FA79" name="my-scoring-function">
+    <dmn:extensionElements/>
+    <dmn:variable id="_DDEDB0DE-576A-435D-9CB4-DEF44BEB4FD9" name="my-scoring-function" typeRef="number"/>
+    <dmn:informationRequirement id="_FA4D000B-328B-444F-BD1E-A34799451430">
+      <dmn:requiredDecision href="#_047FFF53-0583-4FAD-B08F-8E1C077021D6"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_8A345EFB-E9DC-4C89-AD6B-9A17D6F8C947">
+      <dmn:requiredInput href="#_F57061AB-AA10-483F-A611-E62E1E39D1D8"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_F628EDDB-5040-4681-810C-1036F3361210">
+      <dmn:requiredInput href="#_533D6B94-8571-4AB8-AD27-08E2804FCDC1"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_43D088A9-E325-483F-8524-94F4C19E02DC">
+      <dmn:text>if inputsAreValid then ((0.6 * ((42 - age + 18)/42)) + (0.4 * (monthlySalary/8000))) else 0</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_46B5CA54-27CA-4950-B601-63F58BC3BDFE" name="canRequestLoan">
+    <dmn:extensionElements/>
+    <dmn:variable id="_804B6AA0-D4CA-4CC6-BD89-53A879E859BE" name="canRequestLoan" typeRef="boolean"/>
+    <dmn:informationRequirement id="_7438106E-8FC3-4A28-883A-C19890335D06">
+      <dmn:requiredDecision href="#_EB4C6678-E2A9-4479-BC65-B9D538B3FA79"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement id="_1FA4D5C5-03DB-4F56-939F-7456E2E2EA24">
+      <dmn:requiredInput href="#_508F6634-D004-4C02-B9D5-4B5A92F8251D"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_718D13F3-D92A-4F38-B120-A5A97E4F9F6C" hitPolicy="FIRST" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_178939B6-2C71-4136-A0E5-0E082069DC38">
+        <dmn:inputExpression id="_5FA0B0E9-D900-4454-AC91-781777756EC2" typeRef="number">
+          <dmn:text>my-scoring-function</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:input id="_DE1D6374-F2A9-4E46-BD72-83E3E03F04A5">
+        <dmn:inputExpression id="_38EE6A5B-DAAB-4F8C-88E2-6EF75ADE9A2F" typeRef="boolean">
+          <dmn:text>hasReferral</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_C74D4A2E-E319-45FB-A191-49B2A25EA4F4"/>
+      <dmn:annotation name="annotation-1"/>
+      <dmn:rule id="_301245D5-050C-475F-885D-8993331084E6">
+        <dmn:inputEntry id="_18490016-C3F0-4579-AEFA-E1A4A69998FA">
+          <dmn:text>&gt;=0.55</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_3489C84F-B432-4616-AFD1-B0EAA4A99D89">
+          <dmn:text>false</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_702A4EBB-6F90-4DED-82C8-FD0FCC1BBF77">
+          <dmn:text>true</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_DDBF5C0D-4BCF-4749-9547-DFA78CC261F2">
+        <dmn:inputEntry id="_BF9174F4-98B8-4631-9B0F-2046F668D9B4">
+          <dmn:text>&gt;= 0.40</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_1FA062D0-4D2F-4D7D-9800-B7DFCC11A1C0">
+          <dmn:text>true</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_338A1A53-2168-46BF-8363-B4326008D89E">
+          <dmn:text>true</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_351C8E3F-A185-4FEB-9AE1-6BB722031157">
+        <dmn:inputEntry id="_26F476E1-8BB5-4751-A8A4-262EC26507DB">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:inputEntry id="_3DE01767-52B7-42D8-86CF-3FD10961C7BA">
+          <dmn:text>-</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_D08E01D3-656C-4964-9B0E-8C8CA221606D">
+          <dmn:text>false</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+  <dmn:inputData id="_508F6634-D004-4C02-B9D5-4B5A92F8251D" name="hasReferral">
+    <dmn:extensionElements/>
+    <dmn:variable id="_620E4B97-AFFD-451B-8678-6B2B5DF36D75" name="hasReferral" typeRef="boolean"/>
+  </dmn:inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_10112FA3-C6DE-4298-A93A-92B9B774ED66" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_9D82929A-A302-4CBC-9922-C507C0BFB6C1">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_43D088A9-E325-483F-8524-94F4C19E02DC">
+            <kie:width>980</kie:width>
+          </kie:ComponentWidths>
+          <kie:ComponentWidths dmnElementRef="_718D13F3-D92A-4F38-B120-A5A97E4F9F6C">
+            <kie:width>50</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+            <kie:width>100</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_533D6B94-8571-4AB8-AD27-08E2804FCDC1" dmnElementRef="_533D6B94-8571-4AB8-AD27-08E2804FCDC1" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="485" y="411" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_F57061AB-AA10-483F-A611-E62E1E39D1D8" dmnElementRef="_F57061AB-AA10-483F-A611-E62E1E39D1D8" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="646.2990654205607" y="412" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_047FFF53-0583-4FAD-B08F-8E1C077021D6" dmnElementRef="_047FFF53-0583-4FAD-B08F-8E1C077021D6" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="444" y="308" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_EB4C6678-E2A9-4479-BC65-B9D538B3FA79" dmnElementRef="_EB4C6678-E2A9-4479-BC65-B9D538B3FA79" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="647" y="225" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_46B5CA54-27CA-4950-B601-63F58BC3BDFE" dmnElementRef="_46B5CA54-27CA-4950-B601-63F58BC3BDFE" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="648" y="89" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_508F6634-D004-4C02-B9D5-4B5A92F8251D" dmnElementRef="_508F6634-D004-4C02-B9D5-4B5A92F8251D" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="863" y="307" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_B021D25B-5ECC-4C6A-AD10-128699B5A3AE" dmnElementRef="_B021D25B-5ECC-4C6A-AD10-128699B5A3AE">
+        <di:waypoint x="535" y="436"/>
+        <di:waypoint x="494" y="358"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_7633BF32-AB36-4CED-8750-103906C1A426" dmnElementRef="_7633BF32-AB36-4CED-8750-103906C1A426">
+        <di:waypoint x="696.2990654205607" y="437"/>
+        <di:waypoint x="494" y="358"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_FA4D000B-328B-444F-BD1E-A34799451430" dmnElementRef="_FA4D000B-328B-444F-BD1E-A34799451430">
+        <di:waypoint x="494" y="333"/>
+        <di:waypoint x="697" y="275"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_8A345EFB-E9DC-4C89-AD6B-9A17D6F8C947" dmnElementRef="_8A345EFB-E9DC-4C89-AD6B-9A17D6F8C947">
+        <di:waypoint x="696.2990654205607" y="437"/>
+        <di:waypoint x="697" y="275"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_F628EDDB-5040-4681-810C-1036F3361210-AUTO-TARGET" dmnElementRef="_F628EDDB-5040-4681-810C-1036F3361210">
+        <di:waypoint x="535" y="436"/>
+        <di:waypoint x="697" y="275"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_7438106E-8FC3-4A28-883A-C19890335D06" dmnElementRef="_7438106E-8FC3-4A28-883A-C19890335D06">
+        <di:waypoint x="697" y="250"/>
+        <di:waypoint x="698" y="139"/>
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="dmnedge-drg-_1FA4D5C5-03DB-4F56-939F-7456E2E2EA24-AUTO-TARGET" dmnElementRef="_1FA4D5C5-03DB-4F56-939F-7456E2E2EA24">
+        <di:waypoint x="913" y="332"/>
+        <di:waypoint x="698" y="139"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>


### PR DESCRIPTION
[FAI-556](https://issues.redhat.com/browse/FAI-556):

- Add test cover requesting counterfactual explanations from a DMN model (although no structured types support, ATM).
- `DecisionModelWrapper` has been altered to support `Boolean` outcomes from a DMN model.

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
