### PR TITLE
FAI-674: Counterfactual outcome selection decimal errors

### DIFF
--- a/ui-packages/packages/trusty/src/components/Molecules/CounterfactualOutcomeEdit/CounterfactualOutcomeEdit.tsx
+++ b/ui-packages/packages/trusty/src/components/Molecules/CounterfactualOutcomeEdit/CounterfactualOutcomeEdit.tsx
@@ -130,6 +130,8 @@ const CounterfactualOutcomeNumber = (props: CounterfactualOutcomeEditProps) => {
   const { goal, index, onUpdateGoal } = props;
   const [numberValue, setNumberValue] = useState<number>();
 
+  const decimalPlaces = goal.value.value.toString().split('.')[1]?.length || 0;
+
   const touchSpinWidth = useMemo(() => String(goal.value).length + 2, [
     goal.value
   ]);
@@ -142,7 +144,7 @@ const CounterfactualOutcomeNumber = (props: CounterfactualOutcomeEditProps) => {
       ...goal,
       value: {
         ...(goal.value as ItemObjectUnit),
-        value: (goal.value.value as number) - 1
+        value: Number(((goal.value.value as number) - 1).toFixed(decimalPlaces))
       }
     });
   };
@@ -168,7 +170,7 @@ const CounterfactualOutcomeNumber = (props: CounterfactualOutcomeEditProps) => {
       ...goal,
       value: {
         ...(goal.value as ItemObjectUnit),
-        value: (goal.value.value as number) + 1
+        value: Number(((goal.value.value as number) + 1).toFixed(decimalPlaces))
       }
     });
   };

