### PR TITLE
FAI-623: Improve error management

### DIFF
--- a/ui-packages/packages/trusty/src/components/Molecules/CounterfactualError/CounterfactualError.tsx
+++ b/ui-packages/packages/trusty/src/components/Molecules/CounterfactualError/CounterfactualError.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { Button, Modal } from '@patternfly/react-core';
+
+const CounterfactualError = () => {
+  const [isModalOpen, setIsModalOpen] = useState(true);
+  const modalToggle = () => {
+    setIsModalOpen(!isModalOpen);
+  };
+  return (
+    <Modal
+      isOpen={isModalOpen}
+      title="Counterfactual error"
+      titleIconVariant="warning"
+      showClose={true}
+      onClose={modalToggle}
+      width={500}
+      actions={[
+        <Button key="confirm" variant="primary" onClick={modalToggle}>
+          Close
+        </Button>
+      ]}
+    >
+      <span>
+        Something went wrong while running the Counterfactual analysis.
+      </span>
+    </Modal>
+  );
+};
+
+export default CounterfactualError;

--- a/ui-packages/packages/trusty/src/components/Organisms/CounterfactualAnalysis/CounterfactualAnalysis.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/CounterfactualAnalysis/CounterfactualAnalysis.tsx
@@ -24,6 +24,7 @@ import CounterfactualCompletedMessage from '../../Molecules/CounterfactualComple
 import CounterfactualToolbar from '../CounterfactualToolbar/CounterfactualToolbar';
 import CounterfactualTable from '../CounterfactualTable/CounterfactualTable';
 import useCounterfactualExecution from './useCounterfactualExecution';
+import CounterfactualError from '../../Molecules/CounterfactualError/CounterfactualError';
 import {
   CFAnalysisResetType,
   CFExecutionStatus,
@@ -118,6 +119,15 @@ const CounterfactualAnalysis = (props: CounterfactualAnalysisProps) => {
     }
   }, [cfResults]);
 
