### PR TITLE
KOGITO-7766 - Remove Jobs from addons GraphQL schema

### DIFF
--- a/data-index/data-index-common/src/main/java/org/kie/kogito/index/graphql/AbstractGraphQLSchemaManager.java
+++ b/data-index/data-index-common/src/main/java/org/kie/kogito/index/graphql/AbstractGraphQLSchemaManager.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 import org.kie.kogito.index.DataIndexStorageService;
 import org.kie.kogito.index.graphql.query.GraphQLQueryOrderByParser;
 import org.kie.kogito.index.graphql.query.GraphQLQueryParserRegistry;
-import org.kie.kogito.index.model.Job;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.kie.kogito.index.model.UserTaskInstance;
 import org.kie.kogito.persistence.api.Storage;
@@ -66,8 +65,7 @@ public abstract class AbstractGraphQLSchemaManager implements GraphQLSchemaManag
         schema = createSchema();
         GraphQLQueryParserRegistry.get().registerParsers(
                 (GraphQLInputObjectType) schema.getType("ProcessInstanceArgument"),
-                (GraphQLInputObjectType) schema.getType("UserTaskInstanceArgument"),
-                (GraphQLInputObjectType) schema.getType("JobArgument"));
+                (GraphQLInputObjectType) schema.getType("UserTaskInstanceArgument"));
     }
 
     protected TypeDefinitionRegistry loadSchemaDefinitionFile(String fileName) {
@@ -129,10 +127,6 @@ public abstract class AbstractGraphQLSchemaManager implements GraphQLSchemaManag
 
     protected Collection<ProcessInstance> getProcessInstancesValues(DataFetchingEnvironment env) {
         return executeAdvancedQueryForCache(cacheService.getProcessInstancesCache(), env);
-    }
-
-    protected Collection<Job> getJobsValues(DataFetchingEnvironment env) {
-        return executeAdvancedQueryForCache(cacheService.getJobsCache(), env);
     }
 
     protected <T> List<T> executeAdvancedQueryForCache(Storage<String, T> cache, DataFetchingEnvironment env) {

--- a/data-index/data-index-common/src/main/resources/basic.schema.graphqls
+++ b/data-index/data-index-common/src/main/resources/basic.schema.graphqls
@@ -7,7 +7,6 @@ schema {
 type Query {
     ProcessInstances(where: ProcessInstanceArgument, orderBy: ProcessInstanceOrderBy, pagination: Pagination): [ProcessInstance]
     UserTaskInstances(where: UserTaskInstanceArgument, orderBy: UserTaskInstanceOrderBy, pagination: Pagination):  [UserTaskInstance]
-    Jobs(where: JobArgument, orderBy: JobOrderBy, pagination: Pagination):  [Job]
 }
 
 type ProcessInstance {
@@ -295,65 +294,4 @@ enum OrderBy {
 input Pagination {
     limit: Int
     offset: Int
-}
-
-type Job {
-    id: String!
-    processId: String
-    processInstanceId: String
-    nodeInstanceId: String
-    rootProcessInstanceId: String
-    rootProcessId: String
-    status: JobStatus!
-    expirationTime: DateTime
-    priority: Int
-    callbackEndpoint: String
-    repeatInterval: Int
-    repeatLimit: Int
-    scheduledId: String
-    retries: Int
-    lastUpdate: DateTime
-    executionCounter: Int
-    endpoint: String
-}
-
-enum JobStatus {
-    ERROR,
-    EXECUTED,
-    SCHEDULED,
-    RETRY,
-    CANCELED
-}
-
-input JobStatusArgument {
-    equal: JobStatus
-    in: [JobStatus]
-}
-
-input JobArgument {
-    and: [JobArgument!]
-    or: [JobArgument!]
-    not: JobArgument
-    id: IdArgument
-    processId: StringArgument
-    processInstanceId: IdArgument
-    nodeInstanceId: IdArgument
-    rootProcessInstanceId: IdArgument
-    rootProcessId: StringArgument
-    status: JobStatusArgument
-    expirationTime: DateArgument
-    priority: NumericArgument
-    scheduledId: IdArgument
-    lastUpdate: DateArgument
-}
-
-input JobOrderBy {
-    processId: OrderBy
-    rootProcessId: OrderBy
-    status: OrderBy
-    expirationTime: OrderBy
-    priority: OrderBy
-    retries: OrderBy
-    lastUpdate: OrderBy
-    executionCounter: OrderBy
 }

--- a/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/graphql/GraphQLSchemaManagerImpl.java
+++ b/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/graphql/GraphQLSchemaManagerImpl.java
@@ -78,7 +78,9 @@ public class GraphQLSchemaManagerImpl extends AbstractGraphQLSchemaManager {
     @PostConstruct
     public void setup() {
         super.setup();
-        GraphQLQueryParserRegistry.get().registerParsers((GraphQLInputObjectType) getGraphQLSchema().getType("KogitoMetadataArgument"));
+        GraphQLQueryParserRegistry.get().registerParsers(
+                (GraphQLInputObjectType) getGraphQLSchema().getType("KogitoMetadataArgument"),
+                (GraphQLInputObjectType) getGraphQLSchema().getType("JobArgument"));
     }
 
     @Override
@@ -307,6 +309,10 @@ public class GraphQLSchemaManagerImpl extends AbstractGraphQLSchemaManager {
                 env.getArgument(USER),
                 env.getArgument(GROUPS),
                 env.getArgument(ATTACHMENT_ID));
+    }
+
+    protected Collection<Job> getJobsValues(DataFetchingEnvironment env) {
+        return executeAdvancedQueryForCache(cacheService.getJobsCache(), env);
     }
 
     private DataFetcher<Publisher<ObjectNode>> getProcessInstanceAddedDataFetcher() {

--- a/data-index/data-index-service/data-index-service-common/src/main/resources/domain.schema.graphqls
+++ b/data-index/data-index-service/data-index-service-common/src/main/resources/domain.schema.graphqls
@@ -3,6 +3,10 @@ extend schema {
     mutation: Mutation
 }
 
+extend type Query {
+    Jobs(where: JobArgument, orderBy: JobOrderBy, pagination: Pagination):  [Job]
+}
+
 type Mutation {
     ProcessInstanceAbort(id: String): String
     ProcessInstanceRetry(id: String): String
@@ -136,4 +140,65 @@ type Subscription {
     UserTaskInstanceUpdated: UserTaskInstance!
     JobAdded: Job!
     JobUpdated: Job!
+}
+
+type Job {
+    id: String!
+    processId: String
+    processInstanceId: String
+    nodeInstanceId: String
+    rootProcessInstanceId: String
+    rootProcessId: String
+    status: JobStatus!
+    expirationTime: DateTime
+    priority: Int
+    callbackEndpoint: String
+    repeatInterval: Int
+    repeatLimit: Int
+    scheduledId: String
+    retries: Int
+    lastUpdate: DateTime
+    executionCounter: Int
+    endpoint: String
+}
+
+enum JobStatus {
+    ERROR,
+    EXECUTED,
+    SCHEDULED,
+    RETRY,
+    CANCELED
+}
+
+input JobStatusArgument {
+    equal: JobStatus
+    in: [JobStatus]
+}
+
+input JobArgument {
+    and: [JobArgument!]
+    or: [JobArgument!]
+    not: JobArgument
+    id: IdArgument
+    processId: StringArgument
+    processInstanceId: IdArgument
+    nodeInstanceId: IdArgument
+    rootProcessInstanceId: IdArgument
+    rootProcessId: StringArgument
+    status: JobStatusArgument
+    expirationTime: DateArgument
+    priority: NumericArgument
+    scheduledId: IdArgument
+    lastUpdate: DateArgument
+}
+
+input JobOrderBy {
+    processId: OrderBy
+    rootProcessId: OrderBy
+    status: OrderBy
+    expirationTime: OrderBy
+    priority: OrderBy
+    retries: OrderBy
+    lastUpdate: OrderBy
+    executionCounter: OrderBy
 }

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/src/main/java/org/kie/kogito/index/graphql/GraphQLAddonSchemaManagerImpl.java
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/src/main/java/org/kie/kogito/index/graphql/GraphQLAddonSchemaManagerImpl.java
@@ -35,7 +35,6 @@ public class GraphQLAddonSchemaManagerImpl extends AbstractGraphQLSchemaManager 
                 .type("Query", builder -> {
                     builder.dataFetcher("ProcessInstances", this::getProcessInstancesValues);
                     builder.dataFetcher("UserTaskInstances", this::getUserTaskInstancesValues);
-                    builder.dataFetcher("Jobs", this::getJobsValues);
                     return builder;
                 })
                 .type("ProcessInstance", builder -> {


### PR DESCRIPTION
Removing Jobs from GraphQL schema that is published to addons. In this scenario, Jobs information is not added at all. Jobs data is only added to Data Index when running as a separate service that published Kafka messages to Data Index.