### PR TITLE
PLANNER-2598 Add dependency and fix deprecated API 

### DIFF
--- a/task-assigning/task-assigning-core/src/main/java/org/kie/kogito/taskassigning/core/model/solver/DefaultTaskAssigningConstraints.java
+++ b/task-assigning/task-assigning-core/src/main/java/org/kie/kogito/taskassigning/core/model/solver/DefaultTaskAssigningConstraints.java
@@ -33,25 +33,25 @@ public class DefaultTaskAssigningConstraints {
     }
 
     public static Constraint requiredPotentialOwner(ConstraintFactory constraintFactory, Score<?> constraintWeight) {
-        return constraintFactory.from(TaskAssignment.class)
+        return constraintFactory.forEach(TaskAssignment.class)
                 .filter(taskAssignment -> !TaskAssigningConditions.userMeetsPotentialOwnerOrPlanningUserCondition(taskAssignment.getTask(), taskAssignment.getUser()))
                 .penalize("Required Potential Owner", constraintWeight);
     }
 
     public static Constraint requiredSkills(ConstraintFactory constraintFactory, Score<?> constraintWeight) {
-        return constraintFactory.from(TaskAssignment.class)
+        return constraintFactory.forEach(TaskAssignment.class)
                 .filter(taskAssignment -> !TaskAssigningConditions.userMeetsRequiredSkillsOrPlanningUserCondition(taskAssignment.getTask(), taskAssignment.getUser()))
                 .penalize("Required Skills", constraintWeight);
     }
 
     public static Constraint planningUserAssignment(ConstraintFactory constraintFactory, Score<?> constraintWeight) {
-        return constraintFactory.from(TaskAssignment.class)
+        return constraintFactory.forEach(TaskAssignment.class)
                 .filter(taskAssignment -> ModelConstants.IS_PLANNING_USER.test(taskAssignment.getUser().getId()))
                 .penalize("PlanningUser assignment", constraintWeight);
     }
 
     public static Constraint highLevelPriority(ConstraintFactory constraintFactory, Score<?> constraintWeight) {
-        return constraintFactory.from(TaskAssignment.class)
+        return constraintFactory.forEach(TaskAssignment.class)
                 .filter(taskAssignment -> PriorityHelper.isHighLevel(taskAssignment.getTask().getPriority()))
                 .penalize("High level priority",
                         constraintWeight,
@@ -59,7 +59,7 @@ public class DefaultTaskAssigningConstraints {
     }
 
     public static Constraint desiredAffinities(ConstraintFactory constraintFactory, Score<?> constraintWeight) {
-        return constraintFactory.from(TaskAssignment.class)
+        return constraintFactory.forEach(TaskAssignment.class)
                 .filter(taskAssignment -> taskAssignment.getUser().isEnabled())
                 .reward("Desired Affinities",
                         constraintWeight,
@@ -67,7 +67,7 @@ public class DefaultTaskAssigningConstraints {
     }
 
     public static Constraint minimizeMakespan(ConstraintFactory constraintFactory, Score<?> constraintWeight) {
-        return constraintFactory.from(TaskAssignment.class)
+        return constraintFactory.forEach(TaskAssignment.class)
                 .filter(taskAssignment -> taskAssignment.getNextElement() == null)
                 .penalize("Minimize makespan",
                         constraintWeight,
@@ -75,7 +75,7 @@ public class DefaultTaskAssigningConstraints {
     }
 
     public static Constraint mediumLevelPriority(ConstraintFactory constraintFactory, Score<?> constraintWeight) {
-        return constraintFactory.from(TaskAssignment.class)
+        return constraintFactory.forEach(TaskAssignment.class)
                 .filter(taskAssignment -> PriorityHelper.isMediumLevel(taskAssignment.getTask().getPriority()))
                 .penalize("Medium level priority",
                         constraintWeight,
@@ -83,7 +83,7 @@ public class DefaultTaskAssigningConstraints {
     }
 
     public static Constraint lowLevelPriority(ConstraintFactory constraintFactory, Score<?> constraintWeight) {
-        return constraintFactory.from(TaskAssignment.class)
+        return constraintFactory.forEach(TaskAssignment.class)
                 .filter(taskAssignment -> PriorityHelper.isLowLevel(taskAssignment.getTask().getPriority()))
                 .penalize("Low level priority",
                         constraintWeight,

--- a/task-assigning/task-assigning-service/pom.xml
+++ b/task-assigning/task-assigning-service/pom.xml
@@ -82,6 +82,10 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>task-assigning-user-service-properties</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
     <!-- Build container image -->
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Upstream changes have removed some dependencies, and apparently commons-lang is no longer on the classpath transitively. This PR adds an explicit dependency.

Also, I am fixing use of deprecated OptaPlanner APIs.