### PR TITLE
[DROOLS-6036] move util classes into a separated module

### DIFF
--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImplTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImplTest.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.drools.core.util.IoUtils;
+import org.drools.util.IoUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
@@ -18,7 +18,7 @@ package org.kie.kogito.jitexecutor.dmn;
 
 import java.io.IOException;
 
-import org.drools.core.util.IoUtils;
+import org.drools.util.IoUtils;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/JITDMNResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/JITDMNResourceTest.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.drools.core.util.IoUtils;
+import org.drools.util.IoUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.jitexecutor.dmn.requests.JITDMNPayload;

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/MultipleModelsTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/MultipleModelsTest.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.drools.core.IoUtils;
+import org.drools.util.IoUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kie.dmn.api.core.DMNDecisionResult;

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/MultipleModelsTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/MultipleModelsTest.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.drools.core.util.IoUtils;
+import org.drools.core.IoUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kie.dmn.api.core.DMNDecisionResult;

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/SchemaResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/SchemaResourceTest.java
@@ -18,7 +18,7 @@ package org.kie.kogito.jitexecutor.dmn.api;
 
 import java.io.IOException;
 
-import org.drools.core.util.IoUtils;
+import org.drools.core.IoUtils;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/SchemaResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/SchemaResourceTest.java
@@ -18,7 +18,7 @@ package org.kie.kogito.jitexecutor.dmn.api;
 
 import java.io.IOException;
 
-import org.drools.core.IoUtils;
+import org.drools.util.IoUtils;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/ValidatorResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/ValidatorResourceTest.java
@@ -19,7 +19,7 @@ package org.kie.kogito.jitexecutor.dmn.api;
 import java.io.IOException;
 import java.util.List;
 
-import org.drools.core.IoUtils;
+import org.drools.util.IoUtils;
 import org.junit.jupiter.api.Test;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.kogito.jitexecutor.dmn.responses.JITDMNMessage;

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/ValidatorResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/ValidatorResourceTest.java
@@ -19,7 +19,7 @@ package org.kie.kogito.jitexecutor.dmn.api;
 import java.io.IOException;
 import java.util.List;
 
-import org.drools.core.util.IoUtils;
+import org.drools.core.IoUtils;
 import org.junit.jupiter.api.Test;
 import org.kie.dmn.api.core.DMNMessageType;
 import org.kie.kogito.jitexecutor.dmn.responses.JITDMNMessage;


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6036

Related PRs:
https://github.com/kiegroup/drools/pull/4311
https://github.com/kiegroup/kogito-runtimes/pull/2153
https://github.com/kiegroup/optaplanner/pull/1939
https://github.com/kiegroup/kogito-apps/pull/1306