### PR TITLE
[KOGITO-7865] Do not use metadata for custom types

### DIFF
--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/src/main/resources/org/acme/sw/callback-state-timeouts.sw.json
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/src/main/resources/org/acme/sw/callback-state-timeouts.sw.json
@@ -21,11 +21,8 @@
   "functions": [
     {
       "name": "callbackFunction",
-      "metadata": {
-        "interface": "org.kie.kogito.HelloService",
-        "operation": "helloJson",
-        "type": "service"
-      }
+      "type": "custom",
+      "operation": "service:java:org.kie.kogito.HelloService::helloJson"
     }
   ],
   "states": [


### PR DESCRIPTION
Updating integration test to use the standard approach
Related with https://github.com/kiegroup/kogito-runtimes/pull/2421  (since metadata support was removed by this JIRA, the test needs to be updated) but this can be merged indepdendtly right now