### PR TITLE
KOGITO-6682 Force maven version to 3.8.1+

### DIFF
--- a/ui-packages/packages/trusty/it-tests/README.md
+++ b/ui-packages/packages/trusty/it-tests/README.md
@@ -29,7 +29,7 @@ This is e2e test suite. Each test communicates with UI of Trusty AI as real user
 
 - docker version >= 19.03.12
 - java version >= 11
-- maven version >= 3.6.3
+- maven version >= 3.8.1
 - docker-compose version >= 1.25.2
 
 Note: also previous versions of `docker` and `docker-compose` might work, but they were not tested.


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-6682

Related PRs:
- https://github.com/kiegroup/drools/pull/4174
- https://github.com/kiegroup/kogito-runtimes/pull/1962
- https://github.com/kiegroup/optaplanner/pull/1820
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/647
- https://github.com/kiegroup/optaplanner-quickstarts/pull/277
- https://github.com/kiegroup/kogito-apps/pull/1227
- https://github.com/kiegroup/kogito-examples/pull/1109