### PR TITLE
FAI-611: Trusty UI: Toolbars weird extra spacing after PF update

### DIFF
--- a/ui-packages/packages/trusty/src/components/Templates/TrustyApp/TrustyApp.scss
+++ b/ui-packages/packages/trusty/src/components/Templates/TrustyApp/TrustyApp.scss
@@ -1,3 +1,12 @@
 .trusty-logo {
   width: 158px;
 }
+
+/*
+  Fixing weird toolbar extra spacing introduced after updating to PF 2021.08 (see FAI-611)
+  The issue is not present in more recent versions of PF.
+  To be removed after the next PF update on kogito-apps.
+ */
+.pf-c-toolbar__content[hidden] {
+  display: none;
+}


### PR DESCRIPTION
See: https://issues.redhat.com/browse/FAI-611

The main reason behind this PR was increasing the vertical space available to the Counterfactual Table. Given the extra padding problem is caused by PF I decided to fix it globally instead of only addressing it inside CF. It's affecting also the Toolbar's in the audit overiew.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
