### PR TITLE
Kogito 7918 Sonarcloud - (Java) JUnit5 test classes and methods should have default package visibility (359)

### DIFF
--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/api/KogitoRuntimeClientTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/api/KogitoRuntimeClientTest.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class KogitoRuntimeClientTest {
+class KogitoRuntimeClientTest {
 
     private static int ACTIVE = 1;
     private static int ERROR = 5;
@@ -106,7 +106,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testAbortProcessInstance() {
+    void testAbortProcessInstance() {
         setupIdentityMock();
         when(webClientMock.delete(anyString())).thenReturn(httpRequestMock);
 
@@ -123,7 +123,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testRetryProcessInstance() {
+    void testRetryProcessInstance() {
         setupIdentityMock();
         when(webClientMock.post(anyString())).thenReturn(httpRequestMock);
         ProcessInstance pI = createProcessInstance(PROCESS_INSTANCE_ID, ERROR);
@@ -139,7 +139,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testSkipProcessInstance() {
+    void testSkipProcessInstance() {
         setupIdentityMock();
         when(webClientMock.post(anyString())).thenReturn(httpRequestMock);
 
@@ -156,7 +156,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testUpdateProcessInstanceVariables() {
+    void testUpdateProcessInstanceVariables() {
         setupIdentityMock();
         when(webClientMock.put(anyString())).thenReturn(httpRequestMock);
         when(httpRequestMock.putHeader(eq("Content-Type"), anyString())).thenReturn(httpRequestMock);
@@ -174,7 +174,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testTriggerNodeInstance() {
+    void testTriggerNodeInstance() {
         String nodeDefId = "nodeDefId";
         setupIdentityMock();
         when(webClientMock.post(anyString())).thenReturn(httpRequestMock);
@@ -191,7 +191,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testRetriggerNodeInstance() {
+    void testRetriggerNodeInstance() {
         String nodeInstanceId = "nodeInstanceId";
         setupIdentityMock();
         when(webClientMock.post(anyString())).thenReturn(httpRequestMock);
@@ -209,7 +209,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testCancelNodeInstance() {
+    void testCancelNodeInstance() {
         String nodeInstanceId = "nodeInstanceId";
         setupIdentityMock();
         when(webClientMock.delete(anyString())).thenReturn(httpRequestMock);
@@ -227,7 +227,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testCancelJob() {
+    void testCancelJob() {
         setupIdentityMock();
         when(webClientMock.delete(anyString())).thenReturn(httpRequestMock);
 
@@ -243,7 +243,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testRescheduleJob() {
+    void testRescheduleJob() {
         String newJobData = "{ }";
         setupIdentityMock();
         when(webClientMock.put(anyString())).thenReturn(httpRequestMock);
@@ -262,7 +262,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testGetProcessInstanceDiagram() {
+    void testGetProcessInstanceDiagram() {
         setupIdentityMock();
         when(webClientMock.get(anyString())).thenReturn(httpRequestMock);
 
@@ -280,7 +280,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testGetProcessInstanceNodeDefinitions() {
+    void testGetProcessInstanceNodeDefinitions() {
         setupIdentityMock();
         when(webClientMock.get(anyString())).thenReturn(httpRequestMock);
 
@@ -309,7 +309,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testGetProcessInstanceSource() {
+    void testGetProcessInstanceSource() {
         setupIdentityMock();
         when(webClientMock.get(anyString())).thenReturn(httpRequestMock);
 
@@ -327,7 +327,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testGetUserTaskSchema() {
+    void testGetUserTaskSchema() {
         setupIdentityMock();
         when(webClientMock.get(anyString())).thenReturn(httpRequestMock);
 
@@ -343,7 +343,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testUpdateUserTaskInstance() {
+    void testUpdateUserTaskInstance() {
         setupIdentityMock();
         when(webClientMock.patch(anyString())).thenReturn(httpRequestMock);
 
@@ -366,7 +366,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testCreateUserTaskInstanceComment() {
+    void testCreateUserTaskInstanceComment() {
         String commentInfo = "newComment";
         setupIdentityMock();
         when(webClientMock.post(anyString())).thenReturn(httpRequestMock);
@@ -384,7 +384,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testCreateUserTaskInstanceAttachment() {
+    void testCreateUserTaskInstanceAttachment() {
         String attachmentUri = "nhttps://drive.google.com/file/d/AttachmentUri";
         String attachmentName = "newAttachmentName";
         setupIdentityMock();
@@ -406,7 +406,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testUpdateUserTaskInstanceComment() {
+    void testUpdateUserTaskInstanceComment() {
         String commentInfo = "NewCommentContent";
         String commentId = "commentId";
         setupIdentityMock();
@@ -427,7 +427,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testDeleteTaskInstanceComment() {
+    void testDeleteTaskInstanceComment() {
         String commentId = "commentId";
         setupIdentityMock();
         when(webClientMock.delete(anyString())).thenReturn(httpRequestMock);
@@ -444,7 +444,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testUpdateUserTaskInstanceAttachment() {
+    void testUpdateUserTaskInstanceAttachment() {
         String attachmentName = "NewAttachmentName";
         String attachmentContent = "NewAttachmentContent";
         String attachmentId = "attachmentId";
@@ -470,7 +470,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testDeleteTaskInstanceAttachment() {
+    void testDeleteTaskInstanceAttachment() {
         String attachmentId = "attachmentId";
         setupIdentityMock();
         when(webClientMock.delete(anyString())).thenReturn(httpRequestMock);
@@ -487,7 +487,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testWebClientToURLOptions() {
+    void testWebClientToURLOptions() {
         String defaultHost = "localhost";
         int defaultPort = 8180;
         WebClientOptions webClientOptions = client.getWebClientToURLOptions("http://" + defaultHost + ":" + defaultPort);
@@ -496,7 +496,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testWebClientToURLOptionsWithoutPort() {
+    void testWebClientToURLOptionsWithoutPort() {
         String dataIndexUrl = "http://service.com";
         WebClientOptions webClientOptions = client.getWebClientToURLOptions(dataIndexUrl);
         assertThat(webClientOptions.getDefaultPort()).isEqualTo(80);
@@ -505,7 +505,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testWebClientToURLOptionsWithoutPortSSL() {
+    void testWebClientToURLOptionsWithoutPortSSL() {
         String dataIndexurl = "https://service.com";
         WebClientOptions webClientOptions = client.getWebClientToURLOptions(dataIndexurl);
         assertThat(webClientOptions.getDefaultPort()).isEqualTo(443);
@@ -514,7 +514,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testMalformedURL() {
+    void testMalformedURL() {
         assertThat(client.getWebClientToURLOptions("malformedURL")).isNull();
     }
 
@@ -527,7 +527,7 @@ public class KogitoRuntimeClientTest {
     }
 
     @Test
-    public void testGetAuthHeader() {
+    void testGetAuthHeader() {
         tokenCredential = mock(TokenCredential.class);
         when(identityMock.getCredential(TokenCredential.class)).thenReturn(tokenCredential);
         when(tokenCredential.getToken()).thenReturn(AUTHORIZED_TOKEN);

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/DateTimeScalarTypeProducerTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/DateTimeScalarTypeProducerTest.java
@@ -22,12 +22,12 @@ import graphql.schema.GraphQLScalarType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DateTimeScalarTypeProducerTest {
+class DateTimeScalarTypeProducerTest {
 
     GraphQLScalarType dateTimeScalar = new GraphQLScalarTypeProducer(new DefaultDateTimeCoercing()).dateTimeScalar();
 
     @Test
-    public void testScalarType() {
+    void testScalarType() {
         assertThat(dateTimeScalar.getName()).isEqualTo("DateTime");
         assertThat(dateTimeScalar.getDescription()).isEqualTo("An ISO-8601 compliant DateTime Scalar");
         assertThat(dateTimeScalar.getCoercing()).isNotNull();

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/DefaultDateTimeCoercingTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/DefaultDateTimeCoercingTest.java
@@ -28,12 +28,12 @@ import graphql.schema.CoercingSerializeException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public class DefaultDateTimeCoercingTest {
+class DefaultDateTimeCoercingTest {
 
     DefaultDateTimeCoercing dateTimeCoercing = new DefaultDateTimeCoercing();
 
     @Test
-    public void testParseValueAsLong() {
+    void testParseValueAsLong() {
         assertThat(dateTimeCoercing.parseValue(null)).isNull();
         assertThat(dateTimeCoercing.parseValue("2019-11-20T03:14:03.075Z"))
                 .isEqualTo(ZonedDateTime.parse("2019-11-20T03:14:03.075Z").truncatedTo(ChronoUnit.MILLIS).toInstant()
@@ -41,13 +41,13 @@ public class DefaultDateTimeCoercingTest {
     }
 
     @Test
-    public void testParseLiteral() {
+    void testParseLiteral() {
         assertThat(dateTimeCoercing.parseLiteral(null)).isNull();
         assertThat(dateTimeCoercing.parseLiteral(new StringValue("2019-11-20T03:14:03.075Z"))).isEqualTo(1574219643075l);
     }
 
     @Test
-    public void testSerializeNull() {
+    void testSerializeNull() {
         try {
             dateTimeCoercing.serialize(null);
             fail("Method should throw CoercingSerializeException");
@@ -58,7 +58,7 @@ public class DefaultDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeInvalidType() {
+    void testSerializeInvalidType() {
         try {
             dateTimeCoercing.serialize(1);
             fail("Method should throw CoercingSerializeException");
@@ -69,21 +69,21 @@ public class DefaultDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeZonedDateTime() {
+    void testSerializeZonedDateTime() {
         ZonedDateTime time = ZonedDateTime.now().withZoneSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS);
         String result = dateTimeCoercing.serialize(time);
         assertThat(result).isEqualTo(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(time));
     }
 
     @Test
-    public void testSerializeMillisAsString() {
+    void testSerializeMillisAsString() {
         ZonedDateTime time = ZonedDateTime.now().withZoneSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS);
         String result = dateTimeCoercing.serialize(String.valueOf(time.toInstant().toEpochMilli()));
         assertThat(result).isEqualTo(time.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
     }
 
     @Test
-    public void testSerializeInvalidString() {
+    void testSerializeInvalidString() {
         try {
             dateTimeCoercing.serialize("test");
             fail("Method should throw CoercingSerializeException");
@@ -94,7 +94,7 @@ public class DefaultDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeString() {
+    void testSerializeString() {
         String result = dateTimeCoercing.serialize("2019-08-20T19:26:02.092+00:00");
         assertThat(result).isEqualTo("2019-08-20T19:26:02.092Z");
     }

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/GraphQLSchemaManagerTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/GraphQLSchemaManagerTest.java
@@ -29,13 +29,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class GraphQLSchemaManagerTest {
+class GraphQLSchemaManagerTest {
 
     GraphQLSchemaManager schemaManager = new GraphQLSchemaManager();
     ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void testNullServiceUrl() {
+    void testNullServiceUrl() {
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv(null, null))).isNull();
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("travels", null))).isNull();
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("demo.orders", null))).isNull();
@@ -43,7 +43,7 @@ public class GraphQLSchemaManagerTest {
     }
 
     @Test
-    public void testJsonNullServiceUrl() {
+    void testJsonNullServiceUrl() {
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv(null, null))).isNull();
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv("travels", null))).isNull();
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv("demo.orders", null))).isNull();
@@ -51,21 +51,21 @@ public class GraphQLSchemaManagerTest {
     }
 
     @Test
-    public void testNullProcessIdServiceUrl() {
+    void testNullProcessIdServiceUrl() {
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("travels", "/travels"))).isNull();
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("demo.orders", "/orders"))).isNull();
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("demo.orderItems", "/orderItems"))).isNull();
     }
 
     @Test
-    public void testJsonNullProcessIdServiceUrl() {
+    void testJsonNullProcessIdServiceUrl() {
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv("travels", "/travels"))).isNull();
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv("demo.orders", "/orders"))).isNull();
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv("demo.orderItems", "/orderItems"))).isNull();
     }
 
     @Test
-    public void testUrlProcessIdServiceUrl() {
+    void testUrlProcessIdServiceUrl() {
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("travels", "http://localhost:8080/travels"))).isEqualTo("http://localhost:8080");
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("travels", "http://travels.example.com/travels"))).isEqualTo("http://travels.example.com");
         assertThat(schemaManager.getProcessInstanceServiceUrl(getEnv("demo.orders", "http://localhost:8080/orders"))).isEqualTo("http://localhost:8080");
@@ -73,7 +73,7 @@ public class GraphQLSchemaManagerTest {
     }
 
     @Test
-    public void testJsonUrlProcessIdServiceUrl() {
+    void testJsonUrlProcessIdServiceUrl() {
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv("travels", "http://localhost:8080/travels"))).isEqualTo("http://localhost:8080");
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv("travels", "http://travels.example.com/travels"))).isEqualTo("http://travels.example.com");
         assertThat(schemaManager.getProcessInstanceJsonServiceUrl(geJsonEnv("demo.orders", "http://localhost:8080/orders"))).isEqualTo("http://localhost:8080");

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/JsonPropertyDataFetcherTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/JsonPropertyDataFetcherTest.java
@@ -32,13 +32,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class JsonPropertyDataFetcherTest {
+class JsonPropertyDataFetcherTest {
 
     ObjectMapper objectMapper = new ObjectMapper();
     JsonPropertyDataFetcher jsonPropertyDataFetcher = new JsonPropertyDataFetcher();
 
     @Test
-    public void testBasicTypesDataFetcher() {
+    void testBasicTypesDataFetcher() {
         JsonNode addressJson = createTestObjectNodeJson("city1", 8, true, null);
         assertThat(jsonPropertyDataFetcher.get(getMockEnv("city", addressJson))).isEqualTo("city1");
         assertThat(jsonPropertyDataFetcher.get(getMockEnv("amount", addressJson))).isEqualTo(8);
@@ -47,7 +47,7 @@ public class JsonPropertyDataFetcherTest {
     }
 
     @Test
-    public void testArraysTypesDataFetcher() {
+    void testArraysTypesDataFetcher() {
         JsonNode arraysJson = getArraysNodeJson();
         assertThat(((ArrayNode) jsonPropertyDataFetcher.get(getMockEnv("addressArray", arraysJson))).size()).isEqualTo(2);
         List stringArray = ((List) jsonPropertyDataFetcher.get(getMockEnv("stringArray", arraysJson)));

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/query/GraphQLQueryMapperTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/query/GraphQLQueryMapperTest.java
@@ -55,7 +55,7 @@ import static org.kie.kogito.persistence.api.query.QueryFilterFactory.isNull;
 import static org.kie.kogito.persistence.api.query.QueryFilterFactory.notNull;
 
 @ExtendWith(MockitoExtension.class)
-public class GraphQLQueryMapperTest {
+class GraphQLQueryMapperTest {
 
     @InjectMocks
     GraphQLSchemaManager manager;
@@ -125,7 +125,7 @@ public class GraphQLQueryMapperTest {
     }
 
     @Test
-    public void testQuery() {
+    void testQuery() {
         Map<String, Object> where = new HashMap<>();
         Map<String, Object> id = new HashMap();
         Map<String, Object> idValues = new HashMap();
@@ -148,7 +148,7 @@ public class GraphQLQueryMapperTest {
     }
 
     @Test
-    public void testDatesQuery() {
+    void testDatesQuery() {
         Map<String, Object> where = new HashMap<>();
         where.put("start", singletonMap("equal", "2019-01-01"));
         Map<String, Object> between = new HashMap<>();
@@ -164,7 +164,7 @@ public class GraphQLQueryMapperTest {
     }
 
     @Test
-    public void testNodesQuery() {
+    void testNodesQuery() {
         Map<String, Object> where = new HashMap<>();
         where.put("nodes", singletonMap("name", singletonMap("equal", "StartNode")));
 
@@ -175,7 +175,7 @@ public class GraphQLQueryMapperTest {
     }
 
     @Test
-    public void testOrQuery() {
+    void testOrQuery() {
         Map<String, Object> where = new HashMap<>();
         Map<String, Object> id = new HashMap();
         Map<String, Object> idValues = new HashMap();

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/query/GraphQLQueryOrderParserTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/query/GraphQLQueryOrderParserTest.java
@@ -39,7 +39,7 @@ import static org.kie.kogito.persistence.api.query.QueryFilterFactory.orderBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class GraphQLQueryOrderParserTest {
+class GraphQLQueryOrderParserTest {
 
     private static DataFetchingEnvironment mockDataFetchingEnvironment(List<Argument> arguments, Map<String, Object> variables) {
         DataFetchingEnvironment env = mock(DataFetchingEnvironment.class);
@@ -51,26 +51,26 @@ public class GraphQLQueryOrderParserTest {
     }
 
     @Test
-    public void testNull() {
+    void testNull() {
         assertThat(new GraphQLQueryOrderByParser().apply(null)).isEmpty();
     }
 
     @Test
-    public void testEmpty() {
+    void testEmpty() {
         DataFetchingEnvironment env = mockDataFetchingEnvironment(emptyList(), emptyMap());
 
         assertThat(new GraphQLQueryOrderByParser().apply(env)).isEmpty();
     }
 
     @Test
-    public void testNonMatchingArgument() {
+    void testNonMatchingArgument() {
         DataFetchingEnvironment env = mockDataFetchingEnvironment(singletonList(Argument.newArgument().name("where").build()), emptyMap());
 
         assertThat(new GraphQLQueryOrderByParser().apply(env)).isEmpty();
     }
 
     @Test
-    public void testSortSingleArgument() {
+    void testSortSingleArgument() {
         DataFetchingEnvironment env = mockDataFetchingEnvironment(singletonList(
                 Argument.newArgument().name("orderBy").value(
                         ObjectValue.newObjectValue().objectField(
@@ -86,7 +86,7 @@ public class GraphQLQueryOrderParserTest {
     }
 
     @Test
-    public void testSortUsingVariable() {
+    void testSortUsingVariable() {
         DataFetchingEnvironment env = mockDataFetchingEnvironment(singletonList(
                 Argument.newArgument().name("orderBy").value(
                         VariableReference.newVariableReference().name("orderBy").build()).build()),
@@ -100,7 +100,7 @@ public class GraphQLQueryOrderParserTest {
     }
 
     @Test
-    public void testSortArgumentOrder() {
+    void testSortArgumentOrder() {
         DataFetchingEnvironment env = mockDataFetchingEnvironment(singletonList(
                 Argument.newArgument().name("orderBy").value(
                         ObjectValue.newObjectValue()
@@ -120,7 +120,7 @@ public class GraphQLQueryOrderParserTest {
     }
 
     @Test
-    public void testSortArgumentUsingChildEntity() {
+    void testSortArgumentUsingChildEntity() {
         DataFetchingEnvironment env = mockDataFetchingEnvironment(singletonList(
                 Argument.newArgument().name("orderBy").value(
                         ObjectValue.newObjectValue()

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/json/ProcessInstanceMetaMapperTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/json/ProcessInstanceMetaMapperTest.java
@@ -29,10 +29,10 @@ import static org.kie.kogito.index.Constants.KOGITO_DOMAIN_ATTRIBUTE;
 import static org.kie.kogito.index.Constants.PROCESS_INSTANCES_DOMAIN_ATTRIBUTE;
 import static org.kie.kogito.index.TestUtils.getProcessCloudEvent;
 
-public class ProcessInstanceMetaMapperTest {
+class ProcessInstanceMetaMapperTest {
 
     @Test
-    public void testProcessInstanceMapper() {
+    void testProcessInstanceMapper() {
         String processId = "travels";
         String rootProcessId = "root_travels";
         String processInstanceId = UUID.randomUUID().toString();
@@ -63,7 +63,7 @@ public class ProcessInstanceMetaMapperTest {
     }
 
     @Test
-    public void testProcessInstanceMapperWithBusinessKey() {
+    void testProcessInstanceMapperWithBusinessKey() {
         String processId = "travels";
         String rootProcessId = "root_travels";
         String processInstanceId = UUID.randomUUID().toString();

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/json/UserTaskInstanceMetaMapperTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/json/UserTaskInstanceMetaMapperTest.java
@@ -28,10 +28,10 @@ import static org.kie.kogito.index.Constants.KOGITO_DOMAIN_ATTRIBUTE;
 import static org.kie.kogito.index.Constants.USER_TASK_INSTANCES_DOMAIN_ATTRIBUTE;
 import static org.kie.kogito.index.TestUtils.getUserTaskCloudEvent;
 
-public class UserTaskInstanceMetaMapperTest {
+class UserTaskInstanceMetaMapperTest {
 
     @Test
-    public void testUserTaskInstanceMapper() {
+    void testUserTaskInstanceMapper() {
         String taskId = UUID.randomUUID().toString();
         String processId = "travels";
         String rootProcessId = "root_travels";

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/messaging/DomainEventConsumerTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/messaging/DomainEventConsumerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class DomainEventConsumerTest {
+class DomainEventConsumerTest {
 
     @Mock
     IndexingService service;
@@ -57,7 +57,7 @@ public class DomainEventConsumerTest {
     }
 
     @Test
-    public void testOnUserTaskInstanceDomainEventMappingException() {
+    void testOnUserTaskInstanceDomainEventMappingException() {
         UserTaskInstanceDataEvent event = mock(UserTaskInstanceDataEvent.class);
 
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> consumer.onDomainEvent(event));
@@ -66,7 +66,7 @@ public class DomainEventConsumerTest {
     }
 
     @Test
-    public void testOnUserTaskInstanceDomainEventIndexingException() {
+    void testOnUserTaskInstanceDomainEventIndexingException() {
         doThrow(new RuntimeException("")).when(service).indexModel(any());
 
         String taskId = UUID.randomUUID().toString();
@@ -80,7 +80,7 @@ public class DomainEventConsumerTest {
     }
 
     @Test
-    public void testOnUserTaskInstanceEvent() {
+    void testOnUserTaskInstanceEvent() {
         String taskId = UUID.randomUUID().toString();
         String processId = "travels";
         String processInstanceId = UUID.randomUUID().toString();
@@ -99,7 +99,7 @@ public class DomainEventConsumerTest {
     }
 
     @Test
-    public void testOnProcessInstanceDomainEventMappingException() {
+    void testOnProcessInstanceDomainEventMappingException() {
         ProcessInstanceDataEvent event = mock(ProcessInstanceDataEvent.class);
 
         assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> consumer.onDomainEvent(event));
@@ -108,7 +108,7 @@ public class DomainEventConsumerTest {
     }
 
     @Test
-    public void testOnProcessInstanceDomainEventIndexingException() {
+    void testOnProcessInstanceDomainEventIndexingException() {
         doThrow(new RuntimeException("")).when(service).indexModel(any());
 
         String processId = "travels";

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/messaging/ReactiveMessagingEventConsumerTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/messaging/ReactiveMessagingEventConsumerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-public class ReactiveMessagingEventConsumerTest {
+class ReactiveMessagingEventConsumerTest {
 
     @Mock
     IndexingService service;
@@ -56,7 +56,7 @@ public class ReactiveMessagingEventConsumerTest {
     ReactiveMessagingEventConsumer consumer;
 
     @Test
-    public void testOnProcessInstanceEvent() {
+    void testOnProcessInstanceEvent() {
         String processId = "travels";
         String processInstanceId = UUID.randomUUID().toString();
 
@@ -72,7 +72,7 @@ public class ReactiveMessagingEventConsumerTest {
     }
 
     @Test
-    public void testOnUserTaskInstanceEvent() {
+    void testOnUserTaskInstanceEvent() {
 
         String taskId = UUID.randomUUID().toString();
         String processId = "travels";
@@ -89,7 +89,7 @@ public class ReactiveMessagingEventConsumerTest {
     }
 
     @Test
-    public void testOnProcessInstanceEventException() {
+    void testOnProcessInstanceEventException() {
         ProcessInstanceDataEvent event = mock(ProcessInstanceDataEvent.class);
         doThrow(new RuntimeException("")).when(service).indexProcessInstance(any());
 
@@ -102,7 +102,7 @@ public class ReactiveMessagingEventConsumerTest {
     }
 
     @Test
-    public void testOnUserTaskInstanceEventException() {
+    void testOnUserTaskInstanceEventException() {
         UserTaskInstanceDataEvent event = mock(UserTaskInstanceDataEvent.class);
         doThrow(new RuntimeException("")).when(service).indexUserTaskInstance(any());
 
@@ -115,7 +115,7 @@ public class ReactiveMessagingEventConsumerTest {
     }
 
     @Test
-    public void testOnJobEvent() {
+    void testOnJobEvent() {
         KogitoJobCloudEvent event = mock(KogitoJobCloudEvent.class);
 
         UniAssertSubscriber<Void> future = consumer.onJobEvent(event).subscribe().withSubscriber(UniAssertSubscriber.create());
@@ -125,7 +125,7 @@ public class ReactiveMessagingEventConsumerTest {
     }
 
     @Test
-    public void testOnJobEventException() {
+    void testOnJobEventException() {
         KogitoJobCloudEvent event = mock(KogitoJobCloudEvent.class);
         doThrow(new RuntimeException("")).when(service).indexJob(any());
 

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/vertx/VertxRouterSetupTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/vertx/VertxRouterSetupTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class VertxRouterSetupTest {
+class VertxRouterSetupTest {
 
     @Mock
     Router routerMock;
@@ -78,7 +78,7 @@ public class VertxRouterSetupTest {
     }
 
     @Test
-    public void testAuthEnabledTrue() {
+    void testAuthEnabledTrue() {
         vertxRouterSetup.authEnabled = true;
         vertxRouterSetup.graphUIPath = "/graphiql";
         vertxRouterSetup.setupRouter(routerMock);
@@ -87,7 +87,7 @@ public class VertxRouterSetupTest {
     }
 
     @Test
-    public void testAuthEnabledFalse() {
+    void testAuthEnabledFalse() {
         vertxRouterSetup.authEnabled = false;
         vertxRouterSetup.graphUIPath = "/graphiql";
         vertxRouterSetup.setupRouter(routerMock);
@@ -96,7 +96,7 @@ public class VertxRouterSetupTest {
     }
 
     @Test
-    public void testAddGraphiqlRequestHeader() {
+    void testAddGraphiqlRequestHeader() {
         GraphiQLHandler graphiQLHandlerMock = mock(GraphiQLHandler.class);
         String token = "TEST_TOKEN";
         QuarkusHttpUser quarkusHttpUser = mock(QuarkusHttpUser.class);

--- a/data-index/data-index-service/data-index-service-inmemory/src/test/java/org/kie/kogito/index/service/InmemoryPostgreSqlIndexingServiceIT.java
+++ b/data-index/data-index-service/data-index-service-inmemory/src/test/java/org/kie/kogito/index/service/InmemoryPostgreSqlIndexingServiceIT.java
@@ -22,7 +22,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-@TestProfile(InMemoryMessageTestProfile.class)
+Profile(InMemoryMessageTestProfile.class)
 class InmemoryPostgreSqlIndexingServiceIT extends AbstractIndexingServiceIT {
 
 }

--- a/data-index/data-index-service/data-index-service-inmemory/src/test/java/org/kie/kogito/index/service/InmemoryPostgreSqlIndexingServiceIT.java
+++ b/data-index/data-index-service/data-index-service-inmemory/src/test/java/org/kie/kogito/index/service/InmemoryPostgreSqlIndexingServiceIT.java
@@ -22,7 +22,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 
 @QuarkusTest
-Profile(InMemoryMessageTestProfile.class)
+@TestProfile(InMemoryMessageTestProfile.class)
 class InmemoryPostgreSqlIndexingServiceIT extends AbstractIndexingServiceIT {
 
 }

--- a/data-index/data-index-service/data-index-service-oracle/src/test/java/org/kie/kogito/index/graphql/OracleDateTimeCoercingTest.java
+++ b/data-index/data-index-service/data-index-service-oracle/src/test/java/org/kie/kogito/index/graphql/OracleDateTimeCoercingTest.java
@@ -26,26 +26,26 @@ import graphql.schema.CoercingSerializeException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public class OracleDateTimeCoercingTest {
+class OracleDateTimeCoercingTest {
 
     OracleDateTimeCoercing dateTimeCoercing = new OracleDateTimeCoercing();
 
     @Test
-    public void testParseValueAsZonedDateTime() {
+    void testParseValueAsZonedDateTime() {
         assertThat(dateTimeCoercing.parseValue(null)).isNull();
         assertThat(dateTimeCoercing.parseValue("2019-11-20T03:14:03.075Z"))
                 .isEqualTo(ZonedDateTime.parse("2019-11-20T03:14:03.075Z"));
     }
 
     @Test
-    public void testParseLiteral() {
+    void testParseLiteral() {
         assertThat(dateTimeCoercing.parseLiteral(null)).isNull();
         assertThat(dateTimeCoercing.parseLiteral(new StringValue("2019-11-20T03:14:03.075Z")))
                 .isEqualTo(ZonedDateTime.parse("2019-11-20T03:14:03.075Z"));
     }
 
     @Test
-    public void testSerializeInvalidString() {
+    void testSerializeInvalidString() {
         try {
             dateTimeCoercing.serialize("test");
             fail("Method should throw CoercingSerializeException");
@@ -56,7 +56,7 @@ public class OracleDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeNull() {
+    void testSerializeNull() {
         try {
             dateTimeCoercing.serialize(null);
             fail("Method should throw CoercingSerializeException");
@@ -67,7 +67,7 @@ public class OracleDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeInvalidType() {
+    void testSerializeInvalidType() {
         try {
             dateTimeCoercing.serialize(1);
             fail("Method should throw CoercingSerializeException");
@@ -78,7 +78,7 @@ public class OracleDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeString() {
+    void testSerializeString() {
         String result = dateTimeCoercing.serialize("2019-08-20T19:26:02.092+00:00");
         assertThat(result).isEqualTo("2019-08-20T19:26:02.092Z");
     }

--- a/data-index/data-index-service/data-index-service-postgresql/src/test/java/org/kie/kogito/index/graphql/PostgreSqlDateTimeCoercingTest.java
+++ b/data-index/data-index-service/data-index-service-postgresql/src/test/java/org/kie/kogito/index/graphql/PostgreSqlDateTimeCoercingTest.java
@@ -26,26 +26,26 @@ import graphql.schema.CoercingSerializeException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public class PostgreSqlDateTimeCoercingTest {
+class PostgreSqlDateTimeCoercingTest {
 
     PostgreSqlDateTimeCoercing dateTimeCoercing = new PostgreSqlDateTimeCoercing();
 
     @Test
-    public void testParseValueAsZonedDateTime() {
+    void testParseValueAsZonedDateTime() {
         assertThat(dateTimeCoercing.parseValue(null)).isNull();
         assertThat(dateTimeCoercing.parseValue("2019-11-20T03:14:03.075Z"))
                 .isEqualTo(ZonedDateTime.parse("2019-11-20T03:14:03.075Z"));
     }
 
     @Test
-    public void testParseLiteral() {
+    void testParseLiteral() {
         assertThat(dateTimeCoercing.parseLiteral(null)).isNull();
         assertThat(dateTimeCoercing.parseLiteral(new StringValue("2019-11-20T03:14:03.075Z")))
                 .isEqualTo(ZonedDateTime.parse("2019-11-20T03:14:03.075Z"));
     }
 
     @Test
-    public void testSerializeInvalidString() {
+    void testSerializeInvalidString() {
         try {
             dateTimeCoercing.serialize("test");
             fail("Method should throw CoercingSerializeException");
@@ -56,7 +56,7 @@ public class PostgreSqlDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeNull() {
+    void testSerializeNull() {
         try {
             dateTimeCoercing.serialize(null);
             fail("Method should throw CoercingSerializeException");
@@ -67,7 +67,7 @@ public class PostgreSqlDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeInvalidType() {
+    void testSerializeInvalidType() {
         try {
             dateTimeCoercing.serialize(1);
             fail("Method should throw CoercingSerializeException");
@@ -78,7 +78,7 @@ public class PostgreSqlDateTimeCoercingTest {
     }
 
     @Test
-    public void testSerializeString() {
+    void testSerializeString() {
         String result = dateTimeCoercing.serialize("2019-08-20T19:26:02.092+00:00");
         assertThat(result).isEqualTo("2019-08-20T19:26:02.092Z");
     }

--- a/data-index/data-index-storage/data-index-storage-oracle/src/test/java/org/kie/kogito/index/oracle/storage/JobStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-oracle/src/test/java/org/kie/kogito/index/oracle/storage/JobStorageIT.java
@@ -36,7 +36,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(OracleSqlQuarkusTestResource.class)
-public class JobStorageIT extends AbstractStorageIT<JobEntity, Job> {
+class JobStorageIT extends AbstractStorageIT<JobEntity, Job> {
 
     @Inject
     JobEntityRepository repository;
@@ -66,7 +66,7 @@ public class JobStorageIT extends AbstractStorageIT<JobEntity, Job> {
 
     @Test
     @Transactional
-    public void testJobEntity() {
+    void testJobEntity() {
         String jobId = UUID.randomUUID().toString();
         String processInstanceId = UUID.randomUUID().toString();
 

--- a/data-index/data-index-storage/data-index-storage-oracle/src/test/java/org/kie/kogito/index/oracle/storage/ProcessInstanceStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-oracle/src/test/java/org/kie/kogito/index/oracle/storage/ProcessInstanceStorageIT.java
@@ -36,7 +36,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(OracleSqlQuarkusTestResource.class)
-public class ProcessInstanceStorageIT extends AbstractStorageIT<ProcessInstanceEntity, ProcessInstance> {
+class ProcessInstanceStorageIT extends AbstractStorageIT<ProcessInstanceEntity, ProcessInstance> {
 
     @Inject
     ProcessInstanceEntityRepository repository;
@@ -60,7 +60,7 @@ public class ProcessInstanceStorageIT extends AbstractStorageIT<ProcessInstanceE
 
     @Test
     @Transactional
-    public void testProcessInstanceEntity() {
+    void testProcessInstanceEntity() {
         String processInstanceId = UUID.randomUUID().toString();
         ProcessInstance processInstance1 = TestUtils
                 .createProcessInstance(processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),

--- a/data-index/data-index-storage/data-index-storage-oracle/src/test/java/org/kie/kogito/index/oracle/storage/UserTaskInstanceStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-oracle/src/test/java/org/kie/kogito/index/oracle/storage/UserTaskInstanceStorageIT.java
@@ -38,7 +38,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(OracleSqlQuarkusTestResource.class)
-public class UserTaskInstanceStorageIT extends AbstractStorageIT<UserTaskInstanceEntity, UserTaskInstance> {
+class UserTaskInstanceStorageIT extends AbstractStorageIT<UserTaskInstanceEntity, UserTaskInstance> {
 
     @Inject
     UserTaskInstanceEntityRepository repository;
@@ -62,7 +62,7 @@ public class UserTaskInstanceStorageIT extends AbstractStorageIT<UserTaskInstanc
 
     @Test
     @Transactional
-    public void testUserTaskInstanceEntity() {
+    void testUserTaskInstanceEntity() {
         String taskId = UUID.randomUUID().toString();
         String processInstanceId = UUID.randomUUID().toString();
         UserTaskInstance userTaskInstance1 = TestUtils

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/test/java/org/kie/kogito/index/postgresql/storage/JobStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/test/java/org/kie/kogito/index/postgresql/storage/JobStorageIT.java
@@ -36,7 +36,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(PostgreSqlQuarkusTestResource.class)
-public class JobStorageIT extends AbstractStorageIT<JobEntity, Job> {
+class JobStorageIT extends AbstractStorageIT<JobEntity, Job> {
 
     @Inject
     JobEntityRepository repository;
@@ -66,7 +66,7 @@ public class JobStorageIT extends AbstractStorageIT<JobEntity, Job> {
 
     @Test
     @Transactional
-    public void testJobEntity() {
+    void testJobEntity() {
         String jobId = UUID.randomUUID().toString();
         String processInstanceId = UUID.randomUUID().toString();
 

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/test/java/org/kie/kogito/index/postgresql/storage/ProcessInstanceStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/test/java/org/kie/kogito/index/postgresql/storage/ProcessInstanceStorageIT.java
@@ -36,7 +36,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(PostgreSqlQuarkusTestResource.class)
-public class ProcessInstanceStorageIT extends AbstractStorageIT<ProcessInstanceEntity, ProcessInstance> {
+class ProcessInstanceStorageIT extends AbstractStorageIT<ProcessInstanceEntity, ProcessInstance> {
 
     @Inject
     ProcessInstanceEntityRepository repository;
@@ -60,7 +60,7 @@ public class ProcessInstanceStorageIT extends AbstractStorageIT<ProcessInstanceE
 
     @Test
     @Transactional
-    public void testProcessInstanceEntity() {
+    void testProcessInstanceEntity() {
         String processInstanceId = UUID.randomUUID().toString();
         ProcessInstance processInstance1 = TestUtils
                 .createProcessInstance(processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/test/java/org/kie/kogito/index/postgresql/storage/UserTaskInstanceStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/test/java/org/kie/kogito/index/postgresql/storage/UserTaskInstanceStorageIT.java
@@ -35,7 +35,7 @@ import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
 @QuarkusTestResource(PostgreSqlQuarkusTestResource.class)
-public class UserTaskInstanceStorageIT extends AbstractStorageIT<UserTaskInstanceEntity, UserTaskInstance> {
+class UserTaskInstanceStorageIT extends AbstractStorageIT<UserTaskInstanceEntity, UserTaskInstance> {
 
     @Inject
     UserTaskInstanceEntityRepository repository;
@@ -59,7 +59,7 @@ public class UserTaskInstanceStorageIT extends AbstractStorageIT<UserTaskInstanc
 
     @Test
     @Transactional
-    public void testUserTaskInstanceEntity() {
+    void testUserTaskInstanceEntity() {
         String taskId = UUID.randomUUID().toString();
         String processInstanceId = UUID.randomUUID().toString();
         UserTaskInstance userTaskInstance1 = TestUtils

--- a/explainability/explainability-api/src/test/java/org/kie/kogito/explainability/api/CounterfactualDomainSerialisationTest.java
+++ b/explainability/explainability-api/src/test/java/org/kie/kogito/explainability/api/CounterfactualDomainSerialisationTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CounterfactualDomainSerialisationTest {
+class CounterfactualDomainSerialisationTest {
 
     private ObjectMapper mapper;
     private StringWriter writer;
@@ -41,7 +41,7 @@ public class CounterfactualDomainSerialisationTest {
     }
 
     @Test
-    public void testCounterfactualSearchDomain_Range_RoundTrip() throws Exception {
+    void testCounterfactualSearchDomain_Range_RoundTrip() throws Exception {
         CounterfactualDomainRange domainRange = new CounterfactualDomainRange(new IntNode(18), new IntNode(65));
         CounterfactualSearchDomainUnitValue searchDomain = new CounterfactualSearchDomainUnitValue("integer",
                 "integer",
@@ -67,7 +67,7 @@ public class CounterfactualDomainSerialisationTest {
     }
 
     @Test
-    public void testCounterfactualSearchDomain_Categorical_RoundTrip() throws Exception {
+    void testCounterfactualSearchDomain_Categorical_RoundTrip() throws Exception {
         CounterfactualDomainCategorical domainCategorical = new CounterfactualDomainCategorical(List.of(new TextNode("A"), new TextNode("B")));
         CounterfactualSearchDomainUnitValue searchDomain = new CounterfactualSearchDomainUnitValue("integer",
                 "integer",

--- a/explainability/explainability-service-messaging/src/test/java/org/kie/kogito/explainability/messaging/ExplainabilityMessagingHandlerTest.java
+++ b/explainability/explainability-service-messaging/src/test/java/org/kie/kogito/explainability/messaging/ExplainabilityMessagingHandlerTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ExplainabilityMessagingHandlerTest {
+class ExplainabilityMessagingHandlerTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(JsonFormat.getCloudEventJacksonModule());
 

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerServiceHandlerTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/CounterfactualExplainerServiceHandlerTest.java
@@ -70,7 +70,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class CounterfactualExplainerServiceHandlerTest {
+class CounterfactualExplainerServiceHandlerTest {
 
     private static final String EXECUTION_ID = UUID.randomUUID().toString();
 
@@ -101,13 +101,13 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testSupports() {
+    void testSupports() {
         assertTrue(handler.supports(CounterfactualExplainabilityRequest.class));
         assertFalse(handler.supports(BaseExplainabilityRequest.class));
     }
 
     @Test
-    public void testGetPredictionWithEmptyDefinition() {
+    void testGetPredictionWithEmptyDefinition() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -127,7 +127,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithFlatInputModel() {
+    void testGetPredictionWithFlatInputModel() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -157,7 +157,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithStructuredInputModel() {
+    void testGetPredictionWithStructuredInputModel() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -172,7 +172,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithCollectionInputModel() {
+    void testGetPredictionWithCollectionInputModel() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -187,7 +187,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithFlatOutputModel() {
+    void testGetPredictionWithFlatOutputModel() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -215,7 +215,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithFlatOutputModelReordered() {
+    void testGetPredictionWithFlatOutputModelReordered() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -257,7 +257,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithStructuredOutputModel() {
+    void testGetPredictionWithStructuredOutputModel() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -272,7 +272,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithCollectionOutputModel() {
+    void testGetPredictionWithCollectionOutputModel() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -287,7 +287,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithFlatSearchDomainsFixed() {
+    void testGetPredictionWithFlatSearchDomainsFixed() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -313,7 +313,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithFlatSearchDomainsNotFixed() {
+    void testGetPredictionWithFlatSearchDomainsNotFixed() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -343,7 +343,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithStructuredSearchDomains() {
+    void testGetPredictionWithStructuredSearchDomains() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -363,7 +363,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testGetPredictionWithCollectionSearchDomains() {
+    void testGetPredictionWithCollectionSearchDomains() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -382,7 +382,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateSucceededResult() {
+    void testCreateSucceededResult() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -425,7 +425,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateSucceededResultWithNullPredictions() {
+    void testCreateSucceededResultWithNullPredictions() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -447,7 +447,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateSucceededResultWithEmptyPredictions() {
+    void testCreateSucceededResultWithEmptyPredictions() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -469,7 +469,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateSucceededResultWithMoreThanOnePrediction() {
+    void testCreateSucceededResultWithMoreThanOnePrediction() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -491,7 +491,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateIntermediateResult() {
+    void testCreateIntermediateResult() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -535,7 +535,7 @@ public class CounterfactualExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateFailedResult() {
+    void testCreateFailedResult() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -557,7 +557,7 @@ public class CounterfactualExplainerServiceHandlerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testExplainAsyncDelegation() {
+    void testExplainAsyncDelegation() {
         Prediction prediction = mock(Prediction.class);
         PredictionProvider predictionProvider = mock(PredictionProvider.class);
 
@@ -568,7 +568,7 @@ public class CounterfactualExplainerServiceHandlerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testExplainAsyncWithConsumerDelegation() {
+    void testExplainAsyncWithConsumerDelegation() {
         Prediction prediction = mock(Prediction.class);
         PredictionProvider predictionProvider = mock(PredictionProvider.class);
         Consumer<CounterfactualResult> callback = mock(Consumer.class);

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/LimeExplainerServiceHandlerTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/LimeExplainerServiceHandlerTest.java
@@ -57,7 +57,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class LimeExplainerServiceHandlerTest {
+class LimeExplainerServiceHandlerTest {
 
     private static final String EXECUTION_ID = "executionId";
 
@@ -78,13 +78,13 @@ public class LimeExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testSupports() {
+    void testSupports() {
         assertTrue(handler.supports(LIMEExplainabilityRequest.class));
         assertFalse(handler.supports(BaseExplainabilityRequest.class));
     }
 
     @Test
-    public void testGetPredictionWithEmptyDefinition() {
+    void testGetPredictionWithEmptyDefinition() {
         LIMEExplainabilityRequest request = new LIMEExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -101,7 +101,7 @@ public class LimeExplainerServiceHandlerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testGetPredictionWithNonEmptyDefinition() {
+    void testGetPredictionWithNonEmptyDefinition() {
         LIMEExplainabilityRequest request = new LIMEExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -190,7 +190,7 @@ public class LimeExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateSucceededResult() {
+    void testCreateSucceededResult() {
         LIMEExplainabilityRequest request = new LIMEExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -219,7 +219,7 @@ public class LimeExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateIntermediateResult() {
+    void testCreateIntermediateResult() {
         LIMEExplainabilityRequest request = new LIMEExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -230,7 +230,7 @@ public class LimeExplainerServiceHandlerTest {
     }
 
     @Test
-    public void testCreateFailedResult() {
+    void testCreateFailedResult() {
         LIMEExplainabilityRequest request = new LIMEExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -248,7 +248,7 @@ public class LimeExplainerServiceHandlerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testExplainAsyncDelegation() {
+    void testExplainAsyncDelegation() {
         Prediction prediction = mock(Prediction.class);
         PredictionProvider predictionProvider = mock(PredictionProvider.class);
 
@@ -259,7 +259,7 @@ public class LimeExplainerServiceHandlerTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testExplainAsyncWithConsumerDelegation() {
+    void testExplainAsyncWithConsumerDelegation() {
         Prediction prediction = mock(Prediction.class);
         PredictionProvider predictionProvider = mock(PredictionProvider.class);
         Consumer<Map<String, Saliency>> callback = mock(Consumer.class);

--- a/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/LocalExplainerServiceHandlerRegistryTest.java
+++ b/explainability/explainability-service/src/test/java/org/kie/kogito/explainability/handlers/LocalExplainerServiceHandlerRegistryTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class LocalExplainerServiceHandlerRegistryTest {
+class LocalExplainerServiceHandlerRegistryTest {
 
     private static final String EXECUTION_ID = "executionId";
 
@@ -79,7 +79,7 @@ public class LocalExplainerServiceHandlerRegistryTest {
     }
 
     @Test
-    public void testLIME_explainAsyncWithResults() {
+    void testLIME_explainAsyncWithResults() {
         LIMEExplainabilityRequest request = new LIMEExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,
@@ -92,7 +92,7 @@ public class LocalExplainerServiceHandlerRegistryTest {
     }
 
     @Test
-    public void testCounterfactual_explainAsyncWithResults() {
+    void testCounterfactual_explainAsyncWithResults() {
         CounterfactualExplainabilityRequest request = new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 MODEL_IDENTIFIER,

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImplTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/JITDMNServiceImplTest.java
@@ -41,7 +41,7 @@ public class JITDMNServiceImplTest {
     }
 
     @Test
-    public void testModelEvaluation() {
+    void testModelEvaluation() {
         Map<String, Object> context = new HashMap<>();
         context.put("FICO Score", 800);
         context.put("DTI Ratio", .1);
@@ -55,7 +55,7 @@ public class JITDMNServiceImplTest {
     }
 
     @Test
-    public void testExplainability() throws IOException {
+    void testExplainability() throws IOException {
         String allTypesModel = new String(IoUtils.readBytesFromInputStream(JITDMNResourceTest.class.getResourceAsStream("/allTypes.dmn")));
 
         Map<String, Object> context = new HashMap<>();

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
@@ -30,14 +30,14 @@ import io.restassured.http.ContentType;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-public class OneOfEachTypeTest {
+class OneOfEachTypeTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
     @Test
-    public void allTypes() throws IOException {
+    void allTypes() throws IOException {
         String model = new ObjectMapper().writeValueAsString(new String(IoUtils.readBytesFromInputStream(OneOfEachTypeTest.class.getResourceAsStream("/OneOfEachType.dmn"))));
         String payload = "{ \"model\": " + model + ", \"context\": {\n" +
                 "    \"InputBoolean\": true,\n" +

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
@@ -30,7 +30,7 @@ import io.restassured.http.ContentType;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
-class OneOfEachTypeTest {
+public class OneOfEachTypeTest {
 
     static {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
@@ -37,7 +37,7 @@ public class OneOfEachTypeTest {
     }
 
     @Test
-    public void allTypes() throws IOException {
+    void allTypes() throws IOException {
         String model = new ObjectMapper().writeValueAsString(new String(IoUtils.readBytesFromInputStream(OneOfEachTypeTest.class.getResourceAsStream("/OneOfEachType.dmn"))));
         String payload = "{ \"model\": " + model + ", \"context\": {\n" +
                 "    \"InputBoolean\": true,\n" +

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/OneOfEachTypeTest.java
@@ -37,7 +37,7 @@ public class OneOfEachTypeTest {
     }
 
     @Test
-    void allTypes() throws IOException {
+    public void allTypes() throws IOException {
         String model = new ObjectMapper().writeValueAsString(new String(IoUtils.readBytesFromInputStream(OneOfEachTypeTest.class.getResourceAsStream("/OneOfEachType.dmn"))));
         String payload = "{ \"model\": " + model + ", \"context\": {\n" +
                 "    \"InputBoolean\": true,\n" +

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/JITDMNResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/JITDMNResourceTest.java
@@ -44,7 +44,7 @@ public class JITDMNResourceTest {
     }
 
     @Test
-    public void testjitEndpoint() {
+    void testjitEndpoint() {
         JITDMNPayload jitdmnpayload = new JITDMNPayload(model, buildContext());
         given()
                 .contentType(ContentType.JSON)
@@ -56,7 +56,7 @@ public class JITDMNResourceTest {
     }
 
     @Test
-    public void testjitdmnResultEndpoint() {
+    void testjitdmnResultEndpoint() {
         JITDMNPayload jitdmnpayload = new JITDMNPayload(model, buildContext());
         given()
                 .contentType(ContentType.JSON)
@@ -68,7 +68,7 @@ public class JITDMNResourceTest {
     }
 
     @Test
-    public void testjitExplainabilityEndpoint() {
+    void testjitExplainabilityEndpoint() {
         JITDMNPayload jitdmnpayload = new JITDMNPayload(model, buildContext());
         given()
                 .contentType(ContentType.JSON)
@@ -80,7 +80,7 @@ public class JITDMNResourceTest {
     }
 
     @Test
-    public void testjitdmnWithExtensionElements() {
+    void testjitdmnWithExtensionElements() {
         Map<String, Object> context = new HashMap<>();
         context.put("m", 1);
         context.put("n", 2);

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/MultipleModelsTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/MultipleModelsTest.java
@@ -96,7 +96,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testForm() {
+    void testForm() {
         given()
                 .contentType(ContentType.JSON)
                 .body(new MultipleResourcesPayload(URI1, List.of(model1, model2)))
@@ -107,7 +107,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testSchema() {
+    void testSchema() {
         given()
                 .contentType(ContentType.JSON)
                 .body(new MultipleResourcesPayload(URI1, List.of(model1, model2)))
@@ -118,7 +118,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testjitEndpoint() {
+    void testjitEndpoint() {
         JITDMNPayload jitdmnpayload = new JITDMNPayload(URI1, List.of(model1, model2), buildContext());
         given()
                 .contentType(ContentType.JSON)
@@ -134,7 +134,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testjitdmnResultEndpoint() {
+    void testjitdmnResultEndpoint() {
         JITDMNPayload jitdmnpayload = new JITDMNPayload(URI1, List.of(model1, model2), buildContext());
         given()
                 .contentType(ContentType.JSON)
@@ -146,7 +146,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testValidation() throws IOException {
+    void testValidation() throws IOException {
         String response = given()
                 .contentType(ContentType.JSON)
                 .body(new MultipleResourcesPayload(URI1, List.of(model1, model2)))
@@ -164,7 +164,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testjitExplainabilityEndpoint() {
+    void testjitExplainabilityEndpoint() {
         JITDMNPayload jitdmnpayload = new JITDMNPayload(XAIURI1, List.of(xaimodel1, model1, model2), Map.of("FICO Score", 800, "DTI Ratio", .1, "PITI Ratio", .1));
         given()
                 .contentType(ContentType.JSON)
@@ -176,7 +176,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testjitEndpointCH11() {
+    void testjitEndpointCH11() {
         JITDMNPayload jitdmnpayload = new JITDMNPayload(CH11URI1, List.of(ch11model1, ch11model2), buildCH11Context());
         given()
                 .contentType(ContentType.JSON)
@@ -188,7 +188,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testjitdmnResultEndpointCH11() {
+    void testjitdmnResultEndpointCH11() {
         JITDMNPayload jitdmnpayload = new JITDMNPayload(CH11URI1, List.of(ch11model1, ch11model2), buildCH11Context());
         given()
                 .contentType(ContentType.JSON)
@@ -219,7 +219,7 @@ public class MultipleModelsTest {
     }
 
     @Test
-    public void testjitdmnResultEndpointCH11_withErrors() throws Exception {
+    void testjitdmnResultEndpointCH11_withErrors() throws Exception {
         Map<String, Object> context = new HashMap<>(); // will omit `Applicant data` intentionally.
         context.put("Bureau data", Map.of("Bankrupt", false,
                 "CreditScore", 600));

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/SchemaResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/SchemaResourceTest.java
@@ -28,7 +28,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
 @QuarkusTest
-class SchemaResourceTest {
+public class SchemaResourceTest {
 
     @Test
     void test() throws IOException {

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/SchemaResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/SchemaResourceTest.java
@@ -28,10 +28,10 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
 @QuarkusTest
-public class SchemaResourceTest {
+class SchemaResourceTest {
 
     @Test
-    public void test() throws IOException {
+    void test() throws IOException {
         final String MODEL = new String(IoUtils.readBytesFromInputStream(JITDMNResourceTest.class.getResourceAsStream("/test.dmn")));
         given()
                 .contentType(ContentType.XML)

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/ValidatorResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/ValidatorResourceTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-class ValidatorResourceTest {
+public class ValidatorResourceTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ValidatorResourceTest.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/ValidatorResourceTest.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/api/ValidatorResourceTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-public class ValidatorResourceTest {
+class ValidatorResourceTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(ValidatorResourceTest.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -51,7 +51,7 @@ public class ValidatorResourceTest {
                     JITDMNMessage.class);
 
     @Test
-    public void test() throws IOException {
+    void test() throws IOException {
         final String MODEL = new String(IoUtils.readBytesFromInputStream(JITDMNResourceTest.class.getResourceAsStream("/loan.dmn")));
         String response = given()
                 .contentType(ContentType.XML)
@@ -72,7 +72,7 @@ public class ValidatorResourceTest {
     }
 
     @Test
-    public void testOverlap() throws IOException {
+    void testOverlap() throws IOException {
         final String MODEL = new String(IoUtils.readBytesFromInputStream(JITDMNResourceTest.class.getResourceAsStream("/loan_withOverlap.dmn")));
         String response = given()
                 .contentType(ContentType.XML)

--- a/kogito-quarkus-serverless-workflow-devui-parent/kogito-quarkus-serverless-workflow-devui/src/test/java/org/kie/kogito/swf/tools/custom/dashboard/impl/CustomDashboardStorageTest.java
+++ b/kogito-quarkus-serverless-workflow-devui-parent/kogito-quarkus-serverless-workflow-devui/src/test/java/org/kie/kogito/swf/tools/custom/dashboard/impl/CustomDashboardStorageTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class CustomDashboardStorageTest {
+class CustomDashboardStorageTest {
 
     private static String[] DASHBOARD_NAMES = { "age.dash.yaml", "products.dash.yaml" };
     private static String DASHBOARD_NAME = "age.dash.yaml";
@@ -48,7 +48,7 @@ public class CustomDashboardStorageTest {
     }
 
     @Test
-    public void testGetFormInfoList() {
+    void testGetFormInfoList() {
         Collection<CustomDashboardInfo> customDashboardInfoFilterAll = customDashboardStorage.getCustomDashboardFiles(null);
         assertEquals(2, customDashboardInfoFilterAll.size());
 
@@ -65,7 +65,7 @@ public class CustomDashboardStorageTest {
     }
 
     @Test
-    public void testGetFormContent() throws IOException {
+    void testGetFormContent() throws IOException {
         String content = customDashboardStorage.getCustomDashboardFileContent(DASHBOARD_NAME);
         assertNotNull(content);
     }

--- a/kogito-quarkus-serverless-workflow-devui-parent/kogito-quarkus-serverless-workflow-devui/src/test/java/org/kie/kogito/swf/tools/dataindex/DataIndexServiceTest.java
+++ b/kogito-quarkus-serverless-workflow-devui-parent/kogito-quarkus-serverless-workflow-devui/src/test/java/org/kie/kogito/swf/tools/dataindex/DataIndexServiceTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class DataIndexServiceTest {
+class DataIndexServiceTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -53,7 +53,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testWorkflowInstancesCount() {
+    void testWorkflowInstancesCount() {
         when(dataIndexClient.query(DataIndexService.ALL_WORKFLOW_INSTANCES_IDS_QUERY)).thenReturn(WORKFLOW_INSTANCE_RESPONSE);
 
         Response response = dataIndexService.workflowInstancesCount();
@@ -62,7 +62,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testEmptyWorkflowInstancesCount() {
+    void testEmptyWorkflowInstancesCount() {
         when(dataIndexClient.query(DataIndexService.ALL_WORKFLOW_INSTANCES_IDS_QUERY)).thenReturn(EMPTY_WORKFLOW_INSTANCE_RESPONSE);
 
         Response response = dataIndexService.workflowInstancesCount();
@@ -71,7 +71,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testWorkflowInstancestCountError() {
+    void testWorkflowInstancestCountError() {
         when(dataIndexClient.query(DataIndexService.ALL_WORKFLOW_INSTANCES_IDS_QUERY)).thenReturn(ERROR_RESPONSE);
 
         Response response = dataIndexService.workflowInstancesCount();
@@ -79,7 +79,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testJobsCount() {
+    void testJobsCount() {
         when(dataIndexClient.query(DataIndexService.ALL_JOBS_IDS_QUERY)).thenReturn(JOBS_RESPONSE);
 
         Response response = dataIndexService.jobsCount();
@@ -88,7 +88,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testEmptyJobsCount() {
+    void testEmptyJobsCount() {
         when(dataIndexClient.query(DataIndexService.ALL_JOBS_IDS_QUERY)).thenReturn(EMPTY_JOBS_RESPONSE);
 
         Response response = dataIndexService.jobsCount();
@@ -97,7 +97,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testJobsCountError() {
+    void testJobsCountError() {
         when(dataIndexClient.query(DataIndexService.ALL_JOBS_IDS_QUERY)).thenReturn(ERROR_RESPONSE);
 
         Response response = dataIndexService.jobsCount();

--- a/management-console/src/test/java/org/kie/kogito/mgmt/StaticContentIT.java
+++ b/management-console/src/test/java/org/kie/kogito/mgmt/StaticContentIT.java
@@ -29,7 +29,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
-public class StaticContentIT {
+class StaticContentIT {
 
     @TestHTTPResource
     URL url;
@@ -45,7 +45,7 @@ public class StaticContentIT {
     }
 
     @Test
-    public void testIndexHtml() throws Exception {
+    void testIndexHtml() throws Exception {
         try (InputStream in = url.openStream()) {
             String contents = readStream(in);
             assertTrue(contents.contains("<title>Kogito - Management Console</title>"));

--- a/management-console/src/test/java/org/kie/kogito/mgmt/VertxRouterIT.java
+++ b/management-console/src/test/java/org/kie/kogito/mgmt/VertxRouterIT.java
@@ -22,10 +22,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import static io.restassured.RestAssured.given;
 
 @QuarkusTest
-public class VertxRouterIT {
+class VertxRouterIT {
 
     @Test
-    public void testHandlePath() {
+    void testHandlePath() {
         given().when().get("/ProcessInstances")
                 .then()
                 .statusCode(200);

--- a/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/RedisQueryFactoryTest.java
+++ b/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/RedisQueryFactoryTest.java
@@ -34,55 +34,55 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class RedisQueryFactoryTest {
+class RedisQueryFactoryTest {
 
     @Test
-    public void inFilterShouldNotBeSupported() {
+    void inFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.in("attribute", new ArrayList<>()));
     }
 
     @Test
-    public void containsFilterShouldNotBeSupported() {
+    void containsFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.contains("attribute", "value"));
     }
 
     @Test
-    public void containsAllFilterShouldNotBeSupported() {
+    void containsAllFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.containsAll("attribute", new ArrayList<>()));
     }
 
     @Test
-    public void containsAnyFilterShouldNotBeSupported() {
+    void containsAnyFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.containsAny("attribute", new ArrayList<>()));
     }
 
     @Test
-    public void isNullFilterShouldNotBeSupported() {
+    void isNullFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.isNull("attribute"));
     }
 
     @Test
-    public void notNullFilterShouldNotBeSupported() {
+    void notNullFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.notNull("attribute"));
     }
 
     @Test
-    public void andFilterShouldNotBeSupported() {
+    void andFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.and(new ArrayList<>()));
     }
 
     @Test
-    public void orFilterShouldNotBeSupported() {
+    void orFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.or(new ArrayList<>()));
     }
 
     @Test
-    public void notFilterShouldNotBeSupported() {
+    void notFilterShouldNotBeSupported() {
         testFilterShouldNotBeSupported(QueryFilterFactory.not(QueryFilterFactory.equalTo("attribute", "test")));
     }
 
     @Test
-    public void buildQueryBodyTest() {
+    void buildQueryBodyTest() {
         List<AttributeFilter<?>> filters = new ArrayList<>();
         filters.add(QueryFilterFactory.equalTo("firstAttribute", "firstValue"));
         filters.add(QueryFilterFactory.like("secondAttribute", "secondValue"));
@@ -93,7 +93,7 @@ public class RedisQueryFactoryTest {
     }
 
     @Test
-    public void addFiltersTest() {
+    void addFiltersTest() {
         List<AttributeFilter<?>> filters = new ArrayList<>();
         filters.add(QueryFilterFactory.equalTo("shouldBeIgnored", 0));
         filters.add(QueryFilterFactory.like("shouldBeIgnoredAsWell", "test"));

--- a/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/RedisQueryTest.java
+++ b/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/RedisQueryTest.java
@@ -43,16 +43,16 @@ import static org.kie.kogito.persistence.redis.TestContants.TEST_INDEX_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-public class RedisQueryTest {
+class RedisQueryTest {
 
     @Test
-    public void multipleAttributeSortingIsNotSupported() {
+    void multipleAttributeSortingIsNotSupported() {
         RedisQuery<Person> redisQuery = new RedisQuery<>(new RedisClientMock(), TEST_INDEX_NAME, Person.class);
         Assertions.assertThrows(UnsupportedOperationException.class, () -> redisQuery.sort(asList(orderBy("first", SortDirection.DESC), orderBy("second", SortDirection.ASC))));
     }
 
     @Test
-    public void executeTest() throws JsonProcessingException {
+    void executeTest() throws JsonProcessingException {
         Client client = Mockito.mock(Client.class);
 
         Person person = new Person("pippo", 20);

--- a/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/RedisStorageTest.java
+++ b/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/RedisStorageTest.java
@@ -35,7 +35,7 @@ import static org.kie.kogito.persistence.redis.Person.NAME_PROPERTY;
 import static org.kie.kogito.persistence.redis.TestContants.TEST_INDEX_NAME;
 import static org.mockito.Mockito.when;
 
-public class RedisStorageTest {
+class RedisStorageTest {
 
     RedisClientMock redisClientMock;
     RedisStorage<Person> redisStorage;
@@ -56,30 +56,30 @@ public class RedisStorageTest {
     }
 
     @Test
-    public void addObjectCreatedListenerOperationShouldThrowException() {
+    void addObjectCreatedListenerOperationShouldThrowException() {
         assertThrows(UnsupportedOperationException.class, () -> redisStorage.objectCreatedListener().subscribe().with(x -> {
         }));
     }
 
     @Test
-    public void addObjectUpdatedListenerOperationShouldThrowException() {
+    void addObjectUpdatedListenerOperationShouldThrowException() {
         assertThrows(UnsupportedOperationException.class, () -> redisStorage.objectUpdatedListener().subscribe().with(x -> {
         }));
     }
 
     @Test
-    public void addObjectRemovedListenerOperationShouldThrowException() {
+    void addObjectRemovedListenerOperationShouldThrowException() {
         assertThrows(UnsupportedOperationException.class, () -> redisStorage.objectRemovedListener().subscribe().with(x -> {
         }));
     }
 
     @Test
-    public void entrySetOperationShouldThrowException() {
+    void entrySetOperationShouldThrowException() {
         assertThrows(UnsupportedOperationException.class, redisStorage::entries);
     }
 
     @Test
-    public void indexNameIsPresentInStoredDocument() {
+    void indexNameIsPresentInStoredDocument() {
         redisStorage.put("myKey", new Person("pippo", 22));
 
         Map<String, Map<String, Object>> storage = redisClientMock.getStorage();
@@ -96,7 +96,7 @@ public class RedisStorageTest {
     }
 
     @Test
-    public void containsKeyOperationTest() {
+    void containsKeyOperationTest() {
         String key = "myKey";
         redisStorage.put(key, new Person("pippo", 22));
 
@@ -105,7 +105,7 @@ public class RedisStorageTest {
     }
 
     @Test
-    public void putAndGetOperationsTest() {
+    void putAndGetOperationsTest() {
         String key = "myKey";
         Person value = new Person("pippo", 22);
         redisStorage.put(key, value);
@@ -116,12 +116,12 @@ public class RedisStorageTest {
     }
 
     @Test
-    public void getUnexistingDocumentOperationTest() {
+    void getUnexistingDocumentOperationTest() {
         Assertions.assertNull(redisStorage.get("a_key_that_does_not_exist"));
     }
 
     @Test
-    public void removeOperationTest() {
+    void removeOperationTest() {
         String key = "myKey";
         Person value = new Person("pippo", 22);
         redisStorage.put(key, value);
@@ -134,7 +134,7 @@ public class RedisStorageTest {
     }
 
     @Test
-    public void nullIndexedValuesTest() {
+    void nullIndexedValuesTest() {
         String key = "myKey";
         Person value = new Person(null, 22);
         redisStorage.put(key, value);

--- a/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/SanitizerTest.java
+++ b/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/SanitizerTest.java
@@ -23,11 +23,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class SanitizerTest {
+class SanitizerTest {
 
     @ParameterizedTest
     @MethodSource("provideSanitizeTestCases")
-    public void sanitizeTest(String input, String expected) {
+    void sanitizeTest(String input, String expected) {
         String sanitized = (String) Sanitizer.sanitize(input);
         Assertions.assertEquals(expected, sanitized);
     }

--- a/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/index/RedisIndexManagerTest.java
+++ b/persistence-commons/persistence-commons-redis/src/test/java/org/kie/kogito/persistence/redis/index/RedisIndexManagerTest.java
@@ -33,10 +33,10 @@ import static org.kie.kogito.persistence.redis.Person.NAME_PROPERTY;
 import static org.kie.kogito.persistence.redis.TestContants.TEST_INDEX_NAME;
 import static org.mockito.Mockito.when;
 
-public class RedisIndexManagerTest {
+class RedisIndexManagerTest {
 
     @Test
-    public void createSchemaTest() {
+    void createSchemaTest() {
         RedisClientMock redisClientMock = new RedisClientMock();
         RedisClientManager redisClientManager = Mockito.mock(RedisClientManager.class);
         when(redisClientManager.getClient(TEST_INDEX_NAME)).thenReturn(redisClientMock);

--- a/persistence-commons/quarkus-postgresql-inmemory-parent/quarkus-postgresql-inmemory-deployment/src/test/java/org/kie/kogito/persistence/inmemory/postgresql/test/InmemoryPostgreSQLTest.java
+++ b/persistence-commons/quarkus-postgresql-inmemory-parent/quarkus-postgresql-inmemory-deployment/src/test/java/org/kie/kogito/persistence/inmemory/postgresql/test/InmemoryPostgreSQLTest.java
@@ -35,7 +35,7 @@ import io.vertx.mutiny.sqlclient.Tuple;
 
 import static java.util.stream.Collectors.toList;
 
-public class InmemoryPostgreSQLTest {
+class InmemoryPostgreSQLTest {
 
     // Start unit test with your extension loaded
     @RegisterExtension
@@ -48,14 +48,14 @@ public class InmemoryPostgreSQLTest {
     PgPool client;
 
     @Test
-    public void testFlyway() {
+    void testFlyway() {
         List<String> results = select(1);
         Assertions.assertEquals(1, results.size());
         Assertions.assertEquals("test1", results.get(0));
     }
 
     @Test
-    public void testCRUD() {
+    void testCRUD() {
         List<String> results;
 
         // Insert

--- a/persistence-commons/quarkus-postgresql-inmemory-parent/quarkus-postgresql-inmemory-integration-tests/src/test/java/org/kie/kogito/persistence/inmemory/postgresql/it/InmemoryPostgreSQLResourceTest.java
+++ b/persistence-commons/quarkus-postgresql-inmemory-parent/quarkus-postgresql-inmemory-integration-tests/src/test/java/org/kie/kogito/persistence/inmemory/postgresql/it/InmemoryPostgreSQLResourceTest.java
@@ -25,10 +25,10 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsNot.not;
 
 @QuarkusTest
-public class InmemoryPostgreSQLResourceTest {
+class InmemoryPostgreSQLResourceTest {
 
     @Test
-    public void testListAll() {
+    void testListAll() {
         // List all, should have all the database has initially
         given()
                 .when().get("/inmemory-postgresql")

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension/src/test/java/org/kie/kogito/runtime/tools/quarkus/extension/runtime/dataindex/DataIndexServiceTest.java
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension/src/test/java/org/kie/kogito/runtime/tools/quarkus/extension/runtime/dataindex/DataIndexServiceTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class DataIndexServiceTest {
+class DataIndexServiceTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -60,7 +60,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testProcessInstancesCount() {
+    void testProcessInstancesCount() {
         when(dataIndexClient.query(DataIndexService.ALL_PROCESS_INSTANCES_IDS_QUERY)).thenReturn(PROCESS_INSTANCE_RESPONSE);
 
         Response response = dataIndexService.processInstancesCount();
@@ -69,7 +69,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testEmptyProcessInstancesCount() {
+    void testEmptyProcessInstancesCount() {
         when(dataIndexClient.query(DataIndexService.ALL_PROCESS_INSTANCES_IDS_QUERY)).thenReturn(EMPTY_PROCESS_INSTANCE_RESPONSE);
 
         Response response = dataIndexService.processInstancesCount();
@@ -78,7 +78,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testProcessInstancestCountError() {
+    void testProcessInstancestCountError() {
         when(dataIndexClient.query(DataIndexService.ALL_PROCESS_INSTANCES_IDS_QUERY)).thenReturn(ERROR_RESPONSE);
 
         Response response = dataIndexService.processInstancesCount();
@@ -86,7 +86,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testJobsCount() {
+    void testJobsCount() {
         when(dataIndexClient.query(DataIndexService.ALL_JOBS_IDS_QUERY)).thenReturn(JOBS_RESPONSE);
 
         Response response = dataIndexService.jobsCount();
@@ -95,7 +95,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testEmptyJobsCount() {
+    void testEmptyJobsCount() {
         when(dataIndexClient.query(DataIndexService.ALL_JOBS_IDS_QUERY)).thenReturn(EMPTY_JOBS_RESPONSE);
 
         Response response = dataIndexService.jobsCount();
@@ -104,7 +104,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testJobsCountError() {
+    void testJobsCountError() {
         when(dataIndexClient.query(DataIndexService.ALL_JOBS_IDS_QUERY)).thenReturn(ERROR_RESPONSE);
 
         Response response = dataIndexService.jobsCount();
@@ -112,7 +112,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testTasksCount() {
+    void testTasksCount() {
         when(dataIndexClient.query(DataIndexService.ALL_TASKS_IDS_QUERY)).thenReturn(USER_TASK_RESPONSE);
 
         Response response = dataIndexService.tasksCount();
@@ -121,7 +121,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testEmptyTasksCount() {
+    void testEmptyTasksCount() {
         when(dataIndexClient.query(DataIndexService.ALL_TASKS_IDS_QUERY)).thenReturn(EMPTY_USER_TASK_RESPONSE);
 
         Response response = dataIndexService.tasksCount();
@@ -130,7 +130,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testTasksCountError() {
+    void testTasksCountError() {
         when(dataIndexClient.query(DataIndexService.ALL_TASKS_IDS_QUERY)).thenReturn(ERROR_RESPONSE);
 
         Response response = dataIndexService.jobsCount();
@@ -138,7 +138,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testFormsCount() {
+    void testFormsCount() {
         when(formsStorage.getFormsCount()).thenReturn(5);
 
         Response response = dataIndexService.formsCount();
@@ -147,7 +147,7 @@ public class DataIndexServiceTest {
     }
 
     @Test
-    public void testFormsCountError() {
+    void testFormsCountError() {
         when(formsStorage.getFormsCount()).thenThrow(new RuntimeException("something went wrong!"));
 
         Response response = dataIndexService.formsCount();

--- a/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension/src/test/java/org/kie/kogito/runtime/tools/quarkus/extension/runtime/forms/impl/FormsStorageImplTest.java
+++ b/runtime-tools-quarkus-extension-parent/runtime-tools-quarkus-extension/src/test/java/org/kie/kogito/runtime/tools/quarkus/extension/runtime/forms/impl/FormsStorageImplTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.kie.kogito.runtime.tools.quarkus.extension.runtime.forms.impl.FormsStorageImpl.PROJECT_FORM_STORAGE_PROP;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class FormsStorageImplTest {
+class FormsStorageImplTest {
 
     private static final String TEST_FORM_CONTENT = "<div></div>";
     private static final String STYLE1 = "style1";
@@ -68,12 +68,12 @@ public class FormsStorageImplTest {
     }
 
     @Test
-    public void testGetFormsCount() {
+    void testGetFormsCount() {
         assertEquals(2, formsStorage.getFormsCount());
     }
 
     @Test
-    public void testGetFormInfoList() {
+    void testGetFormInfoList() {
         Collection<FormInfo> formInfosAll = formsStorage.getFormInfoList(null);
         assertEquals(2, formInfosAll.size());
 
@@ -96,7 +96,7 @@ public class FormsStorageImplTest {
     }
 
     @Test
-    public void testGetFormContent() throws IOException {
+    void testGetFormContent() throws IOException {
         Form formContent = formsStorage.getFormContent(FORM_NAME);
         assertNotNull(formContent);
         FormInfo formInfo = formContent.getFormInfo();
@@ -104,19 +104,19 @@ public class FormsStorageImplTest {
     }
 
     @Test
-    public void testGetFormContentWithoutConfig() {
+    void testGetFormContentWithoutConfig() {
         assertThrows(RuntimeException.class, () -> formsStorage.getFormContent(FORM_NAME_WITH_OUT_CONFIG));
         assertThrows(RuntimeException.class, () -> formsStorage.getFormContent("ERROR"));
     }
 
     @Test
-    public void testUpdateFormContentInvalidForms() {
+    void testUpdateFormContentInvalidForms() {
         assertThrows(RuntimeException.class, () -> formsStorage.updateFormContent(FORM_NAME_WITH_OUT_CONFIG, new FormContent()));
         assertThrows(RuntimeException.class, () -> formsStorage.updateFormContent(FORM_NAME, null));
     }
 
     @Test
-    public void testUpdateValidForms() throws IOException {
+    void testUpdateValidForms() throws IOException {
         File storage = new File(System.getProperties().getProperty(PROJECT_FORM_STORAGE_PROP));
 
         File sourceFile = new File(storage.toURI().resolve(FORM_NAME + ".html"));

--- a/trusty-ui/src/test/java/org/kie/kogito/trusty/ui/StaticContentTest.java
+++ b/trusty-ui/src/test/java/org/kie/kogito/trusty/ui/StaticContentTest.java
@@ -25,17 +25,17 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
-public class StaticContentTest {
+class StaticContentTest {
 
     @Test
-    public void testIndexHtml() {
+    void testIndexHtml() {
         given().contentType(ContentType.JSON).when().get("/").then()
                 .statusCode(200)
                 .body(containsString("<title>Kogito - TrustyAI</title>"));
     }
 
     @Test
-    public void testHeaders() {
+    void testHeaders() {
         given().contentType(ContentType.JSON).when().get("/").then()
                 .statusCode(200)
                 .header(HttpHeaders.CACHE_CONTROL.toString(), "no-cache")
@@ -43,7 +43,7 @@ public class StaticContentTest {
     }
 
     @Test
-    public void testHandlePath() {
+    void testHandlePath() {
         given().when().get("/audit")
                 .then()
                 .statusCode(200);

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/CounterfactualParameterValidationIdenticalTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/CounterfactualParameterValidationIdenticalTest.java
@@ -31,73 +31,73 @@ import static org.kie.kogito.trusty.service.common.TypedValueTestUtils.buildInpu
 import static org.kie.kogito.trusty.service.common.TypedValueTestUtils.buildSearchDomainStructure;
 import static org.kie.kogito.trusty.service.common.TypedValueTestUtils.buildSearchDomainUnit;
 
-public class CounterfactualParameterValidationIdenticalTest {
+class CounterfactualParameterValidationIdenticalTest {
 
     @Test
-    public void testSearchDomains_NullNull() {
+    void testSearchDomains_NullNull() {
         assertTrue(isStructureIdentical(
                 null,
                 null));
     }
 
     @Test
-    public void testSearchDomains_EmptyEmpty() {
+    void testSearchDomains_EmptyEmpty() {
         assertTrue(isStructureIdentical(
                 Collections.emptyList(),
                 Collections.emptyList()));
     }
 
     @Test
-    public void testSearchDomains_NullEmpty() {
+    void testSearchDomains_NullEmpty() {
         assertFalse(isStructureIdentical(
                 null,
                 Collections.emptyList()));
     }
 
     @Test
-    public void testSearchDomains_EmptyNull() {
+    void testSearchDomains_EmptyNull() {
         assertFalse(isStructureIdentical(
                 Collections.emptyList(),
                 null));
     }
 
     @Test
-    public void testSearchDomains_UnitNull() {
+    void testSearchDomains_UnitNull() {
         assertFalse(isStructureIdentical(
                 List.of(buildInputUnit("age", "integer", new IntNode(18))),
                 null));
     }
 
     @Test
-    public void testSearchDomains_UnitEmpty() {
+    void testSearchDomains_UnitEmpty() {
         assertFalse(isStructureIdentical(
                 List.of(buildInputUnit("age", "integer", new IntNode(18))),
                 Collections.emptyList()));
     }
 
     @Test
-    public void testSearchDomains_NullUnit() {
+    void testSearchDomains_NullUnit() {
         assertFalse(isStructureIdentical(
                 null,
                 List.of(buildSearchDomainUnit("age", "integer", new CounterfactualDomainRange(new IntNode(18), new IntNode(65))))));
     }
 
     @Test
-    public void testSearchDomains_EmptyUnit() {
+    void testSearchDomains_EmptyUnit() {
         assertFalse(isStructureIdentical(
                 Collections.emptyList(),
                 List.of(buildSearchDomainUnit("age", "integer", new CounterfactualDomainRange(new IntNode(18), new IntNode(65))))));
     }
 
     @Test
-    public void testSearchDomains_UnitUnit() {
+    void testSearchDomains_UnitUnit() {
         assertTrue(isStructureIdentical(
                 List.of(buildInputUnit("age", "integer", new IntNode(18))),
                 List.of(buildSearchDomainUnit("age", "integer", new CounterfactualDomainRange(new IntNode(18), new IntNode(65))))));
     }
 
     @Test
-    public void testSearchDomains_UnitUnits() {
+    void testSearchDomains_UnitUnits() {
         assertFalse(isStructureIdentical(
                 List.of(buildInputUnit("age", "integer", new IntNode(18))),
                 List.of(buildSearchDomainUnit("age", "integer", new CounterfactualDomainRange(new IntNode(18), new IntNode(65))),
@@ -105,7 +105,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_UnitsUnit() {
+    void testSearchDomains_UnitsUnit() {
         assertFalse(isStructureIdentical(
                 List.of(buildInputUnit("age", "integer", new IntNode(18)),
                         buildInputUnit("salary", "integer", new IntNode(10000))),
@@ -113,7 +113,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_UnitsUnits() {
+    void testSearchDomains_UnitsUnits() {
         assertTrue(isStructureIdentical(
                 List.of(buildInputUnit("age", "integer", new IntNode(18)),
                         buildInputUnit("salary", "integer", new IntNode(10000))),
@@ -122,7 +122,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_UnitsUnits__WithDifferentOrder() {
+    void testSearchDomains_UnitsUnits__WithDifferentOrder() {
         assertTrue(isStructureIdentical(
                 List.of(buildInputUnit("salary", "integer", new IntNode(10000)),
                         buildInputUnit("age", "integer", new IntNode(18))),
@@ -131,7 +131,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_StructureUnit() {
+    void testSearchDomains_StructureUnit() {
         assertFalse(isStructureIdentical(
                 List.of(buildInputStructure("person", "tPerson",
                         List.of(buildInputUnit("age", "integer", new IntNode(18)),
@@ -140,7 +140,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_UnitStructure() {
+    void testSearchDomains_UnitStructure() {
         assertFalse(isStructureIdentical(
                 List.of(buildInputUnit("age", "integer", new IntNode(18))),
                 List.of(buildSearchDomainStructure("person", "tPerson",
@@ -149,7 +149,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_StructureStructure() {
+    void testSearchDomains_StructureStructure() {
         assertTrue(isStructureIdentical(
                 List.of(buildInputStructure("person", "tPerson",
                         List.of(buildInputUnit("age", "integer", new IntNode(18)),
@@ -160,7 +160,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_StructureStructure__WithDifferentOrder() {
+    void testSearchDomains_StructureStructure__WithDifferentOrder() {
         assertTrue(isStructureIdentical(
                 List.of(buildInputStructure("person", "tPerson",
                         List.of(buildInputUnit("salary", "integer", new IntNode(10000)),
@@ -171,7 +171,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_StructureWithStructureStructureWithStructure() {
+    void testSearchDomains_StructureWithStructureStructureWithStructure() {
         assertTrue(isStructureIdentical(
                 List.of(buildInputStructure("person", "tPerson",
                         List.of(buildInputUnit("age", "integer", new IntNode(18)),
@@ -186,7 +186,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_ComplexComplex() {
+    void testSearchDomains_ComplexComplex() {
         assertTrue(isStructureIdentical(
                 List.of(buildInputUnit("hatSize", "integer", new IntNode(16)),
                         buildInputStructure("person", "tPerson",
@@ -204,7 +204,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_ComplexComplex__WithDifferentOrder() {
+    void testSearchDomains_ComplexComplex__WithDifferentOrder() {
         assertTrue(isStructureIdentical(
                 List.of(buildInputStructure("person", "tPerson",
                         List.of(buildInputStructure("income", "tIncome",
@@ -222,7 +222,7 @@ public class CounterfactualParameterValidationIdenticalTest {
     }
 
     @Test
-    public void testSearchDomains_ComplexComplex__WithDifferentOrder_WithDifference() {
+    void testSearchDomains_ComplexComplex__WithDifferentOrder_WithDifference() {
         assertFalse(isStructureIdentical(
                 List.of(buildInputStructure("person", "tPerson",
                         List.of(buildInputStructure("income", "tIncome",

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/CounterfactualParameterValidationSubsetTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/CounterfactualParameterValidationSubsetTest.java
@@ -33,73 +33,73 @@ import static org.kie.kogito.trusty.service.common.TypedValueTestUtils.buildGoal
 import static org.kie.kogito.trusty.service.common.TypedValueTestUtils.buildOutcomeStructure;
 import static org.kie.kogito.trusty.service.common.TypedValueTestUtils.buildOutcomeUnit;
 
-public class CounterfactualParameterValidationSubsetTest {
+class CounterfactualParameterValidationSubsetTest {
 
     @Test
-    public void testGoals_NullNull() {
+    void testGoals_NullNull() {
         assertTrue(isStructureSubset(
                 null,
                 null));
     }
 
     @Test
-    public void testGoals_EmptyEmpty() {
+    void testGoals_EmptyEmpty() {
         assertTrue(isStructureSubset(
                 Collections.emptyList(),
                 Collections.emptyList()));
     }
 
     @Test
-    public void testGoals_NullEmpty() {
+    void testGoals_NullEmpty() {
         assertFalse(isStructureSubset(
                 null,
                 Collections.emptyList()));
     }
 
     @Test
-    public void testGoals_EmptyNull() {
+    void testGoals_EmptyNull() {
         assertFalse(isStructureSubset(
                 Collections.emptyList(),
                 null));
     }
 
     @Test
-    public void testGoals_UnitNull() {
+    void testGoals_UnitNull() {
         assertFalse(isStructureSubset(
                 List.of(buildOutcomeUnit("age", "integer", new IntNode(18))),
                 null));
     }
 
     @Test
-    public void testGoals_UnitEmpty() {
+    void testGoals_UnitEmpty() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeUnit("age", "integer", new IntNode(18))),
                 Collections.emptyList()));
     }
 
     @Test
-    public void testGoals_NullUnit() {
+    void testGoals_NullUnit() {
         assertFalse(isStructureSubset(
                 null,
                 List.of(buildGoalUnit("age", "integer", new IntNode(18)))));
     }
 
     @Test
-    public void testGoals_EmptyUnit() {
+    void testGoals_EmptyUnit() {
         assertFalse(isStructureSubset(
                 Collections.emptyList(),
                 List.of(buildGoalUnit("age", "integer", new IntNode(18)))));
     }
 
     @Test
-    public void testGoals_UnitUnit() {
+    void testGoals_UnitUnit() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeUnit("age", "integer", new IntNode(18))),
                 List.of(buildGoalUnit("age", "integer", new IntNode(18)))));
     }
 
     @Test
-    public void testGoals_UnitUnits() {
+    void testGoals_UnitUnits() {
         assertFalse(isStructureSubset(
                 List.of(buildOutcomeUnit("age", "integer", new IntNode(18))),
                 List.of(buildGoalUnit("age", "integer", new IntNode(18)),
@@ -107,7 +107,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_UnitsUnit() {
+    void testGoals_UnitsUnit() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeUnit("age", "integer", new IntNode(18)),
                         buildOutcomeUnit("salary", "integer", new IntNode(10000))),
@@ -115,7 +115,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_UnitsUnits() {
+    void testGoals_UnitsUnits() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeUnit("age", "integer", new IntNode(18)),
                         buildOutcomeUnit("salary", "integer", new IntNode(10000))),
@@ -124,7 +124,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_UnitsUnits__WithDifferentOrder() {
+    void testGoals_UnitsUnits__WithDifferentOrder() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeUnit("salary", "integer", new IntNode(10000)),
                         buildOutcomeUnit("age", "integer", new IntNode(18))),
@@ -133,7 +133,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_StructureUnit() {
+    void testGoals_StructureUnit() {
         assertFalse(isStructureSubset(
                 List.of(buildOutcomeStructure("person", "tPerson",
                         Map.of("age", new UnitValue("integer", "integer", new IntNode(18)),
@@ -142,7 +142,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_UnitStructure() {
+    void testGoals_UnitStructure() {
         assertFalse(isStructureSubset(
                 List.of(buildOutcomeUnit("age", "integer", new IntNode(18))),
                 List.of(buildGoalStructure("person", "tPerson",
@@ -151,7 +151,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_StructureStructure() {
+    void testGoals_StructureStructure() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeStructure("person", "tPerson",
                         Map.of("age", new UnitValue("integer", "integer", new IntNode(18)),
@@ -162,7 +162,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_StructureStructureSubset() {
+    void testGoals_StructureStructureSubset() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeStructure("person", "tPerson",
                         Map.of("age", new UnitValue("integer", "integer", new IntNode(18)),
@@ -172,7 +172,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_StructureStructure__WithDifferentOrder() {
+    void testGoals_StructureStructure__WithDifferentOrder() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeStructure("person", "tPerson",
                         Map.of("salary", new UnitValue("integer", "integer", new IntNode(10000)),
@@ -183,7 +183,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_StructureWithStructureStructureWithStructure() {
+    void testGoals_StructureWithStructureStructureWithStructure() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeStructure("person", "tPerson",
                         Map.of("age", new UnitValue("integer", "integer", new IntNode(18)),
@@ -198,7 +198,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_ComplexComplex() {
+    void testGoals_ComplexComplex() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeUnit("hatSize", "integer", new IntNode(16)),
                         buildOutcomeStructure("person", "tPerson",
@@ -215,7 +215,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_ComplexComplex__WithDifferentOrder() {
+    void testGoals_ComplexComplex__WithDifferentOrder() {
         assertTrue(isStructureSubset(
                 List.of(buildOutcomeStructure("person", "tPerson",
                         Map.of("income", new StructureValue("tIncome",
@@ -232,7 +232,7 @@ public class CounterfactualParameterValidationSubsetTest {
     }
 
     @Test
-    public void testGoals_ComplexComplex__WithDifferentOrder_WithDifference() {
+    void testGoals_ComplexComplex__WithDifferentOrder_WithDifference() {
         assertFalse(isStructureSubset(
                 List.of(buildOutcomeStructure("person", "tPerson",
                         Map.of("income", new StructureValue("tIncome",

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/TrustyServiceTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/TrustyServiceTest.java
@@ -83,7 +83,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class TrustyServiceTest {
+class TrustyServiceTest {
 
     private static final String TEST_EXECUTION_ID = UUID.randomUUID().toString();
     private static final String TEST_COUNTERFACTUAL_ID = UUID.randomUUID().toString();

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/api/ExplainabilityApiV1Test.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/api/ExplainabilityApiV1Test.java
@@ -73,7 +73,7 @@ public class ExplainabilityApiV1Test {
     }
 
     @Test
-    public void testRequestCounterfactualsWhenExecutionDoesNotExist() {
+    void testRequestCounterfactualsWhenExecutionDoesNotExist() {
         when(trustyService.requestCounterfactuals(anyString(), any(), any())).thenThrow(new IllegalArgumentException());
 
         org.kie.kogito.trusty.service.common.requests.CounterfactualRequest request =
@@ -85,7 +85,7 @@ public class ExplainabilityApiV1Test {
     }
 
     @Test
-    public void testRequestCounterfactualsWhenExecutionDoesExist() {
+    void testRequestCounterfactualsWhenExecutionDoesExist() {
         when(trustyService.requestCounterfactuals(anyString(), any(), any())).thenReturn(new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 new ModelIdentifier("resourceType", "resourceIdentifier"),
@@ -111,7 +111,7 @@ public class ExplainabilityApiV1Test {
     }
 
     @Test
-    public void testGetAllCounterfactualsWhenExecutionDoesNotExist() {
+    void testGetAllCounterfactualsWhenExecutionDoesNotExist() {
         when(trustyService.getCounterfactualRequests(anyString())).thenThrow(new IllegalArgumentException());
 
         Response response = explainabilityEndpoint.getAllCounterfactualsSummary(EXECUTION_ID);
@@ -121,7 +121,7 @@ public class ExplainabilityApiV1Test {
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void testGetAllCounterfactualsWhenExecutionDoesExist() {
+    void testGetAllCounterfactualsWhenExecutionDoesExist() {
         when(trustyService.getCounterfactualRequests(anyString())).thenReturn(List.of(new CounterfactualExplainabilityRequest(EXECUTION_ID,
                 SERVICE_URL,
                 new ModelIdentifier("resourceType", "resourceIdentifier"),
@@ -147,7 +147,7 @@ public class ExplainabilityApiV1Test {
     }
 
     @Test
-    public void testGetCounterfactualResultsWhenExecutionDoesNotExist() {
+    void testGetCounterfactualResultsWhenExecutionDoesNotExist() {
         when(trustyService.getCounterfactualRequest(anyString(), anyString())).thenThrow(new IllegalArgumentException());
 
         Response response = explainabilityEndpoint.getCounterfactualDetails(EXECUTION_ID, COUNTERFACTUAL_ID);
@@ -156,7 +156,7 @@ public class ExplainabilityApiV1Test {
     }
 
     @Test
-    public void testGetCounterfactualResultsWhenExecutionDoesExist() {
+    void testGetCounterfactualResultsWhenExecutionDoesExist() {
         NamedTypedValue goal = buildGoalUnit("unit",
                 "string",
                 new TextNode("hello"));
@@ -192,7 +192,7 @@ public class ExplainabilityApiV1Test {
     }
 
     @Test
-    public void testGetCounterfactualResultsWhenExecutionDoesExistAndResultsHaveBeenCreated() {
+    void testGetCounterfactualResultsWhenExecutionDoesExistAndResultsHaveBeenCreated() {
         NamedTypedValue goal = buildGoalUnit("unit",
                 "string",
                 new TextNode("hello"));

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/CounterfactualExplainabilityResultsManagerDuplicatesTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/CounterfactualExplainabilityResultsManagerDuplicatesTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class CounterfactualExplainabilityResultsManagerDuplicatesTest {
+class CounterfactualExplainabilityResultsManagerDuplicatesTest {
 
     private static final String EXECUTION_ID = "executionId";
 
@@ -64,7 +64,7 @@ public class CounterfactualExplainabilityResultsManagerDuplicatesTest {
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsSmallerThanMinimum() {
+    void testPurgeWhenResultSetSizeIsSmallerThanMinimum() {
         when(query.execute()).thenReturn(Collections.emptyList());
 
         manager.purge(COUNTERFACTUAL_ID, storage);
@@ -73,7 +73,7 @@ public class CounterfactualExplainabilityResultsManagerDuplicatesTest {
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithDuplicateInputs() {
+    void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithDuplicateInputs() {
         CounterfactualExplainabilityResult result0 = makeResult(0, Collections.emptyList(), Collections.emptyList());
         CounterfactualExplainabilityResult result1 = makeResult(1, Collections.emptyList(), Collections.emptyList());
         CounterfactualExplainabilityResult result2 = makeResult(2, List.of(makeCounterfactualInput("a")), Collections.emptyList());
@@ -87,7 +87,7 @@ public class CounterfactualExplainabilityResultsManagerDuplicatesTest {
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithDuplicateInputs_FinalLast() {
+    void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithDuplicateInputs_FinalLast() {
         CounterfactualExplainabilityResult result0 = makeResult(0, Collections.emptyList(), Collections.emptyList());
         CounterfactualExplainabilityResult result1 = makeResult(1, Collections.emptyList(), Collections.emptyList());
         CounterfactualExplainabilityResult result2 = makeResult(2, List.of(makeCounterfactualInput("a")), Collections.emptyList());
@@ -101,7 +101,7 @@ public class CounterfactualExplainabilityResultsManagerDuplicatesTest {
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithDuplicateInputs_FinalPenultimate() {
+    void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithDuplicateInputs_FinalPenultimate() {
         CounterfactualExplainabilityResult result0 = makeResult(0, Collections.emptyList(), Collections.emptyList());
         CounterfactualExplainabilityResult result1 = makeResult(1, Collections.emptyList(), Collections.emptyList());
         CounterfactualExplainabilityResult result2 = makeResult(2, CounterfactualExplainabilityResult.Stage.FINAL, List.of(makeCounterfactualInput("a")), Collections.emptyList());
@@ -115,7 +115,7 @@ public class CounterfactualExplainabilityResultsManagerDuplicatesTest {
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithoutDuplicateInputs() {
+    void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithoutDuplicateInputs() {
         CounterfactualExplainabilityResult result0 = makeResult(0, List.of(makeCounterfactualInput("0")), Collections.emptyList());
         CounterfactualExplainabilityResult result1 = makeResult(1, List.of(makeCounterfactualInput("1")), Collections.emptyList());
         CounterfactualExplainabilityResult result2 = makeResult(2, List.of(makeCounterfactualInput("2")), Collections.emptyList());
@@ -128,7 +128,7 @@ public class CounterfactualExplainabilityResultsManagerDuplicatesTest {
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithDuplicateOutputs() {
+    void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithDuplicateOutputs() {
         CounterfactualExplainabilityResult result0 = makeResult(0, Collections.emptyList(), Collections.emptyList());
         CounterfactualExplainabilityResult result1 = makeResult(1, Collections.emptyList(), Collections.emptyList());
         CounterfactualExplainabilityResult result2 = makeResult(2, Collections.emptyList(), List.of(makeCounterfactualOutput("a")));
@@ -142,7 +142,7 @@ public class CounterfactualExplainabilityResultsManagerDuplicatesTest {
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithoutDuplicateOutputs() {
+    void testPurgeWhenResultSetSizeIsGreaterThanMinimum_WithoutDuplicateOutputs() {
         CounterfactualExplainabilityResult result0 = makeResult(0, Collections.emptyList(), List.of(makeCounterfactualOutput("0")));
         CounterfactualExplainabilityResult result1 = makeResult(1, Collections.emptyList(), List.of(makeCounterfactualOutput("1")));
         CounterfactualExplainabilityResult result2 = makeResult(2, Collections.emptyList(), List.of(makeCounterfactualOutput("2")));

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/CounterfactualExplainabilityResultsManagerSlidingWindowTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/CounterfactualExplainabilityResultsManagerSlidingWindowTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class CounterfactualExplainabilityResultsManagerSlidingWindowTest {
+class CounterfactualExplainabilityResultsManagerSlidingWindowTest {
 
     private static final String EXECUTION_ID = "executionId";
 
@@ -62,17 +62,17 @@ public class CounterfactualExplainabilityResultsManagerSlidingWindowTest {
     }
 
     @Test
-    public void testInstantiationWithInvalidWindowSizeOfZero() {
+    void testInstantiationWithInvalidWindowSizeOfZero() {
         assertThrows(IllegalArgumentException.class, () -> new CounterfactualExplainabilityResultsManagerSlidingWindow(0));
     }
 
     @Test
-    public void testInstantiationWithInvalidWindowSizeNegative() {
+    void testInstantiationWithInvalidWindowSizeNegative() {
         assertThrows(IllegalArgumentException.class, () -> new CounterfactualExplainabilityResultsManagerSlidingWindow(-1));
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsSmallerThanWindowSize() {
+    void testPurgeWhenResultSetSizeIsSmallerThanWindowSize() {
         when(query.execute()).thenReturn(Collections.emptyList());
 
         manager.purge(COUNTERFACTUAL_ID, storage);
@@ -81,7 +81,7 @@ public class CounterfactualExplainabilityResultsManagerSlidingWindowTest {
     }
 
     @Test
-    public void testPurgeWhenResultSetSizeIsGreaterThanWindowSize() {
+    void testPurgeWhenResultSetSizeIsGreaterThanWindowSize() {
         CounterfactualExplainabilityResult result0 = makeResult(0);
         CounterfactualExplainabilityResult result1 = makeResult(1);
         CounterfactualExplainabilityResult result2 = makeResult(2);

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/CounterfactualExplainerServiceHandlerTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/CounterfactualExplainerServiceHandlerTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class CounterfactualExplainerServiceHandlerTest
+class CounterfactualExplainerServiceHandlerTest
         extends BaseExplainerServiceHandlerTest<CounterfactualExplainerServiceHandler, CounterfactualExplainabilityResult> {
 
     private static final String COUNTERFACTUAL_ID = "counterfactualId";
@@ -85,7 +85,7 @@ public class CounterfactualExplainerServiceHandlerTest
     }
 
     @Test
-    public void testGetExplainabilityResultById_WhenMultipleStored() {
+    void testGetExplainabilityResultById_WhenMultipleStored() {
         CounterfactualExplainabilityResult intermediate = mock(CounterfactualExplainabilityResult.class);
         when(intermediate.getExecutionId()).thenReturn(EXECUTION_ID);
         when(intermediate.getSolutionId()).thenReturn(SOLUTION_ID);
@@ -97,7 +97,7 @@ public class CounterfactualExplainerServiceHandlerTest
     }
 
     @Test
-    public void testGetExplainabilityResultById_WhenOnlyIntermediateStored() {
+    void testGetExplainabilityResultById_WhenOnlyIntermediateStored() {
         CounterfactualExplainabilityResult intermediate = mock(CounterfactualExplainabilityResult.class);
         when(intermediate.getExecutionId()).thenReturn(EXECUTION_ID);
         when(intermediate.getSolutionId()).thenReturn(SOLUTION_ID);

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/ExplainerServiceHandlerRegistryTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/ExplainerServiceHandlerRegistryTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ExplainerServiceHandlerRegistryTest {
+class ExplainerServiceHandlerRegistryTest {
 
     private static final String EXECUTION_ID = "executionId";
 
@@ -75,7 +75,7 @@ public class ExplainerServiceHandlerRegistryTest {
     }
 
     @Test
-    public void testLIME_getExplainabilityResultById() {
+    void testLIME_getExplainabilityResultById() {
         when(storageLIME.containsKey(eq(EXECUTION_ID))).thenReturn(true);
 
         registry.getExplainabilityResultById(EXECUTION_ID, LIMEExplainabilityResult.class);
@@ -84,7 +84,7 @@ public class ExplainerServiceHandlerRegistryTest {
     }
 
     @Test
-    public void testLIME_storeExplainabilityResult() {
+    void testLIME_storeExplainabilityResult() {
         when(storageLIME.containsKey(eq(EXECUTION_ID))).thenReturn(false);
         LIMEExplainabilityResult result = mock(LIMEExplainabilityResult.class);
 
@@ -95,7 +95,7 @@ public class ExplainerServiceHandlerRegistryTest {
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void testCounterfactual_getExplainabilityResultByIdWithFinalResult() {
+    void testCounterfactual_getExplainabilityResultByIdWithFinalResult() {
         Query query = mock(Query.class);
         CounterfactualExplainabilityResult result = mock(CounterfactualExplainabilityResult.class);
         when(result.getStage()).thenReturn(CounterfactualExplainabilityResult.Stage.FINAL);
@@ -112,7 +112,7 @@ public class ExplainerServiceHandlerRegistryTest {
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void testCounterfactual_getExplainabilityResultByIdWithOnlyIntermediateResults() {
+    void testCounterfactual_getExplainabilityResultByIdWithOnlyIntermediateResults() {
         Query query = mock(Query.class);
         CounterfactualExplainabilityResult result = mock(CounterfactualExplainabilityResult.class);
         when(result.getStage()).thenReturn(CounterfactualExplainabilityResult.Stage.INTERMEDIATE);
@@ -126,7 +126,7 @@ public class ExplainerServiceHandlerRegistryTest {
 
     @Test
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void testCounterfactual_getExplainabilityResultByIdWithAllResults() {
+    void testCounterfactual_getExplainabilityResultByIdWithAllResults() {
         Query query = mock(Query.class);
         CounterfactualExplainabilityResult result1 = mock(CounterfactualExplainabilityResult.class);
         CounterfactualExplainabilityResult result2 = mock(CounterfactualExplainabilityResult.class);
@@ -144,7 +144,7 @@ public class ExplainerServiceHandlerRegistryTest {
     }
 
     @Test
-    public void testCounterfactual_storeExplainabilityResult() {
+    void testCounterfactual_storeExplainabilityResult() {
         when(storageCounterfactual.containsKey(eq(EXECUTION_ID))).thenReturn(false);
         CounterfactualExplainabilityResult result = mock(CounterfactualExplainabilityResult.class);
 

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/LIMESaliencyConverterTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/handlers/LIMESaliencyConverterTest.java
@@ -46,7 +46,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class LIMESaliencyConverterTest {
+class LIMESaliencyConverterTest {
 
     private static final String EXECUTION_ID = "executionId";
 
@@ -61,7 +61,7 @@ public class LIMESaliencyConverterTest {
     }
 
     @Test
-    public void testFromResult_DecisionExists() {
+    void testFromResult_DecisionExists() {
         LIMEExplainabilityResult result = LIMEExplainabilityResult.buildSucceeded(EXECUTION_ID,
                 List.of(new SaliencyModel("outcomeName1",
                         List.of(new FeatureImportanceModel("feature1a", 1.0),
@@ -124,7 +124,7 @@ public class LIMESaliencyConverterTest {
     }
 
     @Test
-    public void testFromResult_DecisionExists_WhenOutcomeNameNotFound() {
+    void testFromResult_DecisionExists_WhenOutcomeNameNotFound() {
         LIMEExplainabilityResult result = LIMEExplainabilityResult.buildSucceeded(EXECUTION_ID,
                 List.of(new SaliencyModel("outcomeName1",
                         List.of(new FeatureImportanceModel("feature1", 1.0))),
@@ -174,7 +174,7 @@ public class LIMESaliencyConverterTest {
     }
 
     @Test
-    public void testFromResult_DecisionNotExists() {
+    void testFromResult_DecisionNotExists() {
         LIMEExplainabilityResult result = LIMEExplainabilityResult.buildSucceeded(EXECUTION_ID,
                 List.of(new SaliencyModel("outcomeName1",
                         List.of(new FeatureImportanceModel("feature1a", 1.0),

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/messaging/incoming/DMNModelMetadataIdentifierTest.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/messaging/incoming/DMNModelMetadataIdentifierTest.java
@@ -25,7 +25,7 @@ import org.kie.kogito.trusty.storage.api.model.decision.DMNModelMetadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class DMNModelMetadataIdentifierTest {
+class DMNModelMetadataIdentifierTest {
 
     private static Stream<Arguments> provideParametersForModelIdCreator() {
         return Stream.of(

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/messaging/incoming/ExplainabilityResultConsumerIT.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/messaging/incoming/ExplainabilityResultConsumerIT.java
@@ -78,7 +78,7 @@ public class ExplainabilityResultConsumerIT {
     }
 
     @Test
-    public void explainabilityResultIsProcessedAndStored() {
+    void explainabilityResultIsProcessedAndStored() {
         String executionId = "executionId";
 
         doNothing().when(trustyService).storeExplainabilityResult(eq(executionId), any(BaseExplainabilityResult.class));

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/messaging/incoming/ModelEventConsumerIT.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/messaging/incoming/ModelEventConsumerIT.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.verify;
 
 @QuarkusTest
 @QuarkusTestResource(KafkaQuarkusTestResource.class)
-public class ModelEventConsumerIT {
+class ModelEventConsumerIT {
 
     @QuarkusTestProperty(name = KafkaQuarkusTestResource.KOGITO_KAFKA_PROPERTY)
     String kafkaBootstrapServers;
@@ -60,7 +60,7 @@ public class ModelEventConsumerIT {
     }
 
     @Test
-    public void eventLoopIsNotStoppedWithException() {
+    void eventLoopIsNotStoppedWithException() {
         doThrow(new RuntimeException("Something really bad"))
                 .when(trustyService)
                 .storeModel(any(DMNModelWithMetadata.class));

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/messaging/incoming/TraceEventConsumerIT.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/messaging/incoming/TraceEventConsumerIT.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verify;
 
 @QuarkusTest
 @QuarkusTestResource(KafkaQuarkusTestResource.class)
-public class TraceEventConsumerIT {
+class TraceEventConsumerIT {
 
     @InjectMock
     TrustyService trustyService;
@@ -62,7 +62,7 @@ public class TraceEventConsumerIT {
     }
 
     @Test
-    public void eventLoopIsNotStoppedWithException() {
+    void eventLoopIsNotStoppedWithException() {
         String executionIdException = "idException";
         String executionIdNoException = "idNoException";
         doThrow(new RuntimeException("Something really bad")).when(trustyService).processDecision(eq(executionIdException), any(Decision.class));

--- a/trusty/trusty-service/trusty-service-infinispan/src/test/java/org/kie/kogito/trusty/service/infinispan/NativeInfinispanTrustyServiceIT.java
+++ b/trusty/trusty-service/trusty-service-infinispan/src/test/java/org/kie/kogito/trusty/service/infinispan/NativeInfinispanTrustyServiceIT.java
@@ -26,10 +26,10 @@ import static org.hamcrest.CoreMatchers.is;
 
 @NativeImageTest
 @QuarkusTestResource(InfinispanQuarkusTestResource.class)
-public class NativeInfinispanTrustyServiceIT {
+class NativeInfinispanTrustyServiceIT {
 
     @Test
-    public void testImageGeneration() {
+    void testImageGeneration() {
         given()
                 .when().get("/q/health/live")
                 .then()

--- a/trusty/trusty-storage/trusty-storage-api/src/test/java/org/kie/kogito/trusty/storage/api/model/CounterfactualDomainSerialisationTest.java
+++ b/trusty/trusty-storage/trusty-storage-api/src/test/java/org/kie/kogito/trusty/storage/api/model/CounterfactualDomainSerialisationTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class CounterfactualDomainSerialisationTest {
+class CounterfactualDomainSerialisationTest {
 
     private ObjectMapper mapper;
     private StringWriter writer;
@@ -45,7 +45,7 @@ public class CounterfactualDomainSerialisationTest {
     }
 
     @Test
-    public void testCounterfactualSearchDomain_Range_RoundTrip() throws Exception {
+    void testCounterfactualSearchDomain_Range_RoundTrip() throws Exception {
         CounterfactualDomainRange domainRange = new CounterfactualDomainRange(new IntNode(18), new IntNode(65));
         CounterfactualSearchDomain searchDomain = new CounterfactualSearchDomain("age",
                 new CounterfactualSearchDomainUnitValue("integer",
@@ -73,7 +73,7 @@ public class CounterfactualDomainSerialisationTest {
     }
 
     @Test
-    public void testCounterfactualSearchDomain_Categorical_RoundTrip() throws Exception {
+    void testCounterfactualSearchDomain_Categorical_RoundTrip() throws Exception {
         CounterfactualDomainCategorical domainCategorical = new CounterfactualDomainCategorical(List.of(new TextNode("A"), new TextNode("B")));
         CounterfactualSearchDomain searchDomain = new CounterfactualSearchDomain("age",
                 new CounterfactualSearchDomainUnitValue("integer",

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/CounterfactualExplainabilityRequestMarshallerTest.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/CounterfactualExplainabilityRequestMarshallerTest.java
@@ -32,10 +32,10 @@ import org.kie.kogito.tracing.typedvalue.UnitValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
-public class CounterfactualExplainabilityRequestMarshallerTest extends MarshallerTestTemplate {
+class CounterfactualExplainabilityRequestMarshallerTest extends MarshallerTestTemplate {
 
     @Test
-    public void testWriteAndRead() throws IOException {
+    void testWriteAndRead() throws IOException {
         ModelIdentifier modelIdentifier = new ModelIdentifier("resourceType", "resourceId");
         List<NamedTypedValue> originalInputs = Collections.singletonList(new NamedTypedValue("unitIn",
                 new UnitValue("number",

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/CounterfactualExplainabilityResultMarshallerTest.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/CounterfactualExplainabilityResultMarshallerTest.java
@@ -28,10 +28,10 @@ import org.kie.kogito.tracing.typedvalue.UnitValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
-public class CounterfactualExplainabilityResultMarshallerTest extends MarshallerTestTemplate {
+class CounterfactualExplainabilityResultMarshallerTest extends MarshallerTestTemplate {
 
     @Test
-    public void testWriteAndRead() throws IOException {
+    void testWriteAndRead() throws IOException {
         List<NamedTypedValue> inputs = List.of(new NamedTypedValue("unitIn",
                 new UnitValue("number",
                         "number",

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/DMNModelWithMetadataMarshallerTest.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/DMNModelWithMetadataMarshallerTest.java
@@ -24,10 +24,10 @@ import org.kie.kogito.trusty.storage.api.model.decision.DMNModelWithMetadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class DMNModelWithMetadataMarshallerTest extends MarshallerTestTemplate {
+class DMNModelWithMetadataMarshallerTest extends MarshallerTestTemplate {
 
     @Test
-    public void testWriteAndRead() throws IOException {
+    void testWriteAndRead() throws IOException {
 
         DMNModelWithMetadata dmnModelWithMetadata = new DMNModelWithMetadata("groupId", "artifactId", "version",
                 "dmnVersion", "name", "namespace",

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/DecisionMarshallerTest.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/DecisionMarshallerTest.java
@@ -32,10 +32,10 @@ import org.kie.kogito.trusty.storage.api.model.decision.DecisionOutcome;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
-public class DecisionMarshallerTest extends MarshallerTestTemplate {
+class DecisionMarshallerTest extends MarshallerTestTemplate {
 
     @Test
-    public void testWriteAndRead() throws IOException {
+    void testWriteAndRead() throws IOException {
         List<DecisionInput> inputs = Collections.singletonList(new DecisionInput("id", "in", new UnitValue("nameIn", "number", JsonNodeFactory.instance.numberNode(10))));
         List<DecisionOutcome> outcomes = Collections.singletonList(new DecisionOutcome("id", "out",
                 DMNDecisionResult.DecisionEvaluationStatus.SUCCEEDED.toString(),

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/InfinispanStorageExceptionsProviderImplTest.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/InfinispanStorageExceptionsProviderImplTest.java
@@ -19,9 +19,9 @@ import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class InfinispanStorageExceptionsProviderImplTest {
+class InfinispanStorageExceptionsProviderImplTest {
     @Test
-    public void testConnectionExceptions() {
+    void testConnectionExceptions() {
         InfinispanStorageExceptionsProviderImpl redisStorageExceptionsProvider = new InfinispanStorageExceptionsProviderImpl();
         Assertions.assertTrue(redisStorageExceptionsProvider.isConnectionException(new HotRodClientException("I'm a connection exception")));
         Assertions.assertFalse(redisStorageExceptionsProvider.isConnectionException(new RuntimeException("I'm not a connection exception")));

--- a/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/LIMEExplainabilityResultMarshallerTest.java
+++ b/trusty/trusty-storage/trusty-storage-infinispan/src/test/java/org/kie/kogito/trusty/storage/infinispan/LIMEExplainabilityResultMarshallerTest.java
@@ -28,10 +28,10 @@ import org.kie.kogito.explainability.api.SaliencyModel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class LIMEExplainabilityResultMarshallerTest extends MarshallerTestTemplate {
+class LIMEExplainabilityResultMarshallerTest extends MarshallerTestTemplate {
 
     @Test
-    public void testWriteAndRead() throws IOException {
+    void testWriteAndRead() throws IOException {
 
         List<FeatureImportanceModel> featureImportanceModels = Collections.singletonList(new FeatureImportanceModel("aFeature", 0d));
         List<SaliencyModel> saliencyModels = Collections.singletonList(new SaliencyModel("outcomeName", featureImportanceModels));

--- a/trusty/trusty-storage/trusty-storage-postgresql/src/test/java/org/kie/kogito/trusty/storage/postgresql/BaseTransactionalStorageTest.java
+++ b/trusty/trusty-storage/trusty-storage-postgresql/src/test/java/org/kie/kogito/trusty/storage/postgresql/BaseTransactionalStorageTest.java
@@ -46,67 +46,67 @@ public class BaseTransactionalStorageTest {
     }
 
     @Test
-    public void testObjectCreatedListener() {
+    void testObjectCreatedListener() {
         storage.objectCreatedListener();
         verify(delegate).objectCreatedListener();
     }
 
     @Test
-    public void testObjectUpdatedListener() {
+    void testObjectUpdatedListener() {
         storage.objectUpdatedListener();
         verify(delegate).objectUpdatedListener();
     }
 
     @Test
-    public void testObjectRemovedListener() {
+    void testObjectRemovedListener() {
         storage.objectRemovedListener();
         verify(delegate).objectRemovedListener();
     }
 
     @Test
-    public void testQuery() {
+    void testQuery() {
         storage.query();
         verify(delegate).query();
     }
 
     @Test
-    public void testGet() {
+    void testGet() {
         storage.get(KEY);
         verify(delegate).get(KEY);
     }
 
     @Test
-    public void testPut() {
+    void testPut() {
         storage.put(KEY, VALUE);
         verify(delegate).put(KEY, VALUE);
     }
 
     @Test
-    public void testRemove() {
+    void testRemove() {
         storage.remove(KEY);
         verify(delegate).remove(KEY);
     }
 
     @Test
-    public void testContainsKey() {
+    void testContainsKey() {
         storage.containsKey(KEY);
         verify(delegate).containsKey(KEY);
     }
 
     @Test
-    public void testEntries() {
+    void testEntries() {
         storage.entries();
         verify(delegate).entries();
     }
 
     @Test
-    public void testClear() {
+    void testClear() {
         storage.clear();
         verify(delegate).clear();
     }
 
     @Test
-    public void testGetRootType() {
+    void testGetRootType() {
         storage.getRootType();
         verify(delegate).getRootType();
     }

--- a/trusty/trusty-storage/trusty-storage-postgresql/src/test/java/org/kie/kogito/trusty/storage/postgresql/PostgresStorageServiceTest.java
+++ b/trusty/trusty-storage/trusty-storage-postgresql/src/test/java/org/kie/kogito/trusty/storage/postgresql/PostgresStorageServiceTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-public class PostgresStorageServiceTest {
+class PostgresStorageServiceTest {
 
     private DecisionsStorage decisionsStorage;
     private LIMEResultsStorage limeResultsStorage;

--- a/trusty/trusty-storage/trusty-storage-redis/src/test/java/org/kie/kogito/trusty/storage/redis/IndexProviderTest.java
+++ b/trusty/trusty-storage/trusty-storage-redis/src/test/java/org/kie/kogito/trusty/storage/redis/IndexProviderTest.java
@@ -27,10 +27,10 @@ import static org.kie.kogito.trusty.storage.common.TrustyStorageService.DECISION
 import static org.kie.kogito.trusty.storage.common.TrustyStorageService.LIME_RESULTS_STORAGE;
 import static org.kie.kogito.trusty.storage.common.TrustyStorageService.MODELS_STORAGE;
 
-public class IndexProviderTest {
+class IndexProviderTest {
 
     @Test
-    public void indexesAreCreated() {
+    void indexesAreCreated() {
         RedisIndexManagerMock redisIndexManager = new RedisIndexManagerMock(Mockito.mock(RedisClientManager.class));
         IndexProvider indexProvider = new IndexProvider(redisIndexManager);
 

--- a/trusty/trusty-storage/trusty-storage-redis/src/test/java/org/kie/kogito/trusty/storage/redis/RedisStorageExceptionsProviderImplTest.java
+++ b/trusty/trusty-storage/trusty-storage-redis/src/test/java/org/kie/kogito/trusty/storage/redis/RedisStorageExceptionsProviderImplTest.java
@@ -21,9 +21,9 @@ import org.junit.jupiter.api.Test;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisExhaustedPoolException;
 
-public class RedisStorageExceptionsProviderImplTest {
+class RedisStorageExceptionsProviderImplTest {
     @Test
-    public void testConnectionExceptions() {
+    void testConnectionExceptions() {
         RedisStorageExceptionsProviderImpl redisStorageExceptionsProvider = new RedisStorageExceptionsProviderImpl();
         Assertions.assertTrue(redisStorageExceptionsProvider.isConnectionException(new JedisConnectionException("I'm a connection exception")));
         Assertions.assertTrue(redisStorageExceptionsProvider.isConnectionException(new JedisExhaustedPoolException("I'm a connection exception")));


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7918

Goal here is to reduce the number of code smells in Kogito-apps.

Addressed in this PR is the code smell, "JUnit5 test classes and methods should have default package visibility." I have remedied this by removing the public modifier and using the recommended default package visibility.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

 <b>Jenkins retest this</b>
 
</details>
