### PR TITLE
[DROOLS-6730] move drools-static from kogito to drools

### DIFF
--- a/explainability/explainability-integrationtests/explainability-integrationtests-pmml/pom.xml
+++ b/explainability/explainability-integrationtests/explainability-integrationtests-pmml/pom.xml
@@ -49,15 +49,15 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.kie.kogito</groupId>
-          <artifactId>drools-core-static</artifactId>
+          <groupId>org.drools</groupId>
+          <artifactId>drools-wiring-static</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
 
     <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>drools-core-dynamic</artifactId>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-wiring-dynamic</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6730

Related PRs:
https://github.com/kiegroup/drools/pull/4052
https://github.com/kiegroup/kogito-runtimes/pull/1763
https://github.com/kiegroup/optaplanner/pull/1700
https://github.com/kiegroup/kogito-apps/pull/1138