+  useEffect(() => {
+    if (cfAnalysis?.status === RemoteDataStatus.FAILURE) {
+      dispatch({
+        type: 'CF_RESET_ANALYSIS',
+        payload: { resetType: 'EDIT', inputs, outcomes }
+      });
+    }
+  }, [cfAnalysis, inputs, outcomes]);
+
   const maxRunningTimeSeconds = useMemo(() => {
     if (cfAnalysis?.status === RemoteDataStatus.SUCCESS) {
       return cfAnalysis.data.maxRunningTimeSeconds;
@@ -139,71 +149,78 @@ const CounterfactualAnalysis = (props: CounterfactualAnalysisProps) => {
   return (
     <CFDispatch.Provider value={dispatch}>
       {containerHeight > 0 && (
-        <Drawer
-          isExpanded={isSidePanelExpanded}
-          className="counterfactual__drawer"
-        >
-          <DrawerContent
-            panelContent={panelContent}
-            style={{ height: containerHeight }}
+        <>
+          {cfAnalysis?.status === RemoteDataStatus.FAILURE && (
+            <CounterfactualError />
+          )}
+          <Drawer
+            isExpanded={isSidePanelExpanded}
+            className="counterfactual__drawer"
           >
-            <DrawerContentBody
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                height: '100%'
-              }}
+            <DrawerContent
+              panelContent={panelContent}
+              style={{ height: containerHeight }}
             >
-              <PageSection variant="light" isFilled={true}>
-                <section className="counterfactual__section">
-                  <Stack hasGutter>
-                    <StackItem>
-                      <Flex spaceItems={{ default: 'spaceItemsXl' }}>
-                        <FlexItem>
-                          <Title headingLevel="h3" size="2xl">
-                            Counterfactual Analysis
-                          </Title>
-                        </FlexItem>
-                        <FlexItem>
-                          <CounterfactualOutcomesSelected goals={state.goals} />
-                        </FlexItem>
-                        {state.status.executionStatus ===
-                          CFExecutionStatus.COMPLETED && (
-                          <CounterfactualExecutionInfo
-                            resultsCount={state.results.length}
-                          />
-                        )}
-                      </Flex>
-                    </StackItem>
-                    <CounterfactualHint
-                      isVisible={
-                        state.status.executionStatus ===
-                        CFExecutionStatus.NOT_STARTED
-                      }
-                    />
-                    <CounterfactualCompletedMessage status={state.status} />
-                    <StackItem isFilled={true} style={{ overflow: 'hidden' }}>
-                      <CounterfactualToolbar
-                        status={state.status}
-                        goals={state.goals}
-                        onRunAnalysis={onRunAnalysis}
-                        onSetupNewAnalysis={onSetupNewAnalysis}
-                        maxRunningTimeSeconds={maxRunningTimeSeconds}
+              <DrawerContentBody
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  height: '100%'
+                }}
+              >
+                <PageSection variant="light" isFilled={true}>
+                  <section className="counterfactual__section">
+                    <Stack hasGutter>
+                      <StackItem>
+                        <Flex spaceItems={{ default: 'spaceItemsXl' }}>
+                          <FlexItem>
+                            <Title headingLevel="h3" size="2xl">
+                              Counterfactual Analysis
+                            </Title>
+                          </FlexItem>
+                          <FlexItem>
+                            <CounterfactualOutcomesSelected
+                              goals={state.goals}
+                            />
+                          </FlexItem>
+                          {state.status.executionStatus ===
+                            CFExecutionStatus.COMPLETED && (
+                            <CounterfactualExecutionInfo
+                              resultsCount={state.results.length}
+                            />
+                          )}
+                        </Flex>
+                      </StackItem>
+                      <CounterfactualHint
+                        isVisible={
+                          state.status.executionStatus ===
+                          CFExecutionStatus.NOT_STARTED
+                        }
                       />
-                      <CounterfactualTable
-                        inputs={state.searchDomains}
-                        results={state.results}
-                        status={state.status}
-                        onOpenInputDomainEdit={handleInputDomainEdit}
-                        containerWidth={containerWidth}
-                      />
-                    </StackItem>
-                  </Stack>
-                </section>
-              </PageSection>
-            </DrawerContentBody>
-          </DrawerContent>
-        </Drawer>
+                      <CounterfactualCompletedMessage status={state.status} />
+                      <StackItem isFilled={true} style={{ overflow: 'hidden' }}>
+                        <CounterfactualToolbar
+                          status={state.status}
+                          goals={state.goals}
+                          onRunAnalysis={onRunAnalysis}
+                          onSetupNewAnalysis={onSetupNewAnalysis}
+                          maxRunningTimeSeconds={maxRunningTimeSeconds}
+                        />
+                        <CounterfactualTable
+                          inputs={state.searchDomains}
+                          results={state.results}
+                          status={state.status}
+                          onOpenInputDomainEdit={handleInputDomainEdit}
+                          containerWidth={containerWidth}
+                        />
+                      </StackItem>
+                    </Stack>
+                  </section>
+                </PageSection>
+              </DrawerContentBody>
+            </DrawerContent>
+          </Drawer>
+        </>
       )}
     </CFDispatch.Provider>
   );

--- a/ui-packages/packages/trusty/src/components/Organisms/CounterfactualAnalysis/tests/CounterfactualAnalysis.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/CounterfactualAnalysis/tests/CounterfactualAnalysis.test.tsx
@@ -7,7 +7,8 @@ import {
   CFExecutionStatus,
   CFGoalRole,
   ItemObject,
-  Outcome
+  Outcome,
+  RemoteDataStatus
 } from '../../../../types';
 import useCounterfactualExecution from '../useCounterfactualExecution';
 
