### PR TITLE
fix trusty package after webpack update v3->v4

### DIFF
--- a/ui-packages/packages/trusty/dev-webapp/webpack.dev.js
+++ b/ui-packages/packages/trusty/dev-webapp/webpack.dev.js
@@ -17,15 +17,21 @@ module.exports = merge(common, {
   },
   devtool: 'source-map',
   devServer: {
-    contentBase: path.join(__dirname),
+    static: {
+      directory: path.join(__dirname)
+    },
     host: HOST,
     port: PORT,
     compress: true,
-    inline: true,
     historyApiFallback: true,
     hot: true,
-    overlay: true,
-    open: true
+    open: true,
+    client: {
+      overlay: {
+        warnings: false,
+        errors: true
+      }
+    }
   },
   module: {
     rules: [

--- a/ui-packages/packages/trusty/package.json
+++ b/ui-packages/packages/trusty/package.json
@@ -26,7 +26,7 @@
     "use-react-router-breadcrumbs": "^1.0.4"
   },
   "scripts": {
-    "start": "webpack-dev-server --hot --color --progress --info=true --config ./dev-webapp/webpack.dev.js",
+    "start": "webpack-dev-server --hot --color --progress --stats verbose --config ./dev-webapp/webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "build:prod": "yarn lint && rimraf dist && rimraf dist-standalone && yarn build && yarn build:standalone",
     "build:standalone": "webpack --config ./dev-webapp/webpack.prod.js && locktt",


### PR DESCRIPTION
After webpack upgrade from v3 -> v4, few `cli` options and  `dev server` options were changed. This pr is to fix the webpack config.