### PR TITLE
FAI-636: Remove timeout definition from the producer

### DIFF
--- a/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerProducer.java
+++ b/explainability/explainability-service/src/main/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerProducer.java
@@ -23,9 +23,6 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.kie.kogito.explainability.local.counterfactual.CounterfactualConfig;
 import org.kie.kogito.explainability.local.counterfactual.CounterfactualExplainer;
-import org.kie.kogito.explainability.local.counterfactual.SolverConfigBuilder;
-import org.optaplanner.core.config.solver.SolverConfig;
-import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,28 +30,19 @@ import org.slf4j.LoggerFactory;
 public class CounterfactualExplainerProducer {
 
     private static final Logger LOG = LoggerFactory.getLogger(CounterfactualExplainerProducer.class);
-
-    private final Long maxRunningTimeSeconds;
     private final Double goalThreshold;
 
     @Inject
     public CounterfactualExplainerProducer(
-            @ConfigProperty(name = "trusty.explainability.counterfactuals.maxRunningTimeSeconds",
-                    defaultValue = "60") Integer maxRunningTimeSeconds,
             @ConfigProperty(name = "trusty.explainability.counterfactuals.goalThreshold",
                     defaultValue = "0.01") Double goalThreshold) {
-        this.maxRunningTimeSeconds = Long.valueOf(maxRunningTimeSeconds);
         this.goalThreshold = goalThreshold;
     }
 
     @Produces
     public CounterfactualExplainer produce() {
         LOG.debug("CounterfactualExplainer created");
-        final TerminationConfig terminationConfig = new TerminationConfig().withSecondsSpentLimit(this.maxRunningTimeSeconds);
-        final SolverConfig solverConfig = SolverConfigBuilder.builder().withTerminationConfig(terminationConfig).build();
-        final CounterfactualConfig counterfactualConfig = new CounterfactualConfig()
-                .withSolverConfig(solverConfig)
-                .withGoalThreshold(this.goalThreshold);
+        final CounterfactualConfig counterfactualConfig = new CounterfactualConfig().withGoalThreshold(this.goalThreshold);
         return new CounterfactualExplainer(counterfactualConfig);
     }
 }

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerProducerTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerProducerTest.java
@@ -28,13 +28,11 @@ class CounterfactualExplainerProducerTest {
 
     @Test
     void produce() {
-        CounterfactualExplainerProducer producer = new CounterfactualExplainerProducer(10, 0.01);
+        CounterfactualExplainerProducer producer = new CounterfactualExplainerProducer(0.01);
         LocalExplainer<CounterfactualResult> counterfactualExplainer = producer.produce();
 
         assertNotNull(counterfactualExplainer);
         assertTrue(counterfactualExplainer instanceof CounterfactualExplainer);
-        assertEquals(10, ((CounterfactualExplainer) counterfactualExplainer).getCounterfactualConfig().getSolverConfig()
-                .getTerminationConfig().getSecondsSpentLimit());
         assertEquals(0.01, ((CounterfactualExplainer) counterfactualExplainer).getCounterfactualConfig().getGoalThreshold());
     }
 


### PR DESCRIPTION
[FAI-636](https://issues.redhat.com/browse/FAI-636):

This reverts the `CounterfactualExplainerProducer` to the previous version, which passed the CF search timeout via the prediction object (in order to be accessible to the UI). cc @manstis 

This is also related to [FAI-634](https://issues.redhat.com/browse/FAI-634) cc @r00ta 


> This is reverted to the previous instance where it was defined in `trusty-service`.
> 
> Many thanks for submitting your Pull Request :heart:! 
> 
> Please make sure that your PR meets the following requirements:
> 
> - [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
> - [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
> - [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
> - [x] Pull Request contains link to the JIRA issue
> - [x] Pull Request contains link to any dependent or related Pull Request
> - [x] Pull Request contains description of the issue
> - [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