--- a/ui-packages/packages/trusty/src/components/Molecules/CounterfactualOutcomeEdit/tests/CounterfactualOutcomeEdit.test.tsx
+++ b/ui-packages/packages/trusty/src/components/Molecules/CounterfactualOutcomeEdit/tests/CounterfactualOutcomeEdit.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { CFGoal, CFGoalRole } from '../../../../types';
+import CounterfactualOutcomeEdit from '../CounterfactualOutcomeEdit';
+
+const onUpdateGoal = jest.fn();
+
+describe('CounterfactualOutcomeEdit', () => {
+  test('renders an number input for numerical goals', () => {
+    const wrapper = mount(
+      <CounterfactualOutcomeEdit
+        goal={goals[0]}
+        index={0}
+        onUpdateGoal={onUpdateGoal}
+      />
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  test('updates a goal value using the minus stepper button', () => {
+    const wrapper = mount(
+      <CounterfactualOutcomeEdit
+        goal={goals[0]}
+        index={0}
+        onUpdateGoal={onUpdateGoal}
+      />
+    );
+
+    wrapper
+      .find('CounterfactualOutcomeEdit ButtonBase [aria-label="minus"]')
+      .simulate('click');
+
+    expect(onUpdateGoal).toBeCalledWith({
+      ...goals[0],
+      value: {
+        ...goals[0].value,
+        value: 0.65
+      }
+    });
+  });
+  test('updates a goal value using the plus stepper button', () => {
+    const wrapper = mount(
+      <CounterfactualOutcomeEdit
+        goal={goals[1]}
+        index={1}
+        onUpdateGoal={onUpdateGoal}
+      />
+    );
+
+    wrapper
+      .find('CounterfactualOutcomeEdit ButtonBase [aria-label="plus"]')
+      .simulate('click');
+
+    expect(onUpdateGoal).toBeCalledWith({
+      ...goals[1],
+      value: {
+        ...goals[1].value,
+        value: 2.03
+      }
+    });
+  });
+  test('updates a goal with an integer value', () => {
+    const wrapper = mount(
+      <CounterfactualOutcomeEdit
+        goal={goals[2]}
+        index={2}
+        onUpdateGoal={onUpdateGoal}
+      />
+    );
+
+    wrapper
+      .find('CounterfactualOutcomeEdit ButtonBase [aria-label="plus"]')
+      .simulate('click');
+
+    expect(onUpdateGoal).toBeCalledWith({
+      ...goals[2],
+      value: {
+        ...goals[2].value,
+        value: 6
+      }
+    });
+  });
+});
+
+const goals: CFGoal[] = [
+  {
+    id: 'goal1',
+    name: 'field1',
+    role: CFGoalRole.ORIGINAL,
+    value: {
+      kind: 'UNIT',
+      type: 'number',
+      value: 1.65
+    },
+    originalValue: {
+      kind: 'UNIT',
+      type: 'number',
+      value: 1.65
+    }
+  },
+  {
+    id: 'goal1',
+    name: 'field1',
+    role: CFGoalRole.ORIGINAL,
+    value: {
+      kind: 'UNIT',
+      type: 'number',
+      value: 1.03
+    },
+    originalValue: {
+      kind: 'UNIT',
+      type: 'number',
+      value: 1.03
+    }
+  },
+  {
+    id: 'goal3',
+    name: 'field3',
+    role: CFGoalRole.ORIGINAL,
+    value: {
+      kind: 'UNIT',
+      type: 'number',
+      value: 5
+    },
+    originalValue: {
+      kind: 'UNIT',
+      type: 'number',
+      value: 5
+    }
+  }
+];

--- a/ui-packages/packages/trusty/src/components/Molecules/CounterfactualOutcomeEdit/tests/__snapshots__/CounterfactualOutcomeEdit.test.tsx.snap
+++ b/ui-packages/packages/trusty/src/components/Molecules/CounterfactualOutcomeEdit/tests/__snapshots__/CounterfactualOutcomeEdit.test.tsx.snap
@@ -1,0 +1,281 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CounterfactualOutcomeEdit renders an number input for numerical goals 1`] = `
+<CounterfactualOutcomeEdit
+  goal={
+    Object {
+      "id": "goal1",
+      "name": "field1",
+      "originalValue": Object {
+        "kind": "UNIT",
+        "type": "number",
+        "value": 1.65,
+      },
+      "role": 1,
+      "value": Object {
+        "kind": "UNIT",
+        "type": "number",
+        "value": 1.65,
+      },
+    }
+  }
+  index={0}
+  onUpdateGoal={[MockFunction]}
+>
+  <FormGroup
+    fieldId="goal1"
+    label="field1"
+  >
+    <div
+      className="pf-c-form__group"
+    >
+      <div
+        className="pf-c-form__group-label"
+      >
+        <label
+          className="pf-c-form__label"
+          htmlFor="goal1"
+        >
+          <span
+            className="pf-c-form__label-text"
+          >
+            field1
+          </span>
+        </label>
+         
+      </div>
+      <div
+        className="pf-c-form__group-control"
+      >
+        <CounterfactualOutcomeNumber
+          goal={
+            Object {
+              "id": "goal1",
+              "name": "field1",
+              "originalValue": Object {
+                "kind": "UNIT",
+                "type": "number",
+                "value": 1.65,
+              },
+              "role": 1,
+              "value": Object {
+                "kind": "UNIT",
+                "type": "number",
+                "value": 1.65,
+              },
+            }
+          }
+          index={0}
+          onUpdateGoal={[MockFunction]}
+        >
+          <NumberInput
+            id="goal-0-field1"
+            inputAriaLabel="\`\${outcome.outcomeName} input\`"
+            inputName="goal-0-field1"
+            isDisabled={false}
+            minusBtnAriaLabel="minus"
+            onChange={[Function]}
+            onMinus={[Function]}
+            onPlus={[Function]}
+            plusBtnAriaLabel="plus"
+            value={1.65}
+            widthChars={17}
+          >
+            <div
+              className="pf-c-number-input"
+              id="goal-0-field1"
+              style={
+                Object {
+                  "--pf-c-number-input--c-form-control--width-chars": 17,
+                }
+              }
+            >
+              <div
+                className="pf-c-input-group"
+              >
+                <Button
+                  aria-label="minus"
+                  isDisabled={false}
+                  onClick={[Function]}
+                  variant="control"
+                >
+                  <ButtonBase
+                    aria-label="minus"
+                    innerRef={null}
+                    isDisabled={false}
+                    onClick={[Function]}
+                    variant="control"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-label="minus"
+                      className="pf-c-button pf-m-control"
+                      data-ouia-component-id="OUIA-Generated-Button-control-1"
+                      data-ouia-component-type="PF4/Button"
+                      data-ouia-safe={true}
+                      disabled={false}
+                      onClick={[Function]}
+                      role={null}
+                      type="button"
+                    >
+                      <span
+                        className="pf-c-number-input__icon"
+                      >
+                        <MinusIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 448 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M416 208H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h384c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                            />
+                          </svg>
+                        </MinusIcon>
+                      </span>
+                    </button>
+                  </ButtonBase>
+                </Button>
+                <input
+                  aria-label="\`\${outcome.outcomeName} input\`"
+                  className="pf-c-form-control"
+                  name="goal-0-field1"
+                  onChange={[Function]}
+                  type="number"
+                  value={1.65}
+                />
+                <Button
+                  aria-label="plus"
+                  isDisabled={false}
+                  onClick={[Function]}
+                  variant="control"
+                >
+                  <ButtonBase
+                    aria-label="plus"
+                    innerRef={null}
+                    isDisabled={false}
+                    onClick={[Function]}
+                    variant="control"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-label="plus"
+                      className="pf-c-button pf-m-control"
+                      data-ouia-component-id="OUIA-Generated-Button-control-2"
+                      data-ouia-component-type="PF4/Button"
+                      data-ouia-safe={true}
+                      disabled={false}
+                      onClick={[Function]}
+                      role={null}
+                      type="button"
+                    >
+                      <span
+                        className="pf-c-number-input__icon"
+                      >
+                        <PlusIcon
+                          aria-hidden="true"
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
+                              }
+                            }
+                            viewBox="0 0 448 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                            />
+                          </svg>
+                        </PlusIcon>
+                      </span>
+                    </button>
+                  </ButtonBase>
+                </Button>
+              </div>
+            </div>
+          </NumberInput>
+        </CounterfactualOutcomeNumber>
+      </div>
+    </div>
+  </FormGroup>
+  <Checkbox
+    className="counterfactual-outcome__floating"
+    id="goal1"
+    isChecked={false}
+    isDisabled={false}
+    isValid={true}
+    label={
+      <TextContent>
+        <Text
+          component="small"
+        >
+          Automatically adjust for counterfactual.
+        </Text>
+      </TextContent>
+    }
+    onChange={[Function]}
+  >
+    <div
+      className="pf-c-check counterfactual-outcome__floating"
+    >
+      <input
+        aria-invalid={false}
+        checked={false}
+        className="pf-c-check__input"
+        disabled={false}
+        id="goal1"
+        onChange={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="pf-c-check__label"
+        htmlFor="goal1"
+      >
+        <TextContent>
+          <div
+            className="pf-c-content"
+          >
+            <Text
+              component="small"
+            >
+              <small
+                className=""
+                data-ouia-component-id="OUIA-Generated-Text-1"
+                data-ouia-component-type="PF4/Text"
+                data-ouia-safe={true}
+                data-pf-content={true}
+              >
+                Automatically adjust for counterfactual.
+              </small>
+            </Text>
+          </div>
+        </TextContent>
+      </label>
+    </div>
+  </Checkbox>
+</CounterfactualOutcomeEdit>
+`;


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/FAI-674

This PR fixes the rounding problem that appears on the Counterfactual outcome selection when changing the value of a numerical outcome using the `+` or `-` buttons.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
