### PR TITLE
KOGITO-9825:Data index flyway postgresql migration scripts doesn't al…

### DIFF
--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/V1.32.0__data_index_create.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/V1.32.0__data_index_create.sql
@@ -1,4 +1,4 @@
-create table attachments
+create table IF NOT EXISTS attachments
 (
     id         varchar(255) not null,
     content    varchar(255),
@@ -9,7 +9,7 @@ create table attachments
     primary key (id)
 );
 
-create table comments
+create table IF NOT EXISTS comments
 (
     id         varchar(255) not null,
     content    varchar(255),
@@ -19,7 +19,7 @@ create table comments
     primary key (id)
 );
 
-create table jobs
+create table IF NOT EXISTS jobs
 (
     id                       varchar(255) not null,
     callback_endpoint        varchar(255),
@@ -41,7 +41,7 @@ create table jobs
     primary key (id)
 );
 
-create table milestones
+create table IF NOT EXISTS milestones
 (
     id                  varchar(255) not null,
     process_instance_id varchar(255) not null,
@@ -50,7 +50,7 @@ create table milestones
     primary key (id, process_instance_id)
 );
 
-create table nodes
+create table IF NOT EXISTS nodes
 (
     id                  varchar(255) not null,
     definition_id       varchar(255),
@@ -63,7 +63,7 @@ create table nodes
     primary key (id)
 );
 
-create table processes
+create table IF NOT EXISTS processes
 (
     id                         varchar(255) not null,
     business_key               varchar(255),
@@ -83,21 +83,21 @@ create table processes
     primary key (id)
 );
 
-create table processes_addons
+create table IF NOT EXISTS processes_addons
 (
     process_id varchar(255) not null,
     addon      varchar(255) not null,
     primary key (process_id, addon)
 );
 
-create table processes_roles
+create table IF NOT EXISTS processes_roles
 (
     process_id varchar(255) not null,
     role       varchar(255) not null,
     primary key (process_id, role)
 );
 
-create table tasks
+create table IF NOT EXISTS tasks
 (
     id                       varchar(255) not null,
     actual_owner             varchar(255),
@@ -119,35 +119,35 @@ create table tasks
     primary key (id)
 );
 
-create table tasks_admin_groups
+create table IF NOT EXISTS tasks_admin_groups
 (
     task_id  varchar(255) not null,
     group_id varchar(255) not null,
     primary key (task_id, group_id)
 );
 
-create table tasks_admin_users
+create table IF NOT EXISTS tasks_admin_users
 (
     task_id varchar(255) not null,
     user_id varchar(255) not null,
     primary key (task_id, user_id)
 );
 
-create table tasks_excluded_users
+create table IF NOT EXISTS tasks_excluded_users
 (
     task_id varchar(255) not null,
     user_id varchar(255) not null,
     primary key (task_id, user_id)
 );
 
-create table tasks_potential_groups
+create table IF NOT EXISTS tasks_potential_groups
 (
     task_id  varchar(255) not null,
     group_id varchar(255) not null,
     primary key (task_id, group_id)
 );
 
-create table tasks_potential_users
+create table IF NOT EXISTS tasks_potential_users
 (
     task_id varchar(255) not null,
     user_id varchar(255) not null,
@@ -155,11 +155,19 @@ create table tasks_potential_users
 );
 
 alter table if exists attachments
+  drop constraint if exists fk_attachments_tasks
+cascade;
+
+alter table if exists attachments
     add constraint fk_attachments_tasks
     foreign key (task_id)
     references tasks
     on
 delete
+cascade;
+
+alter table if exists comments
+  drop constraint if exists fk_comments_tasks
 cascade;
 
 alter table if exists comments
@@ -171,11 +179,19 @@ delete
 cascade;
 
 alter table if exists milestones
+drop constraint if exists fk_milestones_process
+cascade;
+
+alter table if exists milestones
     add constraint fk_milestones_process
     foreign key (process_instance_id)
     references processes
     on
 delete
+cascade;
+
+alter table if exists nodes
+drop constraint if exists fk_nodes_process
 cascade;
 
 alter table if exists nodes
@@ -187,11 +203,19 @@ delete
 cascade;
 
 alter table if exists processes_addons
+drop constraint if exists fk_processes_addons_processes
+cascade;
+
+alter table if exists processes_addons
     add constraint fk_processes_addons_processes
     foreign key (process_id)
     references processes
     on
 delete
+cascade;
+
+alter table if exists processes_roles
+drop constraint if exists fk_processes_roles_processes
 cascade;
 
 alter table if exists processes_roles
@@ -203,11 +227,19 @@ delete
 cascade;
 
 alter table if exists tasks_admin_groups
+drop constraint if exists fk_tasks_admin_groups_tasks
+cascade;
+
+alter table if exists tasks_admin_groups
     add constraint fk_tasks_admin_groups_tasks
     foreign key (task_id)
     references tasks
     on
 delete
+cascade;
+
+alter table if exists tasks_admin_users
+drop constraint if exists fk_tasks_admin_users_tasks
 cascade;
 
 alter table if exists tasks_admin_users
@@ -219,6 +251,10 @@ delete
 cascade;
 
 alter table if exists tasks_excluded_users
+drop constraint if exists fk_tasks_excluded_users_tasks
+cascade;
+
+alter table if exists tasks_excluded_users
     add constraint fk_tasks_excluded_users_tasks
     foreign key (task_id)
     references tasks
@@ -227,11 +263,19 @@ delete
 cascade;
 
 alter table if exists tasks_potential_groups
+drop constraint if exists fk_tasks_potential_groups_tasks
+cascade;
+
+alter table if exists tasks_potential_groups
     add constraint fk_tasks_potential_groups_tasks
     foreign key (task_id)
     references tasks
     on
 delete
+cascade;
+
+alter table if exists tasks_potential_users
+drop constraint if exists fk_tasks_potential_users_tasks
 cascade;
 
 alter table if exists tasks_potential_users

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/V1.44.0__data_index_definitions.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/V1.44.0__data_index_definitions.sql
@@ -1,4 +1,4 @@
-create table definitions
+create table IF NOT EXISTS definitions
 (
     id       varchar(255) not null,
     version  varchar(255) not null,
@@ -9,7 +9,7 @@ create table definitions
     primary key (id, version)
 );
 
-create table definitions_addons
+create table IF NOT EXISTS definitions_addons
 (
     process_id      varchar(255) not null,
     process_version varchar(255) not null,
@@ -17,7 +17,7 @@ create table definitions_addons
     primary key (process_id, process_version, addon)
 );
 
-create table definitions_roles
+create table IF NOT EXISTS definitions_roles
 (
     process_id      varchar(255) not null,
     process_version varchar(255) not null,
@@ -26,11 +26,19 @@ create table definitions_roles
 );
 
 alter table if exists definitions_addons
+drop constraint if exists fk_definitions_addons_definitions
+cascade;
+
+alter table if exists definitions_addons
     add constraint fk_definitions_addons_definitions
     foreign key (process_id, process_version)
     references definitions
     on
 delete
+cascade;
+
+alter table if exists definitions_roles
+drop constraint if exists fk_definitions_roles_definitions
 cascade;
 
 alter table if exists definitions_roles
@@ -42,4 +50,4 @@ delete
 cascade;
 
 alter table if exists processes
-    add column version varchar (255);
+    add column IF NOT EXISTS version varchar (255);

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/V1.45.0.0__data_index_node_definitions.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/V1.45.0.0__data_index_node_definitions.sql
@@ -1,4 +1,4 @@
-create table definitions_nodes
+create table IF NOT EXISTS definitions_nodes
 (
     id              varchar(255) not null,
     name            varchar(255),
@@ -9,7 +9,7 @@ create table definitions_nodes
     primary key (id, process_id, process_version)
 );
 
-create table definitions_nodes_metadata
+create table IF NOT EXISTS definitions_nodes_metadata
 (
     node_id         varchar(255) not null,
     process_id      varchar(255) not null,
@@ -18,6 +18,9 @@ create table definitions_nodes_metadata
     key             varchar(255) not null,
     primary key (node_id, process_id, process_version, key)
 );
+alter table if exists definitions_nodes
+drop constraint if exists fk_definitions_nodes_definitions
+cascade;
 
 alter table if exists definitions_nodes
     add constraint fk_definitions_nodes_definitions
@@ -25,6 +28,10 @@ alter table if exists definitions_nodes
     references definitions
     on
 delete
+cascade;
+
+alter table if exists definitions_nodes_metadata
+drop constraint if exists fk_definitions_nodes_metadata_definitions_nodes
 cascade;
 
 alter table if exists definitions_nodes_metadata

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/V1.45.0.1__add_identity_to_process_instance.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/V1.45.0.1__add_identity_to_process_instance.sql
@@ -1,3 +1,3 @@
-ALTER TABLE processes
-    ADD COLUMN created_by character varying,
-    ADD COLUMN updated_by character varying;
+ALTER TABLE IF exists processes
+    ADD COLUMN IF NOT EXISTS created_by character varying,
+    ADD COLUMN IF NOT EXISTS updated_by character varying;

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/readme.txt
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/db/migration/readme.txt
@@ -1,0 +1,2 @@
+Ensure migration scripts are developed to support several executions over the same database without any error.
+This feature will make sure this migration execution would be compatible with other needed flyway migrations without broking the chain.


### PR DESCRIPTION
…low multiple executions

jira: https://issues.redhat.com/browse/KOGITO-9825

Update flyway postgresql migration scripts to just ensure the database changes are applied, avoid them failing when they are executed many times.
This fixes the issue to start an standalone Data index service over the same db as the one the runtime uses with the dataindex persistence addon, allowing to coexists two flyway migrations over the same datasource, just keeping the baseline in different tables.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-lts</b>
 
- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] native-lts</b>
 
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details>