### PR TITLE
FAI-615: Handling of null values in CF score calculation

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
@@ -17,6 +17,7 @@ package org.kie.kogito.explainability.local.counterfactual;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -68,6 +69,11 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
             // If any of the values is zero use the difference instead of change
             // If neither of the values is zero use the change rate
             double distance;
+            if (Double.isNaN(predictionValue) || Double.isNaN(goalValue)) {
+                String message = String.format("Unsupported NaN or NULL for numeric feature '%s'", prediction.getName());
+                logger.error(message);
+                throw new IllegalArgumentException(message);
+            }
             if (predictionValue == 0 || goalValue == 0) {
                 distance = difference;
             } else {
@@ -79,8 +85,10 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
                 return distance;
             }
 
-        } else if (prediction.getType() == Type.CATEGORICAL || prediction.getType() == Type.BOOLEAN || prediction.getType() == Type.TEXT) {
-            return prediction.getValue().getUnderlyingObject().equals(goal.getValue().getUnderlyingObject()) ? 0.0 : 1.0;
+        } else if (prediction.getType() == Type.CATEGORICAL || prediction.getType() == Type.BOOLEAN) {
+            final Object goalValueObject = goal.getValue().getUnderlyingObject();
+            final Object predictionValueObject = prediction.getValue().getUnderlyingObject();
+            return Objects.equals(goalValueObject, predictionValueObject) ? 0.0 : 1.0;
         } else {
             String message = String.format("Feature '%s' has unsupported type '%s'", prediction.getName(), predictionType.toString());
             logger.error(message);

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/CounterFactualScoreCalculator.java
@@ -85,12 +85,14 @@ public class CounterFactualScoreCalculator implements EasyScoreCalculator<Counte
                 return distance;
             }
 
-        } else if (prediction.getType() == Type.CATEGORICAL || prediction.getType() == Type.BOOLEAN) {
+        } else if (prediction.getType() == Type.CATEGORICAL || prediction.getType() == Type.BOOLEAN
+                || prediction.getType() == Type.TEXT) {
             final Object goalValueObject = goal.getValue().getUnderlyingObject();
             final Object predictionValueObject = prediction.getValue().getUnderlyingObject();
             return Objects.equals(goalValueObject, predictionValueObject) ? 0.0 : 1.0;
         } else {
-            String message = String.format("Feature '%s' has unsupported type '%s'", prediction.getName(), predictionType.toString());
+            String message =
+                    String.format("Feature '%s' has unsupported type '%s'", prediction.getName(), predictionType.toString());
             logger.error(message);
             throw new IllegalArgumentException(message);
         }

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/AbstractEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/AbstractEntity.java
@@ -15,6 +15,8 @@
  */
 package org.kie.kogito.explainability.local.counterfactual.entities;
 
+import java.util.Objects;
+
 import org.kie.kogito.explainability.model.Feature;
 
 /**
@@ -50,7 +52,7 @@ public abstract class AbstractEntity<T> implements CounterfactualEntity {
      */
     @Override
     public boolean isChanged() {
-        return !originalValue.equals(this.proposedValue);
+        return !Objects.equals(originalValue, proposedValue);
     }
 
     @Override

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/BooleanEntity.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/BooleanEntity.java
@@ -15,6 +15,8 @@
  */
 package org.kie.kogito.explainability.local.counterfactual.entities;
 
+import java.util.Objects;
+
 import org.kie.kogito.explainability.model.Feature;
 import org.kie.kogito.explainability.model.FeatureFactory;
 import org.optaplanner.core.api.domain.entity.PlanningEntity;
