### PR TITLE
Kogito-7930 Sonarcloud - Fixing code smells related to simplifying and ordering Assertj assertions

### DIFF
--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/api/KogitoRuntimeClientTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/api/KogitoRuntimeClientTest.java
@@ -538,7 +538,7 @@ public class KogitoRuntimeClientTest {
 
         when(identityMock.getCredential(TokenCredential.class)).thenReturn(null);
         token = client.getAuthHeader();
-        assertThat(token).isEqualTo("");
+        assertThat(token).isEmpty();
     }
 
     private AsyncResult createResponseMocks(HttpResponse response, boolean succeed, int statusCode) {

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/JsonPropertyDataFetcherTest.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/graphql/JsonPropertyDataFetcherTest.java
@@ -51,15 +51,15 @@ public class JsonPropertyDataFetcherTest {
         JsonNode arraysJson = getArraysNodeJson();
         assertThat(((ArrayNode) jsonPropertyDataFetcher.get(getMockEnv("addressArray", arraysJson))).size()).isEqualTo(2);
         List stringArray = ((List) jsonPropertyDataFetcher.get(getMockEnv("stringArray", arraysJson)));
-        assertThat(stringArray.size()).isEqualTo(2);
+        assertThat(stringArray).hasSize(2);
         assertThat(stringArray.get(0)).isEqualTo("st1");
         assertThat(stringArray.get(1)).isEqualTo("st2");
         List numberArray = ((List) jsonPropertyDataFetcher.get(getMockEnv("numberArray", arraysJson)));
-        assertThat(numberArray.size()).isEqualTo(2);
+        assertThat(numberArray).hasSize(2);
         assertThat(numberArray.get(0)).isEqualTo(8);
         assertThat(numberArray.get(1)).isEqualTo(98.6);
         List booleanArray = ((List) jsonPropertyDataFetcher.get(getMockEnv("booleanArray", arraysJson)));
-        assertThat(booleanArray.size()).isEqualTo(2);
+        assertThat(booleanArray).hasSize(2);
         assertThat(booleanArray.get(0)).isEqualTo(true);
         assertThat(booleanArray.get(1)).isEqualTo(false);
     }

--- a/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/repository/impl/BaseJobRepositoryTest.java
+++ b/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/repository/impl/BaseJobRepositoryTest.java
@@ -97,7 +97,7 @@ public abstract class BaseJobRepositoryTest {
     @Test
     void testFindAll() throws ExecutionException, InterruptedException {
         List<JobDetails> jobs = tested().findAll().toList().run().toCompletableFuture().get();
-        assertThat(jobs.size()).isEqualTo(1);
+        assertThat(jobs).hasSize(1);
         assertThat(jobs.get(0)).isEqualTo(job);
     }
 
@@ -123,7 +123,7 @@ public abstract class BaseJobRepositoryTest {
                 .toCompletableFuture()
                 .get();
 
-        assertThat(fetched.size()).isEqualTo(5);
+        assertThat(fetched).hasSize(5);
 
         IntStream.rangeClosed(0, 4).forEach(
                 i -> assertThat(fetched.get(i)).isEqualTo(jobs.get(fetched.size() - 1 - i)));
@@ -137,7 +137,7 @@ public abstract class BaseJobRepositoryTest {
                 .toCompletableFuture()
                 .get();
 
-        assertThat(fetchedNotFound.size()).isZero();
+        assertThat(fetchedNotFound).isEmpty();
 
         fetchedNotFound = tested().findByStatusBetweenDatesOrderByPriority(DateUtil.now().plusDays(1),
                 DateUtil.now().plusDays(2),
@@ -147,7 +147,7 @@ public abstract class BaseJobRepositoryTest {
                 .toCompletableFuture()
                 .get();
 
-        assertThat(fetchedNotFound.size()).isZero();
+        assertThat(fetchedNotFound).isEmpty();
     }
 
     @Test

--- a/persistence-commons/persistence-commons-infinispan/src/test/java/org/kie/kogito/persistence/infinispan/cache/InfinispanStorageIT.java
+++ b/persistence-commons/persistence-commons-infinispan/src/test/java/org/kie/kogito/persistence/infinispan/cache/InfinispanStorageIT.java
@@ -82,7 +82,7 @@ class InfinispanStorageIT {
         String value = "testValue";
         storage.put(key, value);
 
-        assertThat(cache.get(key)).isEqualTo(value);
+        assertThat(cache).containsEntry(key, value);
     }
 
     @Test
@@ -91,7 +91,7 @@ class InfinispanStorageIT {
         String value = "testValue";
         cache.put(key, value);
         storage.clear();
-        assertThat(cache.size()).isZero();
+        assertThat(cache).isEmpty();
     }
 
     @Test
@@ -100,7 +100,7 @@ class InfinispanStorageIT {
         String value = "testValue";
         cache.put(key, value);
         storage.remove(key);
-        assertThat(cache.size()).isZero();
+        assertThat(cache).isEmpty();
     }
 
     @Test

--- a/persistence-commons/persistence-commons-oracle/src/test/java/org/kie/kogito/persistence/oracle/OracleStorageServiceIT.java
+++ b/persistence-commons/persistence-commons-oracle/src/test/java/org/kie/kogito/persistence/oracle/OracleStorageServiceIT.java
@@ -190,7 +190,7 @@ class OracleStorageServiceIT {
         cache.remove(key);
 
         assertThat(cache.containsKey(key)).isFalse();
-        assertThat(cache.entries()).hasSize(0);
+        assertThat(cache.entries()).isEmpty();
 
         entity = repository.findById(new CacheId(cacheName, key));
 
@@ -231,7 +231,7 @@ class OracleStorageServiceIT {
         cache.remove(key);
 
         assertThat(cache.containsKey(key)).isFalse();
-        assertThat(cache.entries()).hasSize(0);
+        assertThat(cache.entries()).isEmpty();
 
         entity = repository.findById(new CacheId(cacheName, key));
 

--- a/persistence-commons/persistence-commons-postgresql/src/test/java/org/kie/kogito/persistence/postgresql/PostgresStorageServiceIT.java
+++ b/persistence-commons/persistence-commons-postgresql/src/test/java/org/kie/kogito/persistence/postgresql/PostgresStorageServiceIT.java
@@ -190,7 +190,7 @@ class PostgresStorageServiceIT {
         cache.remove(key);
 
         assertThat(cache.containsKey(key)).isFalse();
-        assertThat(cache.entries()).hasSize(0);
+        assertThat(cache.entries()).isEmpty();
 
         entity = repository.findById(new CacheId(cacheName, key));
 
@@ -231,7 +231,7 @@ class PostgresStorageServiceIT {
         cache.remove(key);
 
         assertThat(cache.containsKey(key)).isFalse();
-        assertThat(cache.entries()).hasSize(0);
+        assertThat(cache.entries()).isEmpty();
 
         entity = repository.findById(new CacheId(cacheName, key));
 

--- a/task-assigning/task-assigning-core/src/test/java/org/kie/kogito/taskassigning/core/model/solver/TaskHelperTest.java
+++ b/task-assigning/task-assigning-core/src/test/java/org/kie/kogito/taskassigning/core/model/solver/TaskHelperTest.java
@@ -183,7 +183,7 @@ class TaskHelperTest {
     void extractTasks() {
         ChainElement chainElement = buildChainElement();
         List<TaskAssignment> result = TaskHelper.extractTaskAssignments(chainElement);
-        assertThat(result.size()).isEqualTo(4);
+        assertThat(result).hasSize(4);
         assertThat(result.get(0).getId()).isEqualTo(TASK_ID_1);
         assertThat(result.get(1).getId()).isEqualTo(TASK_ID_2);
         assertThat(result.get(2).getId()).isEqualTo(TASK_ID_3);
@@ -194,7 +194,7 @@ class TaskHelperTest {
     void extractTasksFiltered() {
         ChainElement chainElement = buildChainElement();
         List<TaskAssignment> result = TaskHelper.extractTaskAssignments(chainElement, testedTask -> testedTask.getId().equals(TASK_ID_1) || testedTask.getId().equals(TASK_ID_4));
-        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).hasSize(2);
         assertThat(result.get(0).getId()).isEqualTo(TASK_ID_1);
         assertThat(result.get(1).getId()).isEqualTo(TASK_ID_4);
     }

--- a/task-assigning/task-assigning-core/src/test/java/org/kie/kogito/taskassigning/core/model/solver/realtime/RemoveUserProblemFactChangeTest.java
+++ b/task-assigning/task-assigning-core/src/test/java/org/kie/kogito/taskassigning/core/model/solver/realtime/RemoveUserProblemFactChangeTest.java
@@ -102,7 +102,7 @@ class RemoveUserProblemFactChangeTest {
 
         verify(scoreDirector).beforeProblemFactRemoved(workingUser);
         verify(scoreDirector).afterProblemFactRemoved(workingUser);
-        assertThat(workingSolution.getUserList().size()).isEqualTo(originalUsersSize - 1);
+        assertThat(workingSolution.getUserList()).hasSize(originalUsersSize - 1);
         assertThat(workingSolution.getUserList()).contains(user2, user3);
         assertThat(workingSolution.getUserList()).doesNotContain(workingUser);
     }
@@ -116,7 +116,7 @@ class RemoveUserProblemFactChangeTest {
         verify(scoreDirector, never()).afterProblemPropertyChanged(any());
         verify(scoreDirector, never()).beforeProblemFactRemoved(any());
         verify(scoreDirector, never()).afterProblemFactRemoved(any());
-        assertThat(workingSolution.getUserList().size()).isEqualTo(2);
+        assertThat(workingSolution.getUserList()).hasSize(2);
         assertThat(workingSolution.getUserList()).contains(user2, user3);
         verify(scoreDirector, never()).triggerVariableListeners();
     }

--- a/task-assigning/task-assigning-core/src/test/java/org/kie/kogito/taskassigning/core/model/solver/realtime/executable/AbstractExecutableProblemFactChangeTest.java
+++ b/task-assigning/task-assigning-core/src/test/java/org/kie/kogito/taskassigning/core/model/solver/realtime/executable/AbstractExecutableProblemFactChangeTest.java
@@ -149,8 +149,8 @@ abstract class AbstractExecutableProblemFactChangeTest extends AbstractTaskAssig
 
         solver.solve(solution);
 
-        assertThat(programmedChanges.isEmpty()).isTrue();
-        assertThat(scheduledChanges.size()).isEqualTo(totalProgrammedChanges);
+        assertThat(programmedChanges).isEmpty();
+        assertThat(scheduledChanges).hasSize(totalProgrammedChanges);
         assertThat(pendingChanges[0]).isZero();
         return initialSolution[0];
     }

--- a/task-assigning/task-assigning-service/src/test/java/org/kie/kogito/taskassigning/service/SolutionBuilderTest.java
+++ b/task-assigning/task-assigning-service/src/test/java/org/kie/kogito/taskassigning/service/SolutionBuilderTest.java
@@ -137,9 +137,9 @@ class SolutionBuilderTest {
             assignments.add(nextElement);
             nextElement = nextElement.getNextElement();
         }
-        assertThat(assignments.size())
+        assertThat(assignments)
                 .withFailMessage("User %s must have %s task assignments, but have %s", userId, expectedTasks, assignments.size())
-                .isEqualTo(expectedTasks);
+                .hasSize(expectedTasks);
         TaskAssignment taskAssignment = assignments.get(expectedTaskPosition);
         assertThat(taskAssignment.getId())
                 .withFailMessage("User %s must have the task %s at the position %s", userId, expectedTask, expectedTaskPosition)

--- a/task-assigning/task-assigning-service/src/test/java/org/kie/kogito/taskassigning/service/TaskServiceConnectorTest.java
+++ b/task-assigning/task-assigning-service/src/test/java/org/kie/kogito/taskassigning/service/TaskServiceConnectorTest.java
@@ -102,7 +102,7 @@ class TaskServiceConnectorTest {
 
         TaskServiceConnector connector = new TaskServiceConnector(config, clientServices);
         List<UserTaskInstance> result = connector.findAllTasks(Collections.singletonList(READY.value()), 3);
-        assertThat(result.size()).isEqualTo(8);
+        assertThat(result).hasSize(8);
         List<String> expectedTasks = Arrays.asList(TASK1, TASK2, TASK4, TASK5, TASK6, TASK7, TASK8, TASK9);
         assertThat(expectedTasks).isEqualTo(result.stream().map(UserTaskInstance::getId).collect(Collectors.toList()));
     }

--- a/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/api/ExplainabilityApiV1IT.java
+++ b/trusty/trusty-service/trusty-service-common/src/test/java/org/kie/kogito/trusty/service/common/api/ExplainabilityApiV1IT.java
@@ -237,8 +237,8 @@ class ExplainabilityApiV1IT {
         assertNotNull(response);
         assertNotNull(response.getExecutionId());
         assertNotNull(response.getCounterfactualId());
-        assertEquals(response.getExecutionId(), TEST_EXECUTION_ID);
-        assertEquals(response.getCounterfactualId(), TEST_COUNTERFACTUAL_ID);
+        assertEquals(TEST_EXECUTION_ID, response.getExecutionId());
+        assertEquals(TEST_COUNTERFACTUAL_ID, response.getCounterfactualId());
 
         verify(executionService).requestCounterfactuals(eq(TEST_EXECUTION_ID), goalsCaptor.capture(), searchDomainsCaptor.capture());
         List<NamedTypedValue> goalsParameter = goalsCaptor.getValue();
@@ -311,8 +311,8 @@ class ExplainabilityApiV1IT {
         assertNotNull(response);
         assertNotNull(response.getExecutionId());
         assertNotNull(response.getCounterfactualId());
-        assertEquals(response.getExecutionId(), TEST_EXECUTION_ID);
-        assertEquals(response.getCounterfactualId(), TEST_COUNTERFACTUAL_ID);
+        assertEquals(TEST_EXECUTION_ID, response.getExecutionId());
+        assertEquals(TEST_COUNTERFACTUAL_ID, response.getCounterfactualId());
 
         verify(executionService).requestCounterfactuals(eq(TEST_EXECUTION_ID), goalsCaptor.capture(), searchDomainsCaptor.capture());
         List<NamedTypedValue> goalsParameter = goalsCaptor.getValue();
@@ -409,8 +409,8 @@ class ExplainabilityApiV1IT {
         assertNotNull(resultsResponse);
         assertNotNull(resultsResponse.getExecutionId());
         assertNotNull(resultsResponse.getCounterfactualId());
-        assertEquals(resultsResponse.getExecutionId(), TEST_EXECUTION_ID);
-        assertEquals(resultsResponse.getCounterfactualId(), TEST_COUNTERFACTUAL_ID);
+        assertEquals(TEST_EXECUTION_ID, resultsResponse.getExecutionId());
+        assertEquals(TEST_COUNTERFACTUAL_ID, resultsResponse.getCounterfactualId());
         assertEquals(2, resultsResponse.getSolutions().size());
     }
 
@@ -437,8 +437,8 @@ class ExplainabilityApiV1IT {
         assertNotNull(resultsResponse);
         assertNotNull(resultsResponse.getExecutionId());
         assertNotNull(resultsResponse.getCounterfactualId());
-        assertEquals(resultsResponse.getExecutionId(), TEST_EXECUTION_ID);
-        assertEquals(resultsResponse.getCounterfactualId(), TEST_COUNTERFACTUAL_ID);
+        assertEquals(TEST_EXECUTION_ID, resultsResponse.getExecutionId());
+        assertEquals(TEST_COUNTERFACTUAL_ID, resultsResponse.getCounterfactualId());
         assertTrue(resultsResponse.getSolutions().isEmpty());
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7930

Goal here is to reduce the number of code smells in Kogito-apps.

Addressed in this PR are the code smells, "Chained AssertJ assertions should be simplified to the corresponding dedicated assertion." And "Assertion arguments should be passed in the correct order." 

I have remedied the first set of code smells by simplifying the assertions to dedicated assertions.

I have remedied the second set of code smells by swapping the assertions from "expected value" followed by "actual value", to "actual value" followed by "expected value."

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

<b>Jenkins retest this</b>

</details>
