### PR TITLE
FAI-659: Rename MatrixUtils to MatrixUtilsExtensions

### DIFF
--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/shap/ShapConfig.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/local/shap/ShapConfig.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ForkJoinPool;
 
 import org.kie.kogito.explainability.model.PerturbationContext;
 import org.kie.kogito.explainability.model.PredictionInput;
-import org.kie.kogito.explainability.utils.MatrixUtils;
+import org.kie.kogito.explainability.utils.MatrixUtilsExtensions;
 
 public class ShapConfig {
     public enum LinkType {
@@ -59,7 +59,7 @@ public class ShapConfig {
     protected ShapConfig(LinkType link, List<PredictionInput> background, PerturbationContext pc, Executor executor, Integer nSamples, double confidence) {
         this.link = link;
         this.background = background;
-        this.backgroundMatrix = MatrixUtils.matrixFromPredictionInput(background);
+        this.backgroundMatrix = MatrixUtilsExtensions.matrixFromPredictionInput(background);
         this.pc = pc;
         this.executor = executor;
         this.nSamples = nSamples;

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/MatrixUtilsExtensions.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/MatrixUtilsExtensions.java
@@ -24,13 +24,13 @@ import java.util.Random;
 import org.kie.kogito.explainability.model.PredictionInput;
 import org.kie.kogito.explainability.model.PredictionOutput;
 
-public class MatrixUtils {
+public class MatrixUtilsExtensions {
     public enum Axis {
         ROW,
         COLUMN
     }
 
-    private MatrixUtils() {
+    private MatrixUtilsExtensions() {
         throw new IllegalStateException("Utility class");
     }
 
@@ -42,7 +42,7 @@ public class MatrixUtils {
      * @return double[][] array, the converted matrix
      */
     public static double[][] matrixFromPredictionInput(PredictionInput p) {
-        return MatrixUtils.rowVector(p.getFeatures().stream()
+        return MatrixUtilsExtensions.rowVector(p.getFeatures().stream()
                 .mapToDouble(f -> f.getValue().asNumber())
                 .toArray());
     }
@@ -68,7 +68,7 @@ public class MatrixUtils {
      * @return double[][] array, the converted matrix
      */
     public static double[][] matrixFromPredictionOutput(PredictionOutput p) {
-        return MatrixUtils.rowVector(p.getOutputs().stream()
+        return MatrixUtilsExtensions.rowVector(p.getOutputs().stream()
                 .mapToDouble(f -> f.getValue().asNumber())
                 .toArray());
     }
@@ -134,7 +134,7 @@ public class MatrixUtils {
      * @return vector, the ith column of x
      */
     public static double[] getCol(double[][] x, int i) {
-        int cols = MatrixUtils.getShape(x)[1];
+        int cols = MatrixUtilsExtensions.getShape(x)[1];
         if (cols <= i || i < 0) {
             throw new IllegalArgumentException(
                     String.format("Column index %d too large, matrix only has %d column(s)", i, cols));
@@ -156,7 +156,7 @@ public class MatrixUtils {
             throw new IllegalArgumentException("Empty column idxs passed to getCols");
         }
 
-        int[] shape = MatrixUtils.getShape(x);
+        int[] shape = MatrixUtilsExtensions.getShape(x);
         double[][] out = new double[shape[0]][idxs.size()];
 
         for (int i = 0; i < shape[0]; i++) {
@@ -180,8 +180,8 @@ public class MatrixUtils {
      * @return the element-wise sum of a and b
      */
     public static double[][] matrixSum(double[][] a, double[][] b) {
-        int[] aShape = MatrixUtils.getShape(a);
-        int[] bShape = MatrixUtils.getShape(b);
+        int[] aShape = MatrixUtilsExtensions.getShape(a);
+        int[] bShape = MatrixUtilsExtensions.getShape(b);
 
         if (!Arrays.equals(aShape, bShape)) {
             throw new IllegalArgumentException("Shape of matrix A must shape of matrix B" +
@@ -206,12 +206,12 @@ public class MatrixUtils {
      * @return the result from adding b from every row of a
      */
     public static double[][] matrixRowSum(double[][] a, double[] b) {
-        int[] aShape = MatrixUtils.getShape(a);
-        double[][] bMat = MatrixUtils.rowVector(b);
+        int[] aShape = MatrixUtilsExtensions.getShape(a);
+        double[][] bMat = MatrixUtilsExtensions.rowVector(b);
         double[][] out = new double[aShape[0]][aShape[1]];
 
         for (int i = 0; i < aShape[0]; i++) {
-            out[i] = MatrixUtils.matrixSum(MatrixUtils.rowVector(a[i]), bMat)[0];
+            out[i] = MatrixUtilsExtensions.matrixSum(MatrixUtilsExtensions.rowVector(a[i]), bMat)[0];
         }
         return out;
     }
@@ -224,7 +224,7 @@ public class MatrixUtils {
      * @return the element-wise matrix difference of a and b
      */
     public static double[][] matrixDifference(double[][] a, double[][] b) {
-        double[][] bNeg = MatrixUtils.matrixMultiply(b, -1.);
+        double[][] bNeg = MatrixUtilsExtensions.matrixMultiply(b, -1.);
         return matrixSum(a, bNeg);
     }
 
@@ -248,8 +248,8 @@ public class MatrixUtils {
      * @return the matrix product of a and b
      */
     public static double[][] matrixMultiply(double[][] a, double[][] b) {
-        int[] aShape = MatrixUtils.getShape(a);
-        int[] bShape = MatrixUtils.getShape(b);
+        int[] aShape = MatrixUtilsExtensions.getShape(a);
+        int[] bShape = MatrixUtilsExtensions.getShape(b);
 
         if (aShape[1] != bShape[0]) {
             throw new IllegalArgumentException("# columns of matrix A must match # rows of matrix B" +
@@ -276,7 +276,7 @@ public class MatrixUtils {
      * @return the matrix product of a and the scalar b
      */
     public static double[][] matrixMultiply(double[][] a, double b) {
-        int[] aShape = MatrixUtils.getShape(a);
+        int[] aShape = MatrixUtilsExtensions.getShape(a);
 
         double[][] product = new double[aShape[0]][aShape[1]];
         for (int i = 0; i < aShape[0]; i++) {
@@ -296,17 +296,17 @@ public class MatrixUtils {
      * @return the result of the sum along that dimension
      */
     public static double[] sum(double[][] x, Axis axis) {
-        int[] shape = MatrixUtils.getShape(x);
-        if (axis == MatrixUtils.Axis.ROW) {
+        int[] shape = MatrixUtilsExtensions.getShape(x);
+        if (axis == MatrixUtilsExtensions.Axis.ROW) {
             double[][] out = new double[1][shape[1]];
             for (int i = 0; i < shape[0]; i++) {
-                out = MatrixUtils.matrixSum(out, MatrixUtils.rowVector(x[i]));
+                out = MatrixUtilsExtensions.matrixSum(out, MatrixUtilsExtensions.rowVector(x[i]));
             }
             return out[0];
         } else {
             double[][] out = new double[1][shape[0]];
             for (int i = 0; i < shape[1]; i++) {
-                out = MatrixUtils.matrixSum(out, MatrixUtils.rowVector(MatrixUtils.getCol(x, i)));
+                out = MatrixUtilsExtensions.matrixSum(out, MatrixUtilsExtensions.rowVector(MatrixUtilsExtensions.getCol(x, i)));
             }
             return out[0];
         }
@@ -319,7 +319,7 @@ public class MatrixUtils {
      * @return the transpose of x
      */
     public static double[][] transpose(double[][] x) {
-        int[] shape = MatrixUtils.getShape(x);
+        int[] shape = MatrixUtilsExtensions.getShape(x);
 
         double[][] transposed = new double[shape[1]][shape[0]];
         for (int i = 0; i < shape[0]; i++) {
@@ -341,7 +341,7 @@ public class MatrixUtils {
     private static int findPivot(double[][] x, boolean[] pivotsUsed) {
         double maxAbs = 0;
         int pivot = 0;
-        int size = MatrixUtils.getShape(x)[0];
+        int size = MatrixUtilsExtensions.getShape(x)[0];
         for (int diagIdx = 0; diagIdx < size; diagIdx++) {
             double abs = Math.abs(x[diagIdx][diagIdx]);
             if (abs > maxAbs && !pivotsUsed[diagIdx]) {
@@ -362,7 +362,7 @@ public class MatrixUtils {
      *         https://www.researchgate.net/publication/271296470_In-Place_Matrix_Inversion_by_Modified_Gauss-Jordan_Algorithm
      */
     private static double[][] invertSquareMatrix(double[][] x, double zeroThreshold) {
-        int size = MatrixUtils.getShape(x)[0];
+        int size = MatrixUtilsExtensions.getShape(x)[0];
         double[][] copy = new double[size][size];
         for (int i = 0; i < size; i++) {
             copy[i] = Arrays.copyOf(x[i], size);
@@ -379,7 +379,7 @@ public class MatrixUtils {
             // find the pivot
             // the pivot idx is the idx of the diagonal element with largest absolute value
             // that hasn't already been used as a pivot
-            int pivot = MatrixUtils.findPivot(copy, pivotsUsed);
+            int pivot = MatrixUtilsExtensions.findPivot(copy, pivotsUsed);
             double pivotVal = copy[pivot][pivot];
 
             // check if pivotVal is 0, allowing for some floating point error
@@ -428,12 +428,12 @@ public class MatrixUtils {
         double[][] xInv;
         for (int jitterTries = 0; jitterTries < numRetries; jitterTries++) {
             try {
-                xInv = MatrixUtils.invertSquareMatrix(x, zeroThreshold);
+                xInv = MatrixUtilsExtensions.invertSquareMatrix(x, zeroThreshold);
                 return xInv;
             } catch (ArithmeticException e) {
                 // if the inversion is unsuccessful, we can try slightly jittering the matrix.
                 // this will reduce the accuracy of the inversion marginally, but ensures that we get results
-                MatrixUtils.jitterMatrix(x, 1e-8, random);
+                MatrixUtilsExtensions.jitterMatrix(x, 1e-8, random);
             }
         }
 

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/WeightedLinearRegression.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/WeightedLinearRegression.java
@@ -88,7 +88,7 @@ public class WeightedLinearRegression {
 
         //invert the coefficient matrix
         try {
-            x = MatrixUtils.jitterInvert(x, 10, 1e-9, random);
+            x = MatrixUtilsExtensions.jitterInvert(x, 10, 1e-9, random);
         } catch (ArithmeticException e) {
             throw new ArithmeticException(
                     "Weighted Linear Regression: Matrix cannot be inverted! " +
@@ -99,7 +99,7 @@ public class WeightedLinearRegression {
         }
 
         // recover the coefficients by multiplying the inverse coefficient matrix by B
-        double[][] coefficients = MatrixUtils.matrixMultiply(x, b);
+        double[][] coefficients = MatrixUtilsExtensions.matrixMultiply(x, b);
         double mse = WeightedLinearRegression
                 .getMSE(adjustedFeatures, observations, sampleWeights, coefficients);
 
@@ -215,7 +215,7 @@ public class WeightedLinearRegression {
         if (dof <= 0) {
             return IntStream.range(0, nfeatures).mapToDouble(x -> Double.POSITIVE_INFINITY).toArray();
         }
-        double[] coefs = MatrixUtils.getCol(coefficients, 0);
+        double[] coefs = MatrixUtilsExtensions.getCol(coefficients, 0);
         double[] tvalues = IntStream.range(0, coefficientError.length)
                 .mapToDouble(i -> coefs[i] / coefficientError[i]).toArray();
         TDistribution tdist = new TDistribution(dof);

--- a/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/WeightedLinearRegressionResults.java
+++ b/explainability/explainability-core/src/main/java/org/kie/kogito/explainability/utils/WeightedLinearRegressionResults.java
@@ -45,13 +45,13 @@ public class WeightedLinearRegressionResults {
             double[] stdErrors, double[] pvalues) {
         //if intercept is true
         if (intercept) {
-            double[] rawCoeffs = MatrixUtils.getCol(coefficients, 0);
+            double[] rawCoeffs = MatrixUtilsExtensions.getCol(coefficients, 0);
             this.coefficients = java.util.Arrays
                     .stream(rawCoeffs, 0, rawCoeffs.length - 1)
                     .toArray();
             this.intercept = rawCoeffs[rawCoeffs.length - 1];
         } else {
-            this.coefficients = MatrixUtils.getCol(coefficients, 0);
+            this.coefficients = MatrixUtilsExtensions.getCol(coefficients, 0);
             this.intercept = 0.0;
         }
 

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/shap/ShapConfigTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/shap/ShapConfigTest.java
@@ -28,7 +28,7 @@ import org.kie.kogito.explainability.model.Feature;
 import org.kie.kogito.explainability.model.FeatureFactory;
 import org.kie.kogito.explainability.model.PerturbationContext;
 import org.kie.kogito.explainability.model.PredictionInput;
-import org.kie.kogito.explainability.utils.MatrixUtils;
+import org.kie.kogito.explainability.utils.MatrixUtilsExtensions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -44,7 +44,7 @@ class ShapConfigTest {
     PredictionInput pi = new PredictionInput(fs);
     List<PredictionInput> pis = Arrays.asList(pi, pi);
     List<PredictionInput> piEmpty = new ArrayList<>();
-    double[][] piMatrix = MatrixUtils.matrixFromPredictionInput(pis);
+    double[][] piMatrix = MatrixUtilsExtensions.matrixFromPredictionInput(pis);
 
     // Test that everything recovers as expected
     @Test

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/shap/ShapKernelExplainerTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/local/shap/ShapKernelExplainerTest.java
@@ -41,7 +41,7 @@ import org.kie.kogito.explainability.model.PredictionOutput;
 import org.kie.kogito.explainability.model.PredictionProvider;
 import org.kie.kogito.explainability.model.Saliency;
 import org.kie.kogito.explainability.model.SimplePrediction;
-import org.kie.kogito.explainability.utils.MatrixUtils;
+import org.kie.kogito.explainability.utils.MatrixUtilsExtensions;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -135,7 +135,7 @@ class ShapKernelExplainerTest {
     // create a list of prediction inputs from double matrix
     private List<PredictionInput> createPIFromMatrix(double[][] m) {
         List<PredictionInput> pis = new ArrayList<>();
-        int[] shape = MatrixUtils.getShape(m);
+        int[] shape = MatrixUtilsExtensions.getShape(m);
         for (int i = 0; i < shape[0]; i++) {
             List<Feature> fs = new ArrayList<>();
             for (int j = 0; j < shape[1]; j++) {
@@ -506,7 +506,7 @@ class ShapKernelExplainerTest {
 
                 double[][] confidence = explanationsAndConfs[1];
 
-                int[] shape = MatrixUtils.getShape(confidence);
+                int[] shape = MatrixUtilsExtensions.getShape(confidence);
                 for (int i = 0; i < shape[0]; i++) {
                     for (int j = 0; j < shape[1]; j++) {
                         double conf = confidence[i][j];

--- a/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MatrixUtilsExtensionsTest.java
+++ b/explainability/explainability-core/src/test/java/org/kie/kogito/explainability/utils/MatrixUtilsExtensionsTest.java
@@ -24,7 +24,7 @@ import org.kie.kogito.explainability.model.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class MatrixUtilsTest {
+class MatrixUtilsExtensionsTest {
     // === Make some matrices to use in tests ===
     double[][] matOneElem = {
             { 5. },
@@ -134,7 +134,7 @@ class MatrixUtilsTest {
             fs.add(FeatureFactory.newNumericalFeature("f", mat3X5[0][j]));
         }
         PredictionInput pi = new PredictionInput(fs);
-        double[][] converted = MatrixUtils.matrixFromPredictionInput(pi);
+        double[][] converted = MatrixUtilsExtensions.matrixFromPredictionInput(pi);
         assertArrayEquals(mat3X5[0], converted[0]);
     }
 
@@ -151,7 +151,7 @@ class MatrixUtilsTest {
             ps.add(new PredictionInput(fs));
         }
 
-        double[][] converted = MatrixUtils.matrixFromPredictionInput(ps);
+        double[][] converted = MatrixUtilsExtensions.matrixFromPredictionInput(ps);
         assertArrayEquals(mat3X5, converted);
     }
 
@@ -166,7 +166,7 @@ class MatrixUtilsTest {
             ;
         }
         PredictionOutput po = new PredictionOutput(os);
-        double[][] converted = MatrixUtils.matrixFromPredictionOutput(po);
+        double[][] converted = MatrixUtilsExtensions.matrixFromPredictionOutput(po);
         assertArrayEquals(mat3X5[0], converted[0]);
     }
 
@@ -184,14 +184,14 @@ class MatrixUtilsTest {
             ps.add(new PredictionOutput(os));
         }
 
-        double[][] converted = MatrixUtils.matrixFromPredictionOutput(ps);
+        double[][] converted = MatrixUtilsExtensions.matrixFromPredictionOutput(ps);
         assertArrayEquals(mat3X5, converted);
     }
 
     // test creation of row matrix from 1-D array
     @Test
     void testRowVectorCreation() {
-        double[][] converted = MatrixUtils.rowVector(vector);
+        double[][] converted = MatrixUtilsExtensions.rowVector(vector);
         for (int i = 0; i < converted.length; i++) {
             assertEquals(converted[0][i], vector[i]);
         }
@@ -200,7 +200,7 @@ class MatrixUtilsTest {
     // test creation of column matrix from 1-D array
     @Test
     void testColVectorCreation() {
-        double[][] converted = MatrixUtils.columnVector(vector);
+        double[][] converted = MatrixUtilsExtensions.columnVector(vector);
         for (int i = 0; i < converted.length; i++) {
             assertEquals(converted[i][0], vector[i]);
         }
@@ -209,7 +209,7 @@ class MatrixUtilsTest {
     // === Shape Tests ===
     @Test
     void testShape() {
-        int[] shape = MatrixUtils.getShape(mat3X5);
+        int[] shape = MatrixUtilsExtensions.getShape(mat3X5);
         assertArrayEquals(new int[] { 3, 5 }, shape);
     }
 
@@ -218,26 +218,26 @@ class MatrixUtilsTest {
     // test if indexing by too big of column throws an error
     @Test
     void testGetColTooBig() {
-        assertThrows(IllegalArgumentException.class, () -> MatrixUtils.getCol(mat3X4, 10));
+        assertThrows(IllegalArgumentException.class, () -> MatrixUtilsExtensions.getCol(mat3X4, 10));
     }
 
     // test if indexing a negative column throws an error
     @Test
     void testGetNegCol() {
-        assertThrows(IllegalArgumentException.class, () -> MatrixUtils.getCol(mat3X4, -10));
+        assertThrows(IllegalArgumentException.class, () -> MatrixUtilsExtensions.getCol(mat3X4, -10));
     }
 
     // test single column indexing
     @Test
     void testGetCol() {
-        double[] col = MatrixUtils.getCol(mat3X4, 1);
+        double[] col = MatrixUtilsExtensions.getCol(mat3X4, 1);
         assertArrayEquals(col, new double[] { 10., 5., -3. });
     }
 
     // test multi column indexing
     @Test
     void testGetCols() {
-        double[][] output = MatrixUtils.getCols(mat3X5, List.of(0, 1, 3));
+        double[][] output = MatrixUtilsExtensions.getCols(mat3X5, List.of(0, 1, 3));
         for (int i = 0; i < mat3X5get013.length; i++) {
             assertArrayEquals(mat3X5get013[i], output[i]);
         }
@@ -246,7 +246,7 @@ class MatrixUtilsTest {
     // test extracting multiple dup columns by indexing
     @Test
     void testGetDupCols() {
-        double[][] output = MatrixUtils.getCols(mat3X5, List.of(0, 3, 1, 3, 0));
+        double[][] output = MatrixUtilsExtensions.getCols(mat3X5, List.of(0, 3, 1, 3, 0));
         for (int i = 0; i < mat3X5get03130.length; i++) {
             assertArrayEquals(mat3X5get03130[i], output[i]);
         }
@@ -256,28 +256,28 @@ class MatrixUtilsTest {
     @Test
     void testGetColsTooBig() {
         List<Integer> testIdxs = List.of(0, 6);
-        assertThrows(IllegalArgumentException.class, () -> MatrixUtils.getCols(mat3X5, testIdxs));
+        assertThrows(IllegalArgumentException.class, () -> MatrixUtilsExtensions.getCols(mat3X5, testIdxs));
     }
 
     // test that extracting negative columns throws error
     @Test
     void testGetNegCols() {
         List<Integer> testIdxs = List.of(0, -6);
-        assertThrows(IllegalArgumentException.class, () -> MatrixUtils.getCols(mat3X5, testIdxs));
+        assertThrows(IllegalArgumentException.class, () -> MatrixUtilsExtensions.getCols(mat3X5, testIdxs));
     }
 
     // test that extracting no columns throws error
     @Test
     void testGetNoCols() {
         List<Integer> testIdxs = List.of();
-        assertThrows(IllegalArgumentException.class, () -> MatrixUtils.getCols(mat3X5, testIdxs));
+        assertThrows(IllegalArgumentException.class, () -> MatrixUtilsExtensions.getCols(mat3X5, testIdxs));
     }
 
     // === Transpose Tests ===
     // test transpose a 1x1 mat
     @Test
     void testOneElemTranspose() {
-        double[][] matOneElemTranspose = MatrixUtils.transpose(matOneElem);
+        double[][] matOneElemTranspose = MatrixUtilsExtensions.transpose(matOneElem);
         for (int i = 0; i < matOneElemTranspose.length; i++) {
             assertArrayEquals(matOneElemTranspose[i], matOneElem[i]);
         }
@@ -286,7 +286,7 @@ class MatrixUtilsTest {
     // test transpose a row vector into column
     @Test
     void testVectorTranspose() {
-        double[][] matRowVectorTranspose = MatrixUtils.transpose(matRowVector);
+        double[][] matRowVectorTranspose = MatrixUtilsExtensions.transpose(matRowVector);
         for (int i = 0; i < matRowVectorTranspose.length; i++) {
             assertArrayEquals(matRowVectorTranspose[i], matColVector[i]);
         }
@@ -295,7 +295,7 @@ class MatrixUtilsTest {
     // test transpose a 3x4 matrix
     @Test
     void testMatrixTranspose() {
-        double[][] mat3X4Transpose = MatrixUtils.transpose(mat3X4);
+        double[][] mat3X4Transpose = MatrixUtilsExtensions.transpose(mat3X4);
         for (int i = 0; i < mat3X4Transpose.length; i++) {
             assertArrayEquals(mat3X4Transpose[i], mat4X3[i]);
         }
@@ -305,21 +305,21 @@ class MatrixUtilsTest {
     // test that summing all the rows of matrix returns expected result
     @Test
     void testIntraSumRow() {
-        double[] sum = MatrixUtils.sum(matSquareSingular, MatrixUtils.Axis.ROW);
+        double[] sum = MatrixUtilsExtensions.sum(matSquareSingular, MatrixUtilsExtensions.Axis.ROW);
         assertArrayEquals(mssSumRow, sum, 1e-6);
     }
 
     // test that summing all the cols of matrix returns expected result
     @Test
     void testIntraSumCol() {
-        double[] sum = MatrixUtils.sum(matSquareSingular, MatrixUtils.Axis.COLUMN);
+        double[] sum = MatrixUtilsExtensions.sum(matSquareSingular, MatrixUtilsExtensions.Axis.COLUMN);
         assertArrayEquals(mssSumCol, sum, 1e-6);
     }
 
     // test that summing two matrices returns expected result
     @Test
     void testMatSum() {
-        double[][] sum = MatrixUtils.matrixSum(matSquareSingular, identity);
+        double[][] sum = MatrixUtilsExtensions.matrixSum(matSquareSingular, identity);
         for (int i = 0; i < sum.length; i++) {
             assertArrayEquals(mssPlusIdentity[i], sum[i], 1e-6);
         }
@@ -329,13 +329,13 @@ class MatrixUtilsTest {
     @Test
     void testMatSumWrongSizes() {
         assertThrows(IllegalArgumentException.class,
-                () -> MatrixUtils.matrixSum(matSquareSingular, mat4X3));
+                () -> MatrixUtilsExtensions.matrixSum(matSquareSingular, mat4X3));
     }
 
     // test that difference of two matrices returns expected result
     @Test
     void testMatDiff() {
-        double[][] diff = MatrixUtils.matrixDifference(matSquareSingular, identity);
+        double[][] diff = MatrixUtilsExtensions.matrixDifference(matSquareSingular, identity);
         for (int i = 0; i < diff.length; i++) {
             assertArrayEquals(mssMinusIdentity[i], diff[i], 1e-6);
         }
@@ -344,7 +344,7 @@ class MatrixUtilsTest {
     // test adding a vector to each row of a matrix
     @Test
     void testMatRowSum() {
-        double[][] sum = MatrixUtils.matrixRowSum(identity, vector);
+        double[][] sum = MatrixUtilsExtensions.matrixRowSum(identity, vector);
         for (int i = 0; i < sum.length; i++) {
             assertArrayEquals(matIdentityPlusVector[i], sum[i], 1e-6);
         }
@@ -353,7 +353,7 @@ class MatrixUtilsTest {
     // test subtracting a vector to each row of a matrix
     @Test
     void testMatRowDiff() {
-        double[][] diff = MatrixUtils.matrixRowDifference(matIdentityPlusVector, vector);
+        double[][] diff = MatrixUtilsExtensions.matrixRowDifference(matIdentityPlusVector, vector);
         for (int i = 0; i < diff.length; i++) {
             assertArrayEquals(identity[i], diff[i], 1e-6);
         }
@@ -363,7 +363,7 @@ class MatrixUtilsTest {
     // test multiplying a matrix by a scalar
     @Test
     void testMatMulScalar() {
-        double[][] prod = MatrixUtils.matrixMultiply(mat4X3, 3.0);
+        double[][] prod = MatrixUtilsExtensions.matrixMultiply(mat4X3, 3.0);
         for (int i = 0; i < prod.length; i++) {
             for (int j = 0; j < prod[0].length; j++) {
                 assertEquals(mat4X3[i][j] * 3.0, prod[i][j], 1e-6);
@@ -374,7 +374,7 @@ class MatrixUtilsTest {
     // test multiplying a matrix by zero
     @Test
     void testMatMulByZero() {
-        double[][] prod = MatrixUtils.matrixMultiply(mat4X3, 0.0);
+        double[][] prod = MatrixUtilsExtensions.matrixMultiply(mat4X3, 0.0);
         for (int i = 0; i < prod.length; i++) {
             for (int j = 0; j < prod[0].length; j++) {
                 assertEquals(mat4X3[i][j] * 0.0, prod[i][j], 1e-6);
@@ -385,7 +385,7 @@ class MatrixUtilsTest {
     // test multiplying a matrix by another matrix
     @Test
     void testMatMulNormal() {
-        double[][] prod = MatrixUtils.matrixMultiply(mat4X3, mat3X5);
+        double[][] prod = MatrixUtilsExtensions.matrixMultiply(mat4X3, mat3X5);
         for (int i = 0; i < prod.length; i++) {
             assertArrayEquals(mat43X35Product[i], prod[i], 1e-6);
         }
@@ -395,14 +395,14 @@ class MatrixUtilsTest {
     @Test
     void testMatMulWrongShape() {
         assertThrows(IllegalArgumentException.class,
-                () -> MatrixUtils.matrixMultiply(mat3X4, mat3X5));
+                () -> MatrixUtilsExtensions.matrixMultiply(mat3X4, mat3X5));
 
     }
 
     // test multiplying a row matrix by a col matrix
     @Test
     void testVectorRowColMultiply() {
-        double[][] prod = MatrixUtils.matrixMultiply(matRowVector, matColVector);
+        double[][] prod = MatrixUtilsExtensions.matrixMultiply(matRowVector, matColVector);
         for (int i = 0; i < prod.length; i++) {
             assertArrayEquals(vectorProdRowCol[i], prod[i], 1e-6);
         }
@@ -411,7 +411,7 @@ class MatrixUtilsTest {
     // test multiplying a col matrix by a row matrix
     @Test
     void testVectorColRowMultiply() {
-        double[][] prod = MatrixUtils.matrixMultiply(matColVector, matRowVector);
+        double[][] prod = MatrixUtilsExtensions.matrixMultiply(matColVector, matRowVector);
         for (int i = 0; i < prod.length; i++) {
             assertArrayEquals(vectorProdColRow[i], prod[i], 1e-6);
         }
@@ -421,7 +421,7 @@ class MatrixUtilsTest {
     // test inverting a non singular square matrix
     @Test
     void testInvertNormal() {
-        double[][] inv = MatrixUtils.jitterInvert(matSquareNonSingular, 1, 1e-9, rn);
+        double[][] inv = MatrixUtilsExtensions.jitterInvert(matSquareNonSingular, 1, 1e-9, rn);
         for (int i = 0; i < inv.length; i++) {
             assertArrayEquals(matSNSInv[i], inv[i], 1e-4);
         }
@@ -430,7 +430,7 @@ class MatrixUtilsTest {
     @Test
     // test inverting a singular square matrix
     void testInvertSingular() {
-        assertThrows(ArithmeticException.class, () -> MatrixUtils.jitterInvert(matSquareSingular, 1, 1e-9, rn));
+        assertThrows(ArithmeticException.class, () -> MatrixUtilsExtensions.jitterInvert(matSquareSingular, 1, 1e-9, rn));
     }
 
     // === Jitter Invert Tests ===
@@ -438,11 +438,11 @@ class MatrixUtilsTest {
     void testJitterInvert() {
         // since there's some randomness in jitter invert, let's make sure it's stable
         for (int run = 0; run < 100; run++) {
-            double[][] inv = MatrixUtils.jitterInvert(matSquareSingular, 10, 1e-9, rn);
+            double[][] inv = MatrixUtilsExtensions.jitterInvert(matSquareSingular, 10, 1e-9, rn);
 
             // since the output of jitterInvert is non-deterministic for singular matrices, check to make sure
             // key properties of the inverse matrix hold true; namely M*M_inv = Identity
-            double[][] prod = MatrixUtils.matrixMultiply(matSquareSingular, inv);
+            double[][] prod = MatrixUtilsExtensions.matrixMultiply(matSquareSingular, inv);
             for (int i = 0; i < prod.length; i++) {
                 assertArrayEquals(prod[i], identity[i], 1e-4);
             }
@@ -453,11 +453,11 @@ class MatrixUtilsTest {
     void testSecureJitterInvert() {
         // since there's some randomness in jitter invert, let's make sure it's stable
         for (int run = 0; run < 100; run++) {
-            double[][] inv = MatrixUtils.jitterInvert(matSquareSingular, 10, 1e-9);
+            double[][] inv = MatrixUtilsExtensions.jitterInvert(matSquareSingular, 10, 1e-9);
 
             // since the output of jitterInvert is non-deterministic for singular matrices, check to make sure
             // key properties of the inverse matrix hold true; namely M*M_inv = Identity
-            double[][] prod = MatrixUtils.matrixMultiply(matSquareSingular, inv);
+            double[][] prod = MatrixUtilsExtensions.matrixMultiply(matSquareSingular, inv);
             for (int i = 0; i < prod.length; i++) {
                 assertArrayEquals(prod[i], identity[i], 1e-4);
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/FAI-659 

To avoid a naming conflict with org.apache.commons.math3.linear.MatrixUtils and prepare for future migration of SHAP linear algebra to that package, rename the existing explainabilty class "MatrixUtils" to "MatrixUtilsExtensions".


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