@@ -67,7 +69,7 @@ public class BooleanEntity extends AbstractEntity<Boolean> {
      */
     @Override
     public double distance() {
-        return proposedValue.equals(originalValue) ? 0.0 : 1.0;
+        return Objects.equals(proposedValue, originalValue) ? 0.0 : 1.0;
     }
 
     @Override

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
@@ -44,6 +44,7 @@ public class CounterfactualEntityFactory {
     public static CounterfactualEntity from(Feature feature, Boolean isConstrained, FeatureDomain featureDomain,
             FeatureDistribution featureDistribution) {
         CounterfactualEntity entity = null;
+        validateFeature(feature);
         if (feature.getType() == Type.NUMBER) {
             if (feature.getValue().getUnderlyingObject() instanceof Double) {
                 if (isConstrained) {
@@ -100,7 +101,6 @@ public class CounterfactualEntityFactory {
         return IntStream.range(0, predictionInput.getFeatures().size())
                 .mapToObj(featureIndex -> {
                     final Feature feature = predictionInput.getFeatures().get(featureIndex);
-                    validateFeature(feature);
                     final Boolean isConstrained = constraints.get(featureIndex);
                     final FeatureDomain domain = domains.get(featureIndex);
                     final FeatureDistribution featureDistribution = Optional

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
@@ -81,6 +81,7 @@ public class CounterfactualEntityFactory {
 
     /**
      * Validation of features for counterfactual entity construction
+     * 
      * @param feature {@link Feature} to be validated
      */
     public static void validateFeature(Feature feature) {

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/counterfactual/entities/CounterfactualEntityFactory.java
@@ -79,12 +79,27 @@ public class CounterfactualEntityFactory {
         return entity;
     }
 
+    /**
+     * Validation of features for counterfactual entity construction
+     * @param feature {@link Feature} to be validated
+     */
+    public static void validateFeature(Feature feature) {
+        final Type type = feature.getType();
+        final Object object = feature.getValue().getUnderlyingObject();
+        if (type == Type.NUMBER) {
+            if (object == null) {
+                throw new IllegalArgumentException("Null numeric features are not supported in counterfactuals");
+            }
+        }
+    }
+
     public static List<CounterfactualEntity> createEntities(PredictionInput predictionInput,
             PredictionFeatureDomain featureDomain, List<Boolean> constraints, DataDistribution dataDistribution) {
         final List<FeatureDomain> domains = featureDomain.getFeatureDomains();
         return IntStream.range(0, predictionInput.getFeatures().size())
                 .mapToObj(featureIndex -> {
                     final Feature feature = predictionInput.getFeatures().get(featureIndex);
+                    validateFeature(feature);
                     final Boolean isConstrained = constraints.get(featureIndex);
                     final FeatureDomain domain = domains.get(featureIndex);
                     final FeatureDistribution featureDistribution = Optional

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualEntityFactoryTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualEntityFactoryTest.java
@@ -41,6 +41,7 @@ import org.kie.kogito.explainability.model.domain.NumericalFeatureDomain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CounterfactualEntityFactoryTest {
@@ -193,5 +194,17 @@ class CounterfactualEntityFactoryTest {
         assertFalse(entities.get(1).isConstrained());
         assertTrue(entities.get(2).isConstrained());
         assertFalse(entities.get(3).isConstrained());
+    }
+
+    @Test
+    void testValidateNullNumericalFeature() {
+        final Feature feature = FeatureFactory.newNumericalFeature("double-feature", null);
+        final FeatureDomain domain = EmptyFeatureDomain.create();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            CounterfactualEntityFactory.from(feature, true, domain);
+        });
+
+        assertEquals("Null numeric features are not supported in counterfactuals", exception.getMessage());
     }
 }

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -38,7 +38,6 @@ import org.kie.kogito.explainability.model.PredictionOutput;
 import org.kie.kogito.explainability.model.PredictionProvider;
 import org.kie.kogito.explainability.model.Type;
 import org.kie.kogito.explainability.model.Value;
-import org.kie.kogito.explainability.model.domain.CategoricalFeatureDomain;
 import org.kie.kogito.explainability.model.domain.EmptyFeatureDomain;
 import org.kie.kogito.explainability.model.domain.FeatureDomain;
 import org.kie.kogito.explainability.model.domain.NumericalFeatureDomain;
@@ -254,6 +253,10 @@ class CounterfactualScoreCalculatorTest {
         distance = CounterFactualScoreCalculator.outputDistance(predictionOutput, goalOutput);
 
         assertEquals(Type.CATEGORICAL, predictionOutput.getType());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 1, 2, 3, 4 })
     void TextDistanceSameValue(int seed) {
         final String value = UUID.randomUUID().toString();
         Feature x = FeatureFactory.newTextFeature("x", value);

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -38,7 +38,6 @@ import org.kie.kogito.explainability.model.PredictionOutput;
 import org.kie.kogito.explainability.model.PredictionProvider;
 import org.kie.kogito.explainability.model.Type;
 import org.kie.kogito.explainability.model.Value;
-import org.kie.kogito.explainability.model.domain.CategoricalFeatureDomain;
 import org.kie.kogito.explainability.model.domain.EmptyFeatureDomain;
 import org.kie.kogito.explainability.model.domain.FeatureDomain;
 import org.kie.kogito.explainability.model.domain.NumericalFeatureDomain;

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -759,7 +759,7 @@ class CounterfactualScoreCalculatorTest {
     }
 
     /**
-     * If the goal and the model's output is the same, the distances should all be zero.
+     * Null values for input Boolean features should be accepted as valid
      */
     @Test
     void testNullBooleanInput() throws ExecutionException, InterruptedException {
@@ -816,7 +816,7 @@ class CounterfactualScoreCalculatorTest {
     }
 
     /**
-     * If the goal and the model's output is the same, the distances should all be zero.
+     * Null values for input Integer features should not be accepted as valid
      */
     @Test
     void testNullIntegerInput() throws ExecutionException, InterruptedException {
@@ -850,7 +850,7 @@ class CounterfactualScoreCalculatorTest {
     }
 
     /**
-     * If the goal and the model's output is the same, the distances should all be zero.
+     * Null values for input Double features should not be accepted as valid
      */
     @Test
     void testNullDoubleInput() {

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/counterfactual/CounterfactualScoreCalculatorTest.java
@@ -38,6 +38,7 @@ import org.kie.kogito.explainability.model.PredictionOutput;
 import org.kie.kogito.explainability.model.PredictionProvider;
 import org.kie.kogito.explainability.model.Type;
 import org.kie.kogito.explainability.model.Value;
+import org.kie.kogito.explainability.model.domain.CategoricalFeatureDomain;
 import org.kie.kogito.explainability.model.domain.EmptyFeatureDomain;
 import org.kie.kogito.explainability.model.domain.FeatureDomain;
 import org.kie.kogito.explainability.model.domain.NumericalFeatureDomain;


### PR DESCRIPTION
JIRA: [FAI-615](https://issues.redhat.com/browse/FAI-615)

This PR defines the formal support for `null` values in CF features and avoids throwing generic NPEs when `null` occurs. 
In summary:

- `null` numeric features are not supported (and a relevant exception is thrown)
- `null` boolean features are supported
- `null` categorical features are supported

> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket
> 

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
