### PR TITLE
FAI-732: E2E test Audit UI - "Traffic Violation open Audit Details – …

### DIFF
--- a/ui-packages/packages/trusty/cypress/e2e/TrafficViolation.ts
+++ b/ui-packages/packages/trusty/cypress/e2e/TrafficViolation.ts
@@ -45,6 +45,8 @@ describe('Traffic Violation', () => {
   });
 
   it('open Audit Details', () => {
+    const plus3DaysShift = new Date().getTime() + 3*60*60*24*1000; 
+    cy.clock(plus3DaysShift);
     cy.visit('/');
     cy.ouiaId(reqId, 'PF4/TableRow', {timeout: 15000}).within(() => {
       cy.ouiaId('status', 'execution-status').should('have.text', 'Completed');


### PR DESCRIPTION
…open Audit Details" failed in the kogito-apps-deploy job

I have added the clock function to synchronized application and test. Application should get same time which was set by test.

https://issues.redhat.com/browse/FAI-732