@@ -419,6 +420,25 @@ describe('CounterfactualAnalysis', () => {
       wrapper.find('CounterfactualCompletedMessage').props()['status']
         .executionStatus
     ).toEqual(CFExecutionStatus.FAILED);
+  });
+
+  test('displays an error message when CF ajax requests fail', () => {
+    (useCounterfactualExecution as jest.Mock).mockReturnValue({
+      runCFAnalysis,
+      cfAnalysis: { status: RemoteDataStatus.FAILURE, error: 'error' },
+      cfResults: undefined
+    });
+    const wrapper = mount(
+      <CounterfactualAnalysis
+        inputs={inputs}
+        outcomes={outcomes}
+        executionId={executionId}
+        containerHeight={900}
+        containerWidth={900}
+      />
+    );
+
+    expect(wrapper.find('CounterfactualError')).toHaveLength(1);
   });
 
   test('lets the user start another analysis', () => {

--- a/ui-packages/packages/trusty/src/components/Templates/ApplicationError/ApplicationError.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/ApplicationError/ApplicationError.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStatePrimary,
+  PageSection,
+  PageSectionVariants,
+  TextContent,
+  Title
+} from '@patternfly/react-core';
+import { WarningTriangleIcon } from '@patternfly/react-icons';
+import { NavLink } from 'react-router-dom';
+
+const ApplicationError = () => {
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <TextContent>
+          <Title size="3xl" headingLevel="h2">
+            Error
+          </Title>
+        </TextContent>
+      </PageSection>
+      <PageSection isFilled={false}>
+        <EmptyState variant={'xl'}>
+          <EmptyStateIcon icon={WarningTriangleIcon} />
+          <Title size="2xl" headingLevel="h4">
+            Something went wrong
+          </Title>
+          <EmptyStatePrimary>
+            <NavLink to="/">
+              Go back to the &quot;Audit investigation&quot; home page
+            </NavLink>
+          </EmptyStatePrimary>
+        </EmptyState>
+      </PageSection>
+    </>
+  );
+};
+
+export default ApplicationError;

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/AuditDetail.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/AuditDetail.tsx
@@ -32,6 +32,7 @@ import ModelLookup from '../ModelLookup/ModelLookup';
 import Counterfactual from '../Counterfactual/Counterfactual';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import CounterfactualUnsupportedBanner from '../../Atoms/CounterfactualUnsupportedBanner/CounterfactualUnsupportedBanner';
+import NotFound from '../NotFound/NotFound';
 import './AuditDetail.scss';
 
 const AuditDetail = () => {
@@ -148,21 +149,24 @@ const AuditDetail = () => {
           </Route>
         )}
         <Route exact path={`${path}/`}>
-          {outcomes.status === RemoteDataStatus.SUCCESS &&
-            outcomes.data.length === 1 && (
-              <Redirect
-                exact
-                from={path}
-                to={`${location.pathname}/single-outcome?outcomeId=${outcomes.data[0].outcomeId}`}
-              />
-            )}
-          {outcomes.status === RemoteDataStatus.SUCCESS &&
-            outcomes.data.length > 1 && (
-              <Redirect
-                exact
-                from={path}
-                to={`${location.pathname}/outcomes`}
-              />
+          {execution.status === RemoteDataStatus.SUCCESS &&
+            outcomes.status === RemoteDataStatus.SUCCESS && (
+              <>
+                {outcomes.data.length === 1 && (
+                  <Redirect
+                    exact
+                    from={path}
+                    to={`${location.pathname}/single-outcome?outcomeId=${outcomes.data[0].outcomeId}`}
+                  />
+                )}
+                {outcomes.data.length > 1 && (
+                  <Redirect
+                    exact
+                    from={path}
+                    to={`${location.pathname}/outcomes`}
+                  />
+                )}
+              </>
             )}
           {outcomes.status === RemoteDataStatus.LOADING && (
             <PageSection>
@@ -180,6 +184,8 @@ const AuditDetail = () => {
             </PageSection>
           )}
         </Route>
+        <Route path="/not-found" component={NotFound} />
+        <Redirect to="/not-found" />
       </Switch>
     </>
   );

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/useDecisionOutcomes.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/useDecisionOutcomes.tsx
@@ -1,39 +1,22 @@
-import { useEffect, useState } from 'react';
-import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
-import { RemoteData, Outcome, RemoteDataStatus } from '../../../types';
-import { AxiosRequestConfig } from 'axios';
+import { EXECUTIONS_PATH } from '../../../utils/api/httpClient';
+import { Outcome, RemoteData, RemoteDataStatus } from '../../../types';
+import useAPI from '../../../utils/api/useAPI';
+import { useMemo } from 'react';
+import { AxiosError } from 'axios';
 
 const useDecisionOutcomes = (executionId: string) => {
-  const [outcomes, setOutcomes] = useState<RemoteData<Error, Outcome[]>>({
-    status: RemoteDataStatus.NOT_ASKED
-  });
+  const outcomes = useAPI<{ outcomes: Outcome[] }>(
+    `${EXECUTIONS_PATH}/decisions/${executionId}/outcomes`,
+    'get'
+  );
 
-  useEffect(() => {
-    let isMounted = true;
-    const config: AxiosRequestConfig = {
-      url: `${EXECUTIONS_PATH}/decisions/${executionId}/outcomes`,
-      method: 'get'
-    };
+  const onlyOutcomes: RemoteData<AxiosError, Outcome[]> = useMemo(() => {
+    return outcomes.status === RemoteDataStatus.SUCCESS
+      ? { ...outcomes, data: outcomes.data.outcomes }
+      : outcomes;
+  }, [outcomes]);
 
-    setOutcomes({ status: RemoteDataStatus.LOADING });
-    httpClient(config)
-      .then(response => {
-        if (isMounted) {
-          setOutcomes({
-            status: RemoteDataStatus.SUCCESS,
-            data: response.data.outcomes
-          });
-        }
-      })
-      .catch(error => {
-        setOutcomes({ status: RemoteDataStatus.FAILURE, error });
-      });
-    return () => {
-      isMounted = false;
-    };
-  }, [executionId]);
-
-  return outcomes;
+  return onlyOutcomes;
 };
 
 export default useDecisionOutcomes;

--- a/ui-packages/packages/trusty/src/components/Templates/AuditDetail/useExecutionInfo.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/AuditDetail/useExecutionInfo.tsx
@@ -1,38 +1,12 @@
-import { useEffect, useState } from 'react';
-import { RemoteData, Execution, RemoteDataStatus } from '../../../types';
-import { AxiosRequestConfig } from 'axios';
-import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
+import { Execution } from '../../../types';
+import { EXECUTIONS_PATH } from '../../../utils/api/httpClient';
+import useAPI from '../../../utils/api/useAPI';
 
 const useExecutionInfo = (executionId: string) => {
-  const [execution, setExecution] = useState<RemoteData<Error, Execution>>({
-    status: RemoteDataStatus.NOT_ASKED
-  });
-
-  useEffect(() => {
-    let isMounted = true;
-    const config: AxiosRequestConfig = {
-      url: `${EXECUTIONS_PATH}/decisions/${executionId}`,
-      method: 'get'
-    };
-    setExecution({ status: RemoteDataStatus.LOADING });
-    httpClient(config)
-      .then(response => {
-        if (isMounted) {
-          setExecution({
-            status: RemoteDataStatus.SUCCESS,
-            data: response.data
-          });
-        }
-      })
-      .catch(error => {
-        setExecution({ status: RemoteDataStatus.FAILURE, error });
-      });
-    return () => {
-      isMounted = false;
-    };
-  }, [executionId]);
-
-  return execution;
+  return useAPI<Execution>(
+    `${EXECUTIONS_PATH}/decisions/${executionId}`,
+    'get'
+  );
 };
 
 export default useExecutionInfo;

--- a/ui-packages/packages/trusty/src/components/Templates/InputData/useInputData.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/InputData/useInputData.tsx
@@ -1,38 +1,22 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { ItemObject, RemoteData, RemoteDataStatus } from '../../../types';
-import { AxiosRequestConfig } from 'axios';
-import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
+import { AxiosError } from 'axios';
+import { EXECUTIONS_PATH } from '../../../utils/api/httpClient';
+import useAPI from '../../../utils/api/useAPI';
 
 const useInputData = (executionId: string) => {
-  const [inputData, setInputData] = useState<RemoteData<Error, ItemObject[]>>({
-    status: RemoteDataStatus.NOT_ASKED
-  });
+  const inputData = useAPI<{ inputs: ItemObject[] }>(
+    `${EXECUTIONS_PATH}/decisions/${executionId}/structuredInputs`,
+    'get'
+  );
 
-  useEffect(() => {
-    let isMounted = true;
-    const config: AxiosRequestConfig = {
-      url: `${EXECUTIONS_PATH}/decisions/${executionId}/structuredInputs`,
-      method: 'get'
-    };
-    setInputData({ status: RemoteDataStatus.LOADING });
-    httpClient(config)
-      .then(response => {
-        if (isMounted) {
-          setInputData({
-            status: RemoteDataStatus.SUCCESS,
-            data: response.data.inputs
-          });
-        }
-      })
-      .catch(error => {
-        setInputData({ status: RemoteDataStatus.FAILURE, error });
-      });
-    return () => {
-      isMounted = false;
-    };
-  }, [executionId]);
+  const onlyInputs: RemoteData<AxiosError, ItemObject[]> = useMemo(() => {
+    return inputData.status === RemoteDataStatus.SUCCESS
+      ? { ...inputData, data: inputData.data.inputs }
+      : inputData;
+  }, [inputData]);
 
-  return inputData;
+  return onlyInputs;
 };
 
 export default useInputData;

--- a/ui-packages/packages/trusty/src/components/Templates/ModelLookup/useModelData.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/ModelLookup/useModelData.tsx
@@ -1,38 +1,9 @@
-import { useEffect, useState } from 'react';
-import { ModelData, RemoteData, RemoteDataStatus } from '../../../types';
-import { AxiosRequestConfig } from 'axios';
-import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
+import { ModelData } from '../../../types';
+import { EXECUTIONS_PATH } from '../../../utils/api/httpClient';
+import useAPI from '../../../utils/api/useAPI';
 
 const useModelData = (executionId: string) => {
-  const [modelData, setModelData] = useState<RemoteData<Error, ModelData>>({
-    status: RemoteDataStatus.NOT_ASKED
-  });
-
-  useEffect(() => {
-    let isMounted = true;
-    const config: AxiosRequestConfig = {
-      url: `${EXECUTIONS_PATH}/${executionId}/model`,
-      method: 'get'
-    };
-    setModelData({ status: RemoteDataStatus.LOADING });
-    httpClient(config)
-      .then(response => {
-        if (isMounted) {
-          setModelData({
-            status: RemoteDataStatus.SUCCESS,
-            data: response.data
-          });
-        }
-      })
-      .catch(error => {
-        setModelData({ status: RemoteDataStatus.FAILURE, error });
-      });
-    return () => {
-      isMounted = false;
-    };
-  }, [executionId]);
-
-  return modelData;
+  return useAPI<ModelData>(`${EXECUTIONS_PATH}/${executionId}/model`, 'get');
 };
 
 export default useModelData;

--- a/ui-packages/packages/trusty/src/components/Templates/NotFound/NotFound.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/NotFound/NotFound.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStatePrimary,
+  PageSection,
+  PageSectionVariants,
+  TextContent,
+  Title
+} from '@patternfly/react-core';
+import { WarningTriangleIcon } from '@patternfly/react-icons';
+import { NavLink } from 'react-router-dom';
+
+const NotFound = () => {
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <TextContent>
+          <Title size="3xl" headingLevel="h2">
+            Not Found
+          </Title>
+        </TextContent>
+      </PageSection>
+      <PageSection isFilled={true}>
+        <EmptyState variant={'xl'}>
+          <EmptyStateIcon icon={WarningTriangleIcon} />
+          <Title size="2xl" headingLevel="h4">
+            The page you are looking for does not exist
+          </Title>
+          <EmptyStatePrimary>
+            <NavLink to="/">
+              Go back to the &quot;Audit investigation&quot; home page
+            </NavLink>
+          </EmptyStatePrimary>
+        </EmptyState>
+      </PageSection>
+    </>
+  );
+};
+
+export default NotFound;

--- a/ui-packages/packages/trusty/src/components/Templates/NotFound/tests/NotFound.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/NotFound/tests/NotFound.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import NotFound from '../NotFound';
+
+describe('NotFound', () => {
+  test('renders correctly', () => {
+    const wrapper = shallow(<NotFound />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/ui-packages/packages/trusty/src/components/Templates/NotFound/tests/__snapshots__/NotFound.test.tsx.snap
+++ b/ui-packages/packages/trusty/src/components/Templates/NotFound/tests/__snapshots__/NotFound.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotFound renders correctly 1`] = `
+<Fragment>
+  <PageSection
+    variant="light"
+  >
+    <TextContent>
+      <Title
+        headingLevel="h2"
+        size="3xl"
+      >
+        Not Found
+      </Title>
+    </TextContent>
+  </PageSection>
+  <PageSection
+    isFilled={true}
+  >
+    <EmptyState
+      variant="xl"
+    >
+      <EmptyStateIcon
+        icon={[Function]}
+      />
+      <Title
+        headingLevel="h4"
+        size="2xl"
+      >
+        The page you are looking for does not exist
+      </Title>
+      <EmptyStatePrimary>
+        <NavLink
+          to="/"
+        >
+          Go back to the "Audit investigation" home page
+        </NavLink>
+      </EmptyStatePrimary>
+    </EmptyState>
+  </PageSection>
+</Fragment>
+`;

--- a/ui-packages/packages/trusty/src/components/Templates/OutcomeDetails/useSaliencies.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/OutcomeDetails/useSaliencies.tsx
@@ -1,39 +1,13 @@
-import { useEffect, useState } from 'react';
-import { RemoteData, RemoteDataStatus, Saliencies } from '../../../types';
-import { AxiosRequestConfig } from 'axios';
-import { EXECUTIONS_PATH, httpClient } from '../../../utils/api/httpClient';
+import { Saliencies } from '../../../types';
+
+import { EXECUTIONS_PATH } from '../../../utils/api/httpClient';
+import useAPI from '../../../utils/api/useAPI';
 
 const useSaliencies = (executionId: string) => {
-  const [saliencies, setSaliencies] = useState<RemoteData<Error, Saliencies>>({
-    status: RemoteDataStatus.NOT_ASKED
-  });
-
-  useEffect(() => {
-    let isMounted = true;
-    const config: AxiosRequestConfig = {
-      url: `${EXECUTIONS_PATH}/decisions/${executionId}/explanations/saliencies`,
-      method: 'get'
-    };
-
-    setSaliencies({ status: RemoteDataStatus.LOADING });
-    httpClient(config)
-      .then(response => {
-        if (isMounted) {
-          setSaliencies({
-            status: RemoteDataStatus.SUCCESS,
-            data: response.data
-          });
-        }
-      })
-      .catch(error => {
-        setSaliencies({ status: RemoteDataStatus.FAILURE, error });
-      });
-    return () => {
-      isMounted = false;
-    };
-  }, [executionId]);
-
-  return saliencies;
+  return useAPI<Saliencies>(
+    `${EXECUTIONS_PATH}/decisions/${executionId}/explanations/saliencies`,
+    'get'
+  );
 };
 
 export default useSaliencies;

--- a/ui-packages/packages/trusty/src/components/Templates/TrustyApp/TrustyApp.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/TrustyApp/TrustyApp.tsx
@@ -22,8 +22,10 @@ import kogitoLogo from '../../../../static/images/kogitoLogo.svg';
 import AuditDetail from '../AuditDetail/AuditDetail';
 import imgAvatar from '../../../../static/images/user.svg';
 import Breadcrumbs from '../../Organisms/Breadcrumbs/Breadcrumbs';
-import './TrustyApp.scss';
+import NotFound from '../NotFound/NotFound';
+import ApplicationError from '../ApplicationError/ApplicationError';
 import { TrustyContextValue } from '../../../types';
+import './TrustyApp.scss';
 
 type TrustyAppProps = {
   explanationEnabled: boolean;
@@ -112,6 +114,11 @@ const TrustyApp = (props: TrustyAppProps) => {
           <Route path="/audit/:executionType/:executionId">
             <AuditDetail />
           </Route>
+          <Route exact path="/error">
+            <ApplicationError />
+          </Route>
+          <Route path="/not-found" component={NotFound} />
+          <Redirect to="/not-found" />
         </Switch>
       </Page>
     </TrustyContext.Provider>

--- a/ui-packages/packages/trusty/src/components/Templates/TrustyApp/tests/TrustyApp.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Templates/TrustyApp/tests/TrustyApp.test.tsx
@@ -1,0 +1,23 @@
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router';
+import * as React from 'react';
+import TrustyApp from '../TrustyApp';
+
+describe('TrustyApp', () => {
+  test('renders the not found page when a path is not matched', () => {
+    const wrapper = mount(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/some-non-existent-page',
+            key: 'some-none-existent-page'
+          }
+        ]}
+      >
+        <TrustyApp explanationEnabled={true} />
+      </MemoryRouter>
+    );
+
+    expect(wrapper.find('NotFound')).toHaveLength(1);
+  });
+});

--- a/ui-packages/packages/trusty/src/utils/api/tests/useAPI.test.ts
+++ b/ui-packages/packages/trusty/src/utils/api/tests/useAPI.test.ts
@@ -1,0 +1,42 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-test-renderer';
+import * as api from '../httpClient';
+import useAPI from '../useAPI';
+import { RemoteDataStatus } from '../../../types';
+import ReactRouterDom from 'react-router-dom';
+
+const flushPromises = () => new Promise(setImmediate);
+const apiMock = jest.spyOn(api, 'httpClient');
+const historyMock = {
+  push: jest.fn(),
+  replace: jest.fn()
+};
+
+jest.mock('react-router-dom', () => ({
+  ...(jest.requireActual('react-router-dom') as typeof ReactRouterDom),
+  useHistory: jest.fn(() => historyMock)
+}));
+
+describe('useAPI', () => {
+  test('redirects to the error page when a request fails', async () => {
+    apiMock.mockImplementation(() => Promise.reject('error'));
+
+    const { result } = renderHook(() => {
+      return useAPI('url', 'get');
+    });
+
+    expect(result.current).toStrictEqual({ status: RemoteDataStatus.LOADING });
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(result.current).toStrictEqual({
+      status: RemoteDataStatus.FAILURE,
+      error: 'error'
+    });
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(historyMock.replace).toHaveBeenCalledTimes(1);
+    expect(historyMock.replace).toBeCalledWith('/error');
+  });
+});

--- a/ui-packages/packages/trusty/src/utils/api/useAPI.ts
+++ b/ui-packages/packages/trusty/src/utils/api/useAPI.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { AxiosError, AxiosRequestConfig } from 'axios';
+import { RemoteData, RemoteDataStatus } from '../../types';
+import { httpClient } from './httpClient';
+import { useHistory } from 'react-router-dom';
+
+const useAPI = <T>(
+  url: string,
+  method: AxiosRequestConfig['method']
+): RemoteData<AxiosError, T> => {
+  const [data, setData] = useState<RemoteData<AxiosError, T>>({
+    status: RemoteDataStatus.NOT_ASKED
+  });
+  const history = useHistory();
+
+  useEffect(() => {
+    let isMounted = true;
+    if (url && method) {
+      const config: AxiosRequestConfig = {
+        url,
+        method
+      };
+
+      setData({ status: RemoteDataStatus.LOADING });
+      httpClient(config)
+        .then(response => {
+          if (isMounted) {
+            setData({
+              status: RemoteDataStatus.SUCCESS,
+              data: response.data
+            });
+          }
+        })
+        .catch(error => {
+          setData({ status: RemoteDataStatus.FAILURE, error });
+          history.replace('/error');
+        });
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [url, method, history]);
+
+  return data;
+};
+
+export default useAPI;


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/FAI-623

I've added a `not-found` page for not recognized paths.
I've added a generic error page to be displayed when ajax requests fail.
The various custom hooks like `useExecutionInfo`, `useDecisionOutcomes` etc. are now using a common `useAPI` hook to do the ajax work. The latter is responsible for redirecting in case of error.
The only two places where this doesn't happen are the audit overview and the counterfactual page. They have some specific logic and they handle errors differently (in-page message and error dialog).

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
