### PR TITLE
KOGITO-9241 - Add Data Index addons DEV UI for GraphQL

### DIFF
--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/src/main/java/org/kie/kogito/index/addon/config/DataIndexRuntimeConfig.java
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/src/main/java/org/kie/kogito/index/addon/config/DataIndexRuntimeConfig.java
@@ -16,6 +16,8 @@
 
 package org.kie.kogito.index.addon.config;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -26,7 +28,7 @@ public class DataIndexRuntimeConfig {
     /**
      * Data Index URL
      */
-    @ConfigItem(name = "url", defaultValue = "http://localhost:${quarkus.http.port}")
-    public String dataIndexUrl;
+    @ConfigItem(name = "url")
+    public Optional<String> dataIndexUrl;
 
 }

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-infinispan/deployment/src/main/resources/dev-templates/dataindex.html
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-infinispan/deployment/src/main/resources/dev-templates/dataindex.html
@@ -1,0 +1,16 @@
+{#include main fluid=true}
+{#style}
+.main-container {
+    margin: 0;
+    padding: 0;
+}
+{/style}
+{#title}Data Index GraphQL UI{/title}
+{#body}
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12">
+        <iframe style="width: 100vw;height: 100vh;position: relative;" src="{config:property('quarkus.http.root-path')}{config:property('quarkus.http.non-application-root-path')}/graphql-ui/" style="border:none;"></iframe>
+    </div>
+</div>
+{/body}
+{/include}

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-infinispan/deployment/src/main/resources/dev-templates/embedded.html
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-infinispan/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,4 @@
+<a href="{urlbase}/dataindex" class="badge badge-light">
+    <i class="fa fa-map-signs fa-fw"></i>
+    Data Index GraphQL UI
+</a>

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/deployment/src/main/resources/dev-templates/dataindex.html
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/deployment/src/main/resources/dev-templates/dataindex.html
@@ -1,0 +1,16 @@
+{#include main fluid=true}
+{#style}
+.main-container {
+    margin: 0;
+    padding: 0;
+}
+{/style}
+{#title}Data Index GraphQL UI{/title}
+{#body}
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12">
+        <iframe style="width: 100vw;height: 100vh;position: relative;" src="{config:property('quarkus.http.root-path')}{config:property('quarkus.http.non-application-root-path')}/graphql-ui/" style="border:none;"></iframe>
+    </div>
+</div>
+{/body}
+{/include}

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/deployment/src/main/resources/dev-templates/embedded.html
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,4 @@
+<a href="{urlbase}/dataindex" class="badge badge-light">
+    <i class="fa fa-map-signs fa-fw"></i>
+    Data Index GraphQL UI
+</a>

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/deployment/src/main/resources/dev-templates/dataindex.html
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/deployment/src/main/resources/dev-templates/dataindex.html
@@ -1,0 +1,16 @@
+{#include main fluid=true}
+{#style}
+.main-container {
+    margin: 0;
+    padding: 0;
+}
+{/style}
+{#title}Data Index GraphQL UI{/title}
+{#body}
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12">
+        <iframe style="width: 100vw;height: 100vh;position: relative;" src="{config:property('quarkus.http.root-path')}{config:property('quarkus.http.non-application-root-path')}/graphql-ui/" style="border:none;"></iframe>
+    </div>
+</div>
+{/body}
+{/include}

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/deployment/src/main/resources/dev-templates/embedded.html
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-mongodb/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,4 @@
+<a href="{urlbase}/dataindex" class="badge badge-light">
+    <i class="fa fa-map-signs fa-fw"></i>
+    Data Index GraphQL UI
+</a>

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/deployment/src/main/resources/dev-templates/dataindex.html
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/deployment/src/main/resources/dev-templates/dataindex.html
@@ -1,0 +1,16 @@
+{#include main fluid=true}
+{#style}
+.main-container {
+    margin: 0;
+    padding: 0;
+}
+{/style}
+{#title}Data Index GraphQL UI{/title}
+{#body}
+<div class="row">
+    <div class="col-xs-12 col-sm-12 col-md-12">
+        <iframe style="width: 100vw;height: 100vh;position: relative;" src="{config:property('quarkus.http.root-path')}{config:property('quarkus.http.non-application-root-path')}/graphql-ui/" style="border:none;"></iframe>
+    </div>
+</div>
+{/body}
+{/include}

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/deployment/src/main/resources/dev-templates/embedded.html
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-postgresql/deployment/src/main/resources/dev-templates/embedded.html
@@ -1,0 +1,4 @@
+<a href="{urlbase}/dataindex" class="badge badge-light">
+    <i class="fa fa-map-signs fa-fw"></i>
+    Data Index GraphQL UI
+</a>


### PR DESCRIPTION
This Adds a new tile in QUarkus DEV ui for the extensions, using relative path. Kogito SW extension won't display the link to GraphQL UI ( expected ).
Please note that there is still work needed in `kogito-quarkus-serverless-workflow-devui`  ( KOGITO-9242 ) to make embedded management console fully work 

Relates to https://github.com/kiegroup/kogito-apps/pull/1745