### PR TITLE
KOGITO-7929 Sonarcloud - (Java) Constructors of an "abstract" class should not be declared "public" (32)

### DIFF
--- a/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/graphql/query/AbstractInputObjectTypeMapper.java
+++ b/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/graphql/query/AbstractInputObjectTypeMapper.java
@@ -38,7 +38,7 @@ public abstract class AbstractInputObjectTypeMapper implements Function<GraphQLO
     private GraphQLSchema schema;
     private Map<String, GraphQLType> additionalTypes;
 
-    public AbstractInputObjectTypeMapper(GraphQLSchema schema, Map<String, GraphQLType> additionalTypes) {
+    protected AbstractInputObjectTypeMapper(GraphQLSchema schema, Map<String, GraphQLType> additionalTypes) {
         this.schema = schema;
         this.additionalTypes = additionalTypes;
     }

--- a/data-index/data-index-storage/data-index-storage-oracle/src/main/java/org/kie/kogito/index/oracle/storage/AbstractStorage.java
+++ b/data-index/data-index-storage/data-index-storage-oracle/src/main/java/org/kie/kogito/index/oracle/storage/AbstractStorage.java
@@ -40,10 +40,10 @@ public abstract class AbstractStorage<E extends AbstractEntity, V> implements St
     private Function<E, V> mapToModel;
     private Function<V, E> mapToEntity;
 
-    public AbstractStorage() {
+    protected AbstractStorage() {
     }
 
-    public AbstractStorage(PanacheRepositoryBase<E, String> repository, Class<V> modelClass, Class<E> entityClass, Function<E, V> mapToModel,
+    protected AbstractStorage(PanacheRepositoryBase<E, String> repository, Class<V> modelClass, Class<E> entityClass, Function<E, V> mapToModel,
             Function<V, E> mapToEntity) {
         this.repository = repository;
         this.modelClass = modelClass;

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/java/org/kie/kogito/index/postgresql/storage/AbstractStorage.java
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/java/org/kie/kogito/index/postgresql/storage/AbstractStorage.java
@@ -40,10 +40,10 @@ public abstract class AbstractStorage<E extends AbstractEntity, V> implements St
     private Function<E, V> mapToModel;
     private Function<V, E> mapToEntity;
 
-    public AbstractStorage() {
+    protected AbstractStorage() {
     }
 
-    public AbstractStorage(PanacheRepositoryBase<E, String> repository, Class<V> modelClass, Class<E> entityClass, Function<E, V> mapToModel,
+    protected AbstractStorage(PanacheRepositoryBase<E, String> repository, Class<V> modelClass, Class<E> entityClass, Function<E, V> mapToModel,
             Function<V, E> mapToEntity) {
         this.repository = repository;
         this.modelClass = modelClass;

--- a/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/BaseExplainabilityRequest.java
+++ b/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/BaseExplainabilityRequest.java
@@ -57,7 +57,7 @@ public abstract class BaseExplainabilityRequest {
     protected BaseExplainabilityRequest() {
     }
 
-    public BaseExplainabilityRequest(@NotNull String executionId,
+    protected BaseExplainabilityRequest(@NotNull String executionId,
             @NotBlank String serviceUrl,
             @NotNull ModelIdentifier modelIdentifier) {
         this.executionId = Objects.requireNonNull(executionId);

--- a/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/BaseExplainabilityResult.java
+++ b/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/BaseExplainabilityResult.java
@@ -51,10 +51,10 @@ public abstract class BaseExplainabilityResult {
     @JsonProperty(STATUS_DETAILS_FIELD)
     private String statusDetails;
 
-    public BaseExplainabilityResult() {
+    protected BaseExplainabilityResult() {
     }
 
-    public BaseExplainabilityResult(@NotNull String executionId,
+    protected BaseExplainabilityResult(@NotNull String executionId,
             @NotNull ExplainabilityStatus status,
             String statusDetails) {
         this.executionId = Objects.requireNonNull(executionId);

--- a/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/CounterfactualSearchDomainValue.java
+++ b/explainability/explainability-api/src/main/java/org/kie/kogito/explainability/api/CounterfactualSearchDomainValue.java
@@ -26,10 +26,10 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 })
 public abstract class CounterfactualSearchDomainValue extends BaseTypedValue<CounterfactualSearchDomainCollectionValue, CounterfactualSearchDomainStructureValue, CounterfactualSearchDomainUnitValue> {
 
-    public CounterfactualSearchDomainValue() {
+    protected CounterfactualSearchDomainValue() {
     }
 
-    public CounterfactualSearchDomainValue(Kind kind, String type) {
+    protected CounterfactualSearchDomainValue(Kind kind, String type) {
         super(kind, type);
     }
 }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/repository/impl/BaseReactiveJobRepository.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/repository/impl/BaseReactiveJobRepository.java
@@ -37,7 +37,7 @@ public abstract class BaseReactiveJobRepository implements ReactiveJobRepository
 
     private JobStreams jobStreams;
 
-    public BaseReactiveJobRepository(Vertx vertx, JobStreams jobStreams) {
+    protected BaseReactiveJobRepository(Vertx vertx, JobStreams jobStreams) {
         this.vertx = vertx;
         this.jobStreams = jobStreams;
     }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/scheduler/BaseTimerJobScheduler.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/scheduler/BaseTimerJobScheduler.java
@@ -73,7 +73,7 @@ public abstract class BaseTimerJobScheduler implements ReactiveJobScheduler {
         this(null, 0, 0, 0, null);
     }
 
-    public BaseTimerJobScheduler(ReactiveJobRepository jobRepository,
+    protected BaseTimerJobScheduler(ReactiveJobRepository jobRepository,
             long backoffRetryMillis,
             long maxIntervalLimitToRetryMillis,
             long schedulerChunkInMinutes,

--- a/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/listener/AbstractCacheObjectListener.java
+++ b/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/listener/AbstractCacheObjectListener.java
@@ -24,7 +24,7 @@ public abstract class AbstractCacheObjectListener<K, T> {
     protected RemoteCache<K, T> cache;
     protected Consumer<T> consumer;
 
-    public AbstractCacheObjectListener(RemoteCache<K, T> cache, Consumer<T> consumer) {
+    protected AbstractCacheObjectListener(RemoteCache<K, T> cache, Consumer<T> consumer) {
         this.cache = cache;
         this.consumer = consumer;
     }

--- a/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/protostream/AbstractMarshaller.java
+++ b/persistence-commons/persistence-commons-infinispan/src/main/java/org/kie/kogito/persistence/infinispan/protostream/AbstractMarshaller.java
@@ -28,7 +28,7 @@ public abstract class AbstractMarshaller {
 
     protected ObjectMapper mapper;
 
-    public AbstractMarshaller(ObjectMapper mapper) {
+    protected AbstractMarshaller(ObjectMapper mapper) {
         this.mapper = mapper;
     }
 

--- a/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-api/src/main/java/org/kie/kogito/persistence/reporting/bootstrap/BaseStartupHandler.java
+++ b/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-api/src/main/java/org/kie/kogito/persistence/reporting/bootstrap/BaseStartupHandler.java
@@ -47,7 +47,7 @@ public abstract class BaseStartupHandler<T, F extends Field, P extends Partition
         //CDI proxy
     }
 
-    public BaseStartupHandler(final BootstrapLoader<T, F, P, J, M, D, S> loader,
+    protected BaseStartupHandler(final BootstrapLoader<T, F, P, J, M, D, S> loader,
             final DatabaseManager<T, F, P, J, M, D, C> databaseManager,
             final MappingService<T, F, P, J, M, D> mappingService,
             final SchemaGenerationAction action) {

--- a/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-postgresql-base/src/main/java/org/kie/kogito/persistence/postgresql/reporting/api/BasePostgresMappingsApiV1.java
+++ b/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-postgresql-base/src/main/java/org/kie/kogito/persistence/postgresql/reporting/api/BasePostgresMappingsApiV1.java
@@ -32,11 +32,11 @@ import org.kie.kogito.persistence.reporting.api.BaseMappingsApiV1;
 public abstract class BasePostgresMappingsApiV1
         extends BaseMappingsApiV1<JsonType, PostgresField, PostgresPartitionField, PostgresJsonField, PostgresMapping, PostgresMappingDefinition, PostgresMappingDefinitions, PostgresContext> {
 
-    public BasePostgresMappingsApiV1() {
+    protected BasePostgresMappingsApiV1() {
         //CDI proxies
     }
 
-    public BasePostgresMappingsApiV1(final PostgresMappingServiceImpl mappingService,
+    protected BasePostgresMappingsApiV1(final PostgresMappingServiceImpl mappingService,
             final BasePostgresDatabaseManagerImpl databaseManager) {
         super(mappingService, databaseManager);
     }

--- a/trusty/trusty-service/trusty-service-api/src/main/java/org/kie/kogito/trusty/service/common/responses/ExecutionHeaderResponse.java
+++ b/trusty/trusty-service/trusty-service-api/src/main/java/org/kie/kogito/trusty/service/common/responses/ExecutionHeaderResponse.java
@@ -64,7 +64,7 @@ public abstract class ExecutionHeaderResponse {
     protected ExecutionHeaderResponse() {
     }
 
-    public ExecutionHeaderResponse(String executionId,
+    protected ExecutionHeaderResponse(String executionId,
             OffsetDateTime executionDate,
             Boolean hasSucceeded,
             String executorName,

--- a/trusty/trusty-service/trusty-service-api/src/main/java/org/kie/kogito/trusty/service/common/responses/OutcomesResponse.java
+++ b/trusty/trusty-service/trusty-service-api/src/main/java/org/kie/kogito/trusty/service/common/responses/OutcomesResponse.java
@@ -54,7 +54,7 @@ public abstract class OutcomesResponse<T extends ExecutionHeaderResponse, E exte
     protected OutcomesResponse() {
     }
 
-    public OutcomesResponse(T header, Collection<E> outcomes, ModelDomain modelDomain) {
+    protected OutcomesResponse(T header, Collection<E> outcomes, ModelDomain modelDomain) {
         this.header = header;
         this.outcomes = outcomes;
         this.modelDomain = modelDomain;

--- a/trusty/trusty-service/trusty-service-api/src/main/java/org/kie/kogito/trusty/service/common/responses/StructuredInputsResponse.java
+++ b/trusty/trusty-service/trusty-service-api/src/main/java/org/kie/kogito/trusty/service/common/responses/StructuredInputsResponse.java
@@ -48,7 +48,7 @@ public abstract class StructuredInputsResponse<T extends Input> {
     protected StructuredInputsResponse() {
     }
 
-    public StructuredInputsResponse(Collection<T> inputs, ModelDomain modelDomain) {
+    protected StructuredInputsResponse(Collection<T> inputs, ModelDomain modelDomain) {
         this.inputs = inputs;
         this.modelDomain = modelDomain;
     }

--- a/trusty/trusty-service/trusty-service-common/src/main/java/org/kie/kogito/trusty/service/common/messaging/BaseEventConsumer.java
+++ b/trusty/trusty-service/trusty-service-common/src/main/java/org/kie/kogito/trusty/service/common/messaging/BaseEventConsumer.java
@@ -50,7 +50,7 @@ public abstract class BaseEventConsumer<E> {
         this(null, null, null, null);
     }
 
-    public BaseEventConsumer(final TrustyService service,
+    protected BaseEventConsumer(final TrustyService service,
             final ObjectMapper mapper,
             final StorageExceptionsProvider storageExceptionsProvider,
             final ManagedExecutor executor) {

--- a/trusty/trusty-storage/trusty-storage-api/src/main/java/org/kie/kogito/trusty/storage/api/model/Input.java
+++ b/trusty/trusty-storage/trusty-storage-api/src/main/java/org/kie/kogito/trusty/storage/api/model/Input.java
@@ -42,10 +42,10 @@ public abstract class Input {
     @JsonProperty(VALUE_FIELD)
     private TypedValue value;
 
-    public Input() {
+    protected Input() {
     }
 
-    public Input(String id, String name, TypedValue value) {
+    protected Input(String id, String name, TypedValue value) {
         this.id = id;
         this.name = name;
         this.value = value;

--- a/trusty/trusty-storage/trusty-storage-api/src/main/java/org/kie/kogito/trusty/storage/api/model/ModelMetadata.java
+++ b/trusty/trusty-storage/trusty-storage-api/src/main/java/org/kie/kogito/trusty/storage/api/model/ModelMetadata.java
@@ -51,17 +51,17 @@ public abstract class ModelMetadata {
     @JsonProperty("@type")
     private ModelDomain modelDomain;
 
-    public ModelMetadata() {
+    protected ModelMetadata() {
     }
 
-    public ModelMetadata(String groupId, String artifactId, String modelVersion, ModelDomain modelDomain) {
+    protected ModelMetadata(String groupId, String artifactId, String modelVersion, ModelDomain modelDomain) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.modelVersion = modelVersion;
         this.modelDomain = modelDomain;
     }
 
-    public ModelMetadata(KogitoGAV gav, ModelDomain modelDomain) {
+    protected ModelMetadata(KogitoGAV gav, ModelDomain modelDomain) {
         this(gav.getGroupId(), gav.getArtifactId(), gav.getVersion(), modelDomain);
     }
 

--- a/trusty/trusty-storage/trusty-storage-api/src/main/java/org/kie/kogito/trusty/storage/api/model/ModelWithMetadata.java
+++ b/trusty/trusty-storage/trusty-storage-api/src/main/java/org/kie/kogito/trusty/storage/api/model/ModelWithMetadata.java
@@ -38,10 +38,10 @@ public abstract class ModelWithMetadata<T extends ModelMetadata> {
     @JsonProperty("@type")
     private ModelDomain modelDomain;
 
-    public ModelWithMetadata() {
+    protected ModelWithMetadata() {
     }
 
-    public ModelWithMetadata(T modelMetaData, ModelDomain modelDomain) {
+    protected ModelWithMetadata(T modelMetaData, ModelDomain modelDomain) {
         this.modelMetaData = modelMetaData;
         this.modelDomain = modelDomain;
     }

--- a/trusty/trusty-storage/trusty-storage-api/src/main/java/org/kie/kogito/trusty/storage/api/model/Outcome.java
+++ b/trusty/trusty-storage/trusty-storage-api/src/main/java/org/kie/kogito/trusty/storage/api/model/Outcome.java
@@ -57,10 +57,10 @@ public abstract class Outcome {
     @JsonProperty(MESSAGES_FIELD)
     private Collection<Message> messages;
 
-    public Outcome() {
+    protected Outcome() {
     }
 
-    public Outcome(String outcomeId, String outcomeName, String evaluationStatus,
+    protected Outcome(String outcomeId, String outcomeName, String evaluationStatus,
             TypedValue outcomeResult,
             Collection<NamedTypedValue> outcomeInputs,
             Collection<Message> messages) {

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/main/java/org/kie/kogito/trusty/storage/infinispan/AbstractModelMarshaller.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/main/java/org/kie/kogito/trusty/storage/infinispan/AbstractModelMarshaller.java
@@ -24,7 +24,7 @@ abstract class AbstractModelMarshaller<T> extends AbstractMarshaller implements 
 
     private final Class<? extends T> javaClass;
 
-    public AbstractModelMarshaller(ObjectMapper mapper, Class<? extends T> javaClass) {
+    protected AbstractModelMarshaller(ObjectMapper mapper, Class<? extends T> javaClass) {
         super(mapper);
         this.javaClass = javaClass;
     }

--- a/trusty/trusty-storage/trusty-storage-postgresql/src/main/java/org/kie/kogito/trusty/storage/postgresql/BaseTransactionalStorage.java
+++ b/trusty/trusty-storage/trusty-storage-postgresql/src/main/java/org/kie/kogito/trusty/storage/postgresql/BaseTransactionalStorage.java
@@ -36,7 +36,7 @@ public abstract class BaseTransactionalStorage<T> implements Storage<String, T> 
         //CDI proxy
     }
 
-    public BaseTransactionalStorage(String name, CacheEntityRepository repository, ObjectMapper mapper, Class<T> type) {
+    protected BaseTransactionalStorage(String name, CacheEntityRepository repository, ObjectMapper mapper, Class<T> type) {
         this(new PostgresStorage<>(name, repository, mapper, type));
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7929

Goal here is to reduce the number of code smells in Kogito-apps.

Addressed in this PR is the code smell, "Constructors of an abstract class should not be declared public." I have remedied this by changing the modifier from public to protected in the affected areas.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

 <b>Jenkins retest this</b>
 
</details>
