### PR TITLE
FAI-448: Breadcrumb forcing page reload

### DIFF
--- a/ui-packages/packages/trusty/src/components/Organisms/Breadcrumbs/Breadcrumbs.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/Breadcrumbs/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import useBreadcrumbs from 'use-react-router-breadcrumbs';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
-import { RouteComponentProps } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import ExecutionId from '../../Atoms/ExecutionId/ExecutionId';
 
 const Breadcrumbs = () => {
@@ -15,12 +15,14 @@ const Breadcrumbs = () => {
             return (
               <BreadcrumbItem
                 className="breadcrumb-item"
-                to={match.url}
                 key={match.url}
                 isActive={location.pathname === match.url}
-              >
-                {breadcrumb}
-              </BreadcrumbItem>
+                render={({ className }) => (
+                  <Link to={match.url} className={className}>
+                    {breadcrumb}
+                  </Link>
+                )}
+              />
             );
           })}
         </Breadcrumb>

--- a/ui-packages/packages/trusty/src/components/Organisms/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -54,8 +54,21 @@ describe('Breadcrumbs', () => {
     ).toMatch('Outcomes');
     expect(
       breadcrumbs
-        .find('li.breadcrumb-item')
-        .find('.pf-c-breadcrumb__link.pf-m-current')
-    ).toHaveLength(1);
+        .find('BreadcrumbItem')
+        .at(0)
+        .prop('isActive') as boolean
+    ).toBeFalsy();
+    expect(
+      breadcrumbs
+        .find('BreadcrumbItem')
+        .at(1)
+        .prop('isActive') as boolean
+    ).toBeFalsy();
+    expect(
+      breadcrumbs
+        .find('BreadcrumbItem')
+        .at(2)
+        .prop('isActive') as boolean
+    ).toBeTruthy();
   });
 });

--- a/ui-packages/packages/trusty/src/components/Organisms/Breadcrumbs/tests/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/ui-packages/packages/trusty/src/components/Organisms/Breadcrumbs/tests/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -19,31 +19,42 @@ exports[`Breadcrumbs renders outcome details breadcrumbs links 1`] = `
           className="breadcrumb-item"
           isActive={false}
           key=".$/audit"
+          render={[Function]}
           showDivider={false}
-          to="/audit"
         >
           <li
             className="pf-c-breadcrumb__item breadcrumb-item"
           >
-            <a
+            <Link
               className="pf-c-breadcrumb__link"
-              href="/audit"
-              target={null}
+              to="/audit"
             >
-              <span
-                key="/audit"
+              <LinkAnchor
+                className="pf-c-breadcrumb__link"
+                href="/audit"
+                navigate={[Function]}
               >
-                Audit Investigation
-              </span>
-            </a>
+                <a
+                  className="pf-c-breadcrumb__link"
+                  href="/audit"
+                  onClick={[Function]}
+                >
+                  <span
+                    key="/audit"
+                  >
+                    Audit Investigation
+                  </span>
+                </a>
+              </LinkAnchor>
+            </Link>
           </li>
         </BreadcrumbItem>
         <BreadcrumbItem
           className="breadcrumb-item"
           isActive={false}
           key=".$/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
+          render={[Function]}
           showDivider={true}
-          to="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
         >
           <li
             className="pf-c-breadcrumb__item breadcrumb-item"
@@ -76,56 +87,67 @@ exports[`Breadcrumbs renders outcome details breadcrumbs links 1`] = `
                 </svg>
               </AngleRightIcon>
             </span>
-            <a
+            <Link
               className="pf-c-breadcrumb__link"
-              href="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
-              target={null}
+              to="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
             >
-              <AuditDetailBreadcrumb
-                key="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
-                location={
-                  Object {
-                    "hash": "",
-                    "key": "execution",
-                    "pathname": "/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes",
-                    "search": "",
-                  }
-                }
-                match={
-                  Object {
-                    "isExact": true,
-                    "params": Object {
-                      "executionType": "decision",
-                      "id": "b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000",
-                    },
-                    "path": "/audit/:executionType/:id",
-                    "url": "/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000",
-                  }
-                }
+              <LinkAnchor
+                className="pf-c-breadcrumb__link"
+                href="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
+                navigate={[Function]}
               >
-                <span>
-                  Execution 
-                  <ExecutionId
-                    id="b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
+                <a
+                  className="pf-c-breadcrumb__link"
+                  href="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
+                  onClick={[Function]}
+                >
+                  <AuditDetailBreadcrumb
+                    key="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
+                    location={
+                      Object {
+                        "hash": "",
+                        "key": "execution",
+                        "pathname": "/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes",
+                        "search": "",
+                      }
+                    }
+                    match={
+                      Object {
+                        "isExact": true,
+                        "params": Object {
+                          "executionType": "decision",
+                          "id": "b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000",
+                        },
+                        "path": "/audit/:executionType/:id",
+                        "url": "/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000",
+                      }
+                    }
                   >
-                    <span
-                      className="execution-id"
-                    >
-                      #
-                      b2b0ed8d
+                    <span>
+                      Execution 
+                      <ExecutionId
+                        id="b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000"
+                      >
+                        <span
+                          className="execution-id"
+                        >
+                          #
+                          b2b0ed8d
+                        </span>
+                      </ExecutionId>
                     </span>
-                  </ExecutionId>
-                </span>
-              </AuditDetailBreadcrumb>
-            </a>
+                  </AuditDetailBreadcrumb>
+                </a>
+              </LinkAnchor>
+            </Link>
           </li>
         </BreadcrumbItem>
         <BreadcrumbItem
           className="breadcrumb-item"
           isActive={true}
           key=".$/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes"
+          render={[Function]}
           showDivider={true}
-          to="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes"
         >
           <li
             className="pf-c-breadcrumb__item breadcrumb-item"
@@ -158,18 +180,28 @@ exports[`Breadcrumbs renders outcome details breadcrumbs links 1`] = `
                 </svg>
               </AngleRightIcon>
             </span>
-            <a
-              aria-current="page"
+            <Link
               className="pf-c-breadcrumb__link pf-m-current"
-              href="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes"
-              target={null}
+              to="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes"
             >
-              <span
-                key="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes"
+              <LinkAnchor
+                className="pf-c-breadcrumb__link pf-m-current"
+                href="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes"
+                navigate={[Function]}
               >
-                Outcomes
-              </span>
-            </a>
+                <a
+                  className="pf-c-breadcrumb__link pf-m-current"
+                  href="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes"
+                  onClick={[Function]}
+                >
+                  <span
+                    key="/audit/decision/b2b0ed8d-c1e2-46b5-3ac54ff4beae-1000/outcomes"
+                  >
+                    Outcomes
+                  </span>
+                </a>
+              </LinkAnchor>
+            </Link>
           </li>
         </BreadcrumbItem>
       </ol>


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/FAI-448

Using breadcrumb links forced a full page reload.
After an update to PF, it's possible to pass a render prop to `BreadcrumbItem`. 
Using react-router's `Link` there solves the issue.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
