### PR TITLE
FAI-732: E2E test Audit UI - "Traffic Violation open Audit Details – …

### DIFF
--- a/ui-packages/packages/trusty/cypress/e2e/TrafficViolation.ts
+++ b/ui-packages/packages/trusty/cypress/e2e/TrafficViolation.ts
@@ -46,7 +46,6 @@ describe('Traffic Violation', () => {
 
   it('open Audit Details', () => {
     cy.visit('/');
-    cy.ouiaId('refresh-button').click();
     cy.ouiaId(reqId, 'PF4/TableRow', {timeout: 15000}).within(() => {
       cy.ouiaId('status', 'execution-status').should('have.text', 'Completed');
       cy.ouiaId('show-detail', 'link').click();


### PR DESCRIPTION
…open Audit Details" failed in the kogito-apps-deploy job

Based on screenshot, the page contains a filter with wrong date. I have removed the click on the refresh button to not apply any suggested filter.

JIRA: https://issues.redhat.com/browse/FAI-732
![image](https://user-images.githubusercontent.com/1536609/158561840-a5c0ff60-2dd3-432f-9e7b-0b1deb74db3f.png)
