### PR TITLE
KOGITO-8064: Update Dashbuilder version in Kogito Apps

### DIFF
--- a/ui-packages/package.json
+++ b/ui-packages/package.json
@@ -60,7 +60,7 @@
     "@babel/core": "^7.14.0",
     "@babel/preset-env": "^7.14.1",
     "@babel/preset-react": "^7.13.13",
-    "@dashbuilder-js/dashbuilder-client": "^0.20.0",
+    "@kie-tools/dashbuilder-client": "^0.23.0",
     "@fortawesome/fontawesome-free": "^5.10.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.22",
     "@fortawesome/free-solid-svg-icons": "^5.10.2",

--- a/ui-packages/packages/custom-dashboard-view/package.json
+++ b/ui-packages/packages/custom-dashboard-view/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "precommit": "lint-staged",
-    "copy:dashbuilder": "mkdir -p dist/dashbuilder && cp -r ../../node_modules/@dashbuilder-js/dashbuilder-client/dist/* dist/dashbuilder && cp src/dashbuilder/setup.js dist/dashbuilder",
+    "copy:dashbuilder": "mkdir -p dist/dashbuilder && cp -r ../../node_modules/@kie-tools/dashbuilder-client/dist/* dist/dashbuilder && cp src/dashbuilder/setup.js dist/dashbuilder",
     "copy:css": "copyfiles -u 1 \"src/**/*.{sass,scss,css,svg,png}\" dist/",
     "build": "rimraf dist  && tsc -m commonjs -p tsconfig.json && yarn run copy:dashbuilder && yarn run copy:css ",
     "build:prod": "yarn run build",

--- a/ui-packages/packages/monitoring-webapp/package.json
+++ b/ui-packages/packages/monitoring-webapp/package.json
@@ -13,7 +13,7 @@
   },
 
   "scripts": {
-    "copy:dashbuilder": "copyfiles -u 6 \"../../node_modules/@dashbuilder-js/dashbuilder-client/dist/**/*\" ./dist/ && copyfiles -u 1 src/* ./dist/",
+    "copy:dashbuilder": "copyfiles -u 6 \"../../node_modules/@kie-tools/dashbuilder-client/dist/**/*\" ./dist/ && copyfiles -u 1 src/* ./dist/",
     "build": "rimraf dist && yarn run copy:dashbuilder",
     "build:prod": "yarn run build"
   },

--- a/ui-packages/yarn.lock
+++ b/ui-packages/yarn.lock
@@ -2167,11 +2167,6 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dashbuilder-js/dashbuilder-client@^0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@dashbuilder-js/dashbuilder-client/-/dashbuilder-client-0.20.0.tgz#e0c1caf2f021700447fda9df93d480095832ae82"
-  integrity sha512-dhNGi1/dMm9yh6y/zU5s0Qv8gHyiyg7fp6RSqKm3efAhVd9JCh+jqOuBM/N5lLJNDNo/KctUgOh23E6f5Xujhg==
-
 "@discoveryjs/json-ext@^0.5.0", "@discoveryjs/json-ext@^0.5.3":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
@@ -3028,6 +3023,11 @@
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
+
+"@kie-tools/dashbuilder-client@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@kie-tools/dashbuilder-client/-/dashbuilder-client-0.23.0.tgz#241f410012b1070179c8270c919fcaacac061fe5"
+  integrity sha512-2KrpkU5d/MyvI/wmZ8ABCQDihwZSrDixETiy4WHet1t+Tlyw9INuR742hFw4tz0Jkn2RS2GsF47iZJ+TrfH3Nw==
 
 "@kogito-apps/management-console@file:packages/management-console":
   version "1.0.0"


### PR DESCRIPTION
Updating Dashbuilder Version to use the latest version from the official Kie-tools package 