### PR TITLE
[1.27.x] Jenkins Nightly Native should use BUILD_MVN_OPTS

### DIFF
--- a/.ci/jenkins/Jenkinsfile.native
+++ b/.ci/jenkins/Jenkinsfile.native
@@ -146,6 +146,10 @@ MavenCommand getNativeMavenCommand(String directory, String builderImage = getNa
     if (builderImage) {
         mvnCmd.withProperty('quarkus.native.builder-image', builderImage)
     }
+    
+    if (env.BUILD_MVN_OPTS) {
+        mvnCmd.withOptions([ env.BUILD_MVN_OPTS ])
+    }
 
     return mvnCmd
 }


### PR DESCRIPTION
- https://github.com/kiegroup/drools/pull/4675
- https://github.com/kiegroup/kogito-runtimes/pull/2450
- https://github.com/kiegroup/kogito-apps/pull/1454
- https://github.com/kiegroup/kogito-examples/pull/1391