### PR TITLE
[KOGITO-9568] Fixing dependencies

### DIFF
--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/pom.xml
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>data-index-common</artifactId>
         </dependency>
         <dependency>
+             <groupId>org.kie.kogito</groupId>
+             <artifactId>jbpm-flow</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.kie.kogito</groupId>
             <artifactId>kogito-addons-process-svg</artifactId>
         </dependency>


### PR DESCRIPTION
data-index-common-runtime was relying on jbpm-flow being there (which after changes in process-codegen dependencies is not longer true), now this is stated explicitly in the pom

To be merged with https://github.com/kiegroup/kogito-runtimes/pull/3126