### PR TITLE
KOGITO-5817 Disable REST codegen if resteasy is not present

### DIFF
--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus/pom.xml
@@ -46,6 +46,14 @@
       <artifactId>kogito-addons-persistence-filesystem</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-test-utils</artifactId>
       <scope>test</scope>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/pom.xml
@@ -33,6 +33,14 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-addons-quarkus-jobs-management</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/apps-integration-tests/integration-tests-task-assigning-service/integration-tests-task-assigning-service-processes/pom.xml
+++ b/apps-integration-tests/integration-tests-task-assigning-service/integration-tests-task-assigning-service-processes/pom.xml
@@ -18,6 +18,14 @@
       <artifactId>kogito-quarkus</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-addons-quarkus-events-smallrye</artifactId>
     </dependency>

--- a/apps-integration-tests/integration-tests-task-assigning-service/integration-tests-task-assigning-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-task-assigning-service/integration-tests-task-assigning-service-quarkus/pom.xml
@@ -23,6 +23,14 @@
       <artifactId>quarkus-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>integration-tests-data-index-service-common</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Throws an Exception at build-time, *unless* RESTEasy is present.

- https://github.com/kiegroup/kogito-runtimes/pull/1643
- https://github.com/kiegroup/kogito-apps/pull/1060
- https://github.com/kiegroup/kogito-examples/pull/932

http://issues.redhat.com/browse/KOGITO-5817