### PR TITLE
FAI-639: CF boolean input constraints limitations

### DIFF
--- a/ui-packages/packages/trusty/src/components/Organisms/CounterfactualAnalysis/tests/__snapshots__/CounterfactualAnalysis.test.tsx.snap
+++ b/ui-packages/packages/trusty/src/components/Organisms/CounterfactualAnalysis/tests/__snapshots__/CounterfactualAnalysis.test.tsx.snap
@@ -1891,6 +1891,7 @@ exports[`CounterfactualAnalysis renders correctly 1`] = `
                                                                       data-label="Constraint"
                                                                     >
                                                                       <ConstraintCell
+                                                                        isInputConstraintSupported={[Function]}
                                                                         isInputSelectionEnabled={true}
                                                                         isInputTypeSupported={[Function]}
                                                                         onEditConstraint={[Function]}
@@ -2113,6 +2114,7 @@ exports[`CounterfactualAnalysis renders correctly 1`] = `
                                                                       data-label="Constraint"
                                                                     >
                                                                       <ConstraintCell
+                                                                        isInputConstraintSupported={[Function]}
                                                                         isInputSelectionEnabled={true}
                                                                         isInputTypeSupported={[Function]}
                                                                         onEditConstraint={[Function]}

--- a/ui-packages/packages/trusty/src/components/Organisms/CounterfactualTable/CounterfactualTable.tsx
+++ b/ui-packages/packages/trusty/src/components/Organisms/CounterfactualTable/CounterfactualTable.tsx
@@ -42,7 +42,10 @@ import {
 import { CFDispatch } from '../CounterfactualAnalysis/CounterfactualAnalysis';
 import FormattedValue from '../../Atoms/FormattedValue/FormattedValue';
 import './CounterfactualTable.scss';
-import { isInputTypeSupported } from '../../Templates/Counterfactual/counterfactualReducer';
+import {
+  isInputConstraintSupported,
+  isInputTypeSupported
+} from '../../Templates/Counterfactual/counterfactualReducer';
 
 type CounterfactualTableProps = {
   inputs: CFSearchInput[];
@@ -397,6 +400,9 @@ const CounterfactualTable = (props: CounterfactualTableProps) => {
                               rowIndex={rowIndex}
                               isInputSelectionEnabled={isInputSelectionEnabled}
                               isInputTypeSupported={isInputTypeSupported}
+                              isInputConstraintSupported={
+                                isInputConstraintSupported
+                              }
                               onEditConstraint={onOpenInputDomainEdit}
                             />
                           </Td>
@@ -486,6 +492,7 @@ type ConstraintCellProps = {
   rowIndex: number;
   isInputSelectionEnabled: boolean;
   isInputTypeSupported: (input: CFSearchInput) => boolean;
+  isInputConstraintSupported: (input: CFSearchInput) => boolean;
   onEditConstraint: (row: CFSearchInput, rowIndex: number) => void;
 };
 
@@ -495,11 +502,14 @@ const ConstraintCell = (props: ConstraintCellProps) => {
     rowIndex,
     isInputSelectionEnabled,
     isInputTypeSupported,
+    isInputConstraintSupported,
     onEditConstraint
   } = props;
 
   const isTypeSupported = isInputTypeSupported(row);
-  const isConstraintEditEnabled = isInputSelectionEnabled && isTypeSupported;
+  const isConstraintSupported = isInputConstraintSupported(row);
+  const isConstraintEditEnabled =
+    isInputSelectionEnabled && isConstraintSupported;
 
   return (
     <>

--- a/ui-packages/packages/trusty/src/components/Templates/Counterfactual/counterfactualReducer.ts
+++ b/ui-packages/packages/trusty/src/components/Templates/Counterfactual/counterfactualReducer.ts
@@ -248,6 +248,20 @@ export const isInputTypeSupported = (searchInput: CFSearchInput): boolean => {
   return false;
 };
 
+export const isInputConstraintSupported = (
+  searchInput: CFSearchInput
+): boolean => {
+  //Structures, Collections and Strings are not supported. Constraints selection
+  //not allowed for Booleans.
+  if (searchInput.kind === 'UNIT') {
+    switch (typeof searchInput.value) {
+      case 'number':
+        return true;
+    }
+  }
+  return false;
+};
+
 export const isOutcomeTypeSupported = (outcome: Outcome): boolean => {
   //Structures and Collections are not supported
   if (outcome.outcomeResult.kind === 'UNIT') {


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/FAI-639

It should not be possible to set up constraints for boolean search inputs.
So we have to differentiate between inputs that can be selected and inputs that support constraints.

Before this PR the constraint button was visible (but disabled) for boolean inputs. Then it disappeared after selecting the row.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
