### PR TITLE
KOGITO-6349: Fix DataIndex config in runtime-tools-quarkus-dev-ui

### DIFF
--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/java/org/kie/kogito/runtime/tools/quarkus/extension/deployment/DevConsoleBuildTimeConfig.java
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/java/org/kie/kogito/runtime/tools/quarkus/extension/deployment/DevConsoleBuildTimeConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.runtime.tools.quarkus.extension.deployment;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "kogito", prefix = "", phase = ConfigPhase.BUILD_TIME)
+public class DevConsoleBuildTimeConfig {
+
+    /**
+     * Configuration for Runtime Tools DevConsole services. It should keep data-index url to initialize DataIndexClient accordingly
+     */
+    @ConfigItem(name = "data-index.url", defaultValue = "http://localhost:8180")
+    public String dataIndexUrl;
+}

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/java/org/kie/kogito/runtime/tools/quarkus/extension/deployment/DevConsoleProcessor.java
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/java/org/kie/kogito/runtime/tools/quarkus/extension/deployment/DevConsoleProcessor.java
@@ -38,9 +38,11 @@ import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
 import io.quarkus.vertx.http.runtime.devmode.DevConsoleRecorder;
 
+import static org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient.DATA_INDEX_CONFIG_KEY;
+
 public class DevConsoleProcessor {
 
-    private static final String DATA_INDEX_CLIENT_KEY = "quarkus.rest-client.\"org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient\".url";
+    private static final String DATA_INDEX_CLIENT_KEY = "quarkus.rest-client.\"" + DATA_INDEX_CONFIG_KEY + "\".url";
     private static final String STATIC_RESOURCES_PATH = "dev-static/";
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/java/org/kie/kogito/runtime/tools/quarkus/extension/deployment/DevConsoleProcessor.java
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/java/org/kie/kogito/runtime/tools/quarkus/extension/deployment/DevConsoleProcessor.java
@@ -29,6 +29,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.builditem.ShutdownContextBuildItem;
+import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.util.WebJarUtil;
 import io.quarkus.devconsole.spi.DevConsoleRouteBuildItem;
@@ -39,12 +40,21 @@ import io.quarkus.vertx.http.runtime.devmode.DevConsoleRecorder;
 
 public class DevConsoleProcessor {
 
-    private static String STATIC_RESOURCES_PATH = "dev-static/";
+    private static final String DATA_INDEX_CLIENT_KEY = "quarkus.rest-client.\"org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient\".url";
+    private static final String STATIC_RESOURCES_PATH = "dev-static/";
 
     @BuildStep(onlyIf = IsDevelopment.class)
     public DevConsoleRuntimeTemplateInfoBuildItem collectUsersInfo() {
         return new DevConsoleRuntimeTemplateInfoBuildItem("userInfo",
                 new UserInfoSupplier());
+    }
+
+    @BuildStep(onlyIf = IsDevelopment.class)
+    public void setUpDataIndexServiceURL(
+            final DevConsoleBuildTimeConfig config,
+            final BuildProducer<SystemPropertyBuildItem> systemProperties) throws IOException {
+
+        systemProperties.produce(new SystemPropertyBuildItem(DATA_INDEX_CLIENT_KEY, config.dataIndexUrl));
     }
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/resources/dev-templates/forms.html
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/resources/dev-templates/forms.html
@@ -34,7 +34,7 @@
       const devUI = RuntimeToolsDevUI.open({
           container: document.getElementById("envelope-app"),
           users: {info:userInfo.arrayRepresentation.raw},
-          dataIndexUrl: "{config:property('org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient/mp-rest/url')}/graphql",
+          dataIndexUrl: "{config:property('kogito.data-index.url')}/graphql",
           page: "Forms"
       })
   </script>

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/resources/dev-templates/jobs.html
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/resources/dev-templates/jobs.html
@@ -34,7 +34,7 @@ height: calc(100vh - 98px);
     const devUI = RuntimeToolsDevUI.open({
         container: document.getElementById("envelope-app"),
         users: {info:userInfo.arrayRepresentation.raw},
-        dataIndexUrl: "{config:property('org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient/mp-rest/url')}/graphql",
+        dataIndexUrl: "{config:property('kogito.data-index.url')}/graphql",
         page: "JobsManagement"
     })
 </script>

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/resources/dev-templates/processInstances.html
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/resources/dev-templates/processInstances.html
@@ -17,12 +17,12 @@
 {#include main fluid=true}
 {#style}
 .main-container {
-margin: 0;
-padding: 0;
+    margin: 0;
+    padding: 0;
 }
 #envelope-app {
-width: 100vw;
-height: calc(100vh - 98px);
+    width: 100vw;
+    height: calc(100vh - 98px);
 }
 {/style}
 {#title}Runtime UI{/title}
@@ -34,7 +34,7 @@ height: calc(100vh - 98px);
     const devUI = RuntimeToolsDevUI.open({
         container: document.getElementById("envelope-app"),
         users: {info:userInfo.arrayRepresentation.raw},
-        dataIndexUrl: "{config:property('org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient/mp-rest/url')}/graphql",
+        dataIndexUrl: "{config:property('kogito.data-index.url')}/graphql",
         page: "ProcessInstances"
     })
 </script>

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/resources/dev-templates/tasks.html
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension-deployment/src/main/resources/dev-templates/tasks.html
@@ -34,7 +34,7 @@ height: calc(100vh - 98px);
     const devUI = RuntimeToolsDevUI.open({
         container: document.getElementById("envelope-app"),
         users: {info:userInfo.arrayRepresentation.raw},
-        dataIndexUrl: "{config:property('org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient/mp-rest/url')}/graphql",
+        dataIndexUrl: "{config:property('kogito.data-index.url')}/graphql",
         page: "TaskInbox"
     })
 </script>

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension/src/main/java/org/kie/kogito/runtime/tools/quarkus/extension/runtime/dataindex/DataIndexClient.java
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension/src/main/java/org/kie/kogito/runtime/tools/quarkus/extension/runtime/dataindex/DataIndexClient.java
@@ -24,10 +24,14 @@ import javax.ws.rs.core.MediaType;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
+import static org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient.DATA_INDEX_CONFIG_KEY;
+
 @Path("/graphql")
-@RegisterRestClient
+@RegisterRestClient(configKey = DATA_INDEX_CONFIG_KEY)
 @ApplicationScoped
 public interface DataIndexClient {
+
+    String DATA_INDEX_CONFIG_KEY = "kogito.data-index.url";
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension/src/main/resources/application.properties
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension/src/main/resources/application.properties
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.kie.kogito.runtime.tools.quarkus.extension.runtime.dataindex.DataIndexClient/mp-rest/url=http://localhost:8180
-quarkus.arc.remove-unused-beans=false
 quarkus.kogito-runtime-tools.users=admin,user
 quarkus.kogito-runtime-tools.users.admin.groups=admin
 quarkus.kogito-runtime-tools.users.user.groups=user


### PR DESCRIPTION
Looks like in the last update the way rest-clients are configured has changed. It is affecting our `DataIndexClient` which was using an old-fashioned property in `application.properties` file

This PR tries to unify the config of the data-index url by using the same `kogito.data-index.url` system property that is being used in other extensions.

- First it tweaks the existing `DevConsoleProcessor` to get the value from the `kogito.data-index.url` system property and configure the `DataIndexClient` accordingly.
- Secondly it also modifies qute templates to use that  `kogito.data-index.url` system property instead of the old one.

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/kiegroup/kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>Pull Request</b>  
  Please add comment: <b>Jenkins retest this</b>
 
* <b>Quarkus LTS checks</b>  
  Please add comment: <b>Jenkins run LTS</b>

* <b>Native checks</b>  
  Please add comment: <b>Jenkins run native</b>

</details>
