### PR TITLE
kie-issues#626: disable Keycloak devservice

### DIFF
--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/src/main/resources/application.properties
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/src/main/resources/application.properties
@@ -3,6 +3,7 @@ kogito.service.url=http://localhost:8080
 # Disable the KSinkInjectionHealthCheck since the K_SINK env variable is not passed in this context.
 quarkus.smallrye-health.check."org.kie.kogito.addons.quarkus.knative.eventing.KSinkInjectionHealthCheck".enabled=false
 
+quarkus.kafka.devservices.enabled=false
 quarkus.kogito.devservices.enabled=false
 
 # Events produced by kogito-addons-quarkus-jobs-knative-eventing to program the timers on the jobs service.

--- a/data-index/data-index-service/data-index-service-infinispan/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-infinispan/src/test/resources/application.properties
@@ -32,3 +32,6 @@ quarkus.oidc.auth-server-url=none
 
 kogito.data-index.vertx-graphql.ui.path=/graphiql
 kogito.data-index.vertx-graphql.ui.tenant=web-app-tenant
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/data-index/data-index-service/data-index-service-inmemory/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-inmemory/src/test/resources/application.properties
@@ -31,3 +31,6 @@ quarkus.oidc.auth-server-url=none
 %keycloak-test.quarkus.oidc.web-app-tenant.client-id=kogito-app
 %keycloak-test.quarkus.oidc.web-app-tenant.credentials.secret=secret
 %keycloak-test.quarkus.oidc.web-app-tenant.application-type=web-app
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/data-index/data-index-service/data-index-service-mongodb/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-mongodb/src/test/resources/application.properties
@@ -40,3 +40,6 @@ quarkus.oidc.auth-server-url=none
 
 kogito.data-index.vertx-graphql.ui.path=/graphiql
 kogito.data-index.vertx-graphql.ui.tenant=web-app-tenant
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/data-index/data-index-service/data-index-service-oracle/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-oracle/src/test/resources/application.properties
@@ -39,3 +39,6 @@ quarkus.oidc.auth-server-url=none
 %keycloak-test.quarkus.oidc.web-app-tenant.client-id=kogito-app
 %keycloak-test.quarkus.oidc.web-app-tenant.credentials.secret=secret
 %keycloak-test.quarkus.oidc.web-app-tenant.application-type=web-app
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/data-index/data-index-service/data-index-service-postgresql/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-postgresql/src/test/resources/application.properties
@@ -38,3 +38,6 @@ quarkus.oidc.auth-server-url=none
 %keycloak-test.quarkus.oidc.web-app-tenant.client-id=kogito-app
 %keycloak-test.quarkus.oidc.web-app-tenant.credentials.secret=secret
 %keycloak-test.quarkus.oidc.web-app-tenant.application-type=web-app
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/explainability/explainability-service-rest/src/test/resources/application.properties
+++ b/explainability/explainability-service-rest/src/test/resources/application.properties
@@ -5,3 +5,6 @@ quarkus.oidc.auth-server-url=none
 %keycloak.quarkus.oidc.tenant-enabled=true
 %keycloak.quarkus.oidc.client-id=kogito-app
 %keycloak.quarkus.oidc.credentials.secret=secret
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/jobs-service/jobs-service-common/src/test/resources/application.properties
+++ b/jobs-service/jobs-service-common/src/test/resources/application.properties
@@ -17,3 +17,6 @@ quarkus.http.auth.permission.permit1.methods=GET
 %keycloak.quarkus.oidc.tenant-enabled=true
 %keycloak.quarkus.oidc.client-id=kogito-app
 %keycloak.quarkus.oidc.credentials.secret=secret
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/security-commons/src/test/resources/application.properties
+++ b/security-commons/src/test/resources/application.properties
@@ -19,3 +19,5 @@ quarkus.oidc.enabled=true
 quarkus.oidc.tenant-enabled=true
 quarkus.oidc.client-id=kogito-app
 quarkus.oidc.credentials.secret=secret
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/trusty-ui/src/test/resources/application.properties
+++ b/trusty-ui/src/test/resources/application.properties
@@ -15,3 +15,6 @@ quarkus.oidc.tenant-enabled=false
 %keycloak-test.quarkus.oidc.web-app-tenant.client-id=kogito-app
 %keycloak-test.quarkus.oidc.web-app-tenant.credentials.secret=secret
 %keycloak-test.quarkus.oidc.web-app-tenant.application-type=web-app
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false

--- a/trusty/trusty-service/trusty-service-common/src/test/resources/application.properties
+++ b/trusty/trusty-service/trusty-service-common/src/test/resources/application.properties
@@ -32,3 +32,6 @@ mp.messaging.incoming.trusty-explainability-result.connector=smallrye-kafka
 mp.messaging.incoming.trusty-explainability-result.topic=trusty-explainability-result-test
 mp.messaging.incoming.trusty-explainability-result.value.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.trusty-explainability-result.auto.offset.reset=earliest
+
+# Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
+quarkus.keycloak.devservices.enabled=false


### PR DESCRIPTION
apache/incubator-kie-issues#626

Disabling Keycloak dev service that is started by default when quarkus-oidc maven dependency is used (https://quarkus.io/guides/dev-services#keycloak).

Given that our tests instead of the Dev service rely on `org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource`, the dev service started for no use and also caused failures due to strict startTimeout = 60s which was often exceeded. (even after apache/incubator-kie-issues#622 was fixed, because is a different thing)

Also there was version mismatch between the Keycloak image versions being used - that was the main reason to dig into this topic in first place.