### PR TITLE
Automated pull request backporting workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -80,3 +80,19 @@ How to retest this PR or trigger a specific build:
   Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] mandrel-lts</b>
  
 </details>
+
+<details>
+<summary>
+How to backport a pull request to a different branch?
+</summary>
+
+In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).
+
+> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.
+
+Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.
+
+If something goes wrong, the author will be notified and at this point a manual backporting is needed.
+
+> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
+</details>

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -1,0 +1,43 @@
+name: Pull Request Backporting
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  compute-targets:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    outputs:
+      target-branches: ${{ steps.set-targets.outputs.targets }}
+    env:
+      LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+    steps:
+      - name: Set target branches
+        id: set-targets
+        uses: kiegroup/kogito-pipelines/.ci/actions/parse-labels@main
+        with:
+          labels: ${LABELS}
+  
+  backporting:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged && needs.compute-targets.outputs.target-branches != '[]' }}
+    name: "[${{ matrix.target-branch }}] - Backporting"
+    runs-on: ubuntu-latest
+    needs: compute-targets
+    strategy:
+      matrix: 
+        target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
+      fail-fast: true
+    env:
+      REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+    steps:
+      - name: Backporting
+        uses: kiegroup/kogito-pipelines/.ci/actions/backporting@main
+        with:
+          target-branch: ${{ matrix.target-branch }}
+          additional-reviewers: ${REVIEWERS}


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

**JIRA**: 

https://issues.redhat.com/browse/BXMSPROD-1892

**referenced Pull Requests**:

* https://github.com/kiegroup/kogito-pipelines/pull/743

Added GitHub workflow to automate pull request backporting:
* create backporting pull requests whenever a pull request (having one or more labels `backport-<branch>`) is successfully merged.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-lts</b>
 
- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] native</b>

- for <b>mandrel checks</b>  
  Run native checks against Mandrel image
  Please add comment: <b>Jenkins run mandrel</b>

- for a <b>specific mandrel check</b>  
  Run native checks against Mandrel image  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] mandrel</b>

- for <b>mandrel lts checks</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins run mandrel-lts</b>

- for a <b>specific mandrel lts check</b>  
  Run native checks against Mandrel image and quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] mandrel-lts</b>
 
</details>
