### PR TITLE
FAI-646: CF UI - Highlighted results columns transparent background

### DIFF
--- a/ui-packages/packages/trusty/src/components/Organisms/CounterfactualTable/CounterfactualTable.scss
+++ b/ui-packages/packages/trusty/src/components/Organisms/CounterfactualTable/CounterfactualTable.scss
@@ -208,6 +208,6 @@
     background-color: rgba(115, 188, 247, 1);
   }
   to {
-    background-color: rgba(115, 188, 247, 0);
+    background-color: rgba(255, 255, 255, 1);
   }
 }


### PR DESCRIPTION
See: https://issues.redhat.com/browse/FAI-646

The background color animation to highlight new results columns is ending with a transparent background. When scrolling the table down, the scrolled content will be visible behind the table heading.

With this PR I've changed the ending background color to a full white.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
