### PR TITLE
[KOGITO-7857] Updating dependencies to use kogito-event-core

### DIFF
--- a/data-index/data-index-service/data-index-service-common/pom.xml
+++ b/data-index/data-index-service/data-index-service-common/pom.xml
@@ -19,7 +19,7 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-events-api</artifactId>
+      <artifactId>kogito-events-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/explainability/explainability-service-messaging/pom.xml
+++ b/explainability/explainability-service-messaging/pom.xml
@@ -27,7 +27,7 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-events-api</artifactId>
+      <artifactId>kogito-events-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/jobs-service/jobs-service-common/pom.xml
+++ b/jobs-service/jobs-service-common/pom.xml
@@ -108,7 +108,7 @@
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-events-api</artifactId>
+      <artifactId>kogito-events-core</artifactId>
     </dependency>
 
     <!-- Health Check -->

--- a/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-api/pom.xml
+++ b/persistence-commons/persistence-commons-reporting-parent/persistence-commons-reporting-api/pom.xml
@@ -32,7 +32,7 @@
     <!-- Use the same JSON ObjectMapper that is set-up and configured centrally -->
     <dependency>
       <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-events-api</artifactId>
+      <artifactId>kogito-events-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Changing dependencies from kogito-events-api to kogito-events-core
Depends on https://github.com/kiegroup/kogito-runtimes/pull/2505

