### PR TITLE
[KOGITO-9022] Missing assertj-core in some dependencies

### DIFF
--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/deployment/pom.xml
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/deployment/pom.xml
@@ -125,6 +125,11 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Depends on https://github.com/kiegroup/drools/pull/5179