### PR TITLE
kie-issues#648: report cypress results in CI publishers

### DIFF
--- a/ui-packages/packages/management-console-webapp/cypress.config.ts
+++ b/ui-packages/packages/management-console-webapp/cypress.config.ts
@@ -21,6 +21,10 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
   viewportWidth: 1920,
   viewportHeight: 1080,
+  reporter: 'junit',
+  reporterOptions: {
+    mochaFile: 'cypress-results/TEST-it-[hash]/junit.xml'
+  },
 
   e2e: {
     // We've imported your old cypress plugins here.

--- a/ui-packages/packages/trusty/cypress/cypress.e2e.ts
+++ b/ui-packages/packages/trusty/cypress/cypress.e2e.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     chromeWebSecurity: false,
     reporter: 'junit',
     reporterOptions: {
-      mochaFile: 'target/surefire-reports/TEST-e2e-[hash].xml',
+      mochaFile: 'cypress-results/TEST-e2e-[hash]/junit.xml',
       toConsole: false
     },
     setupNodeEvents(on, config) {

--- a/ui-packages/packages/trusty/cypress/cypress.it.ts
+++ b/ui-packages/packages/trusty/cypress/cypress.it.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     chromeWebSecurity: false,
     reporter: 'junit',
     reporterOptions: {
-      mochaFile: 'target/surefire-reports/TEST-e2e-[hash].xml',
+      mochaFile: 'cypress-results/TEST-it-[hash]/junit.xml',
       toConsole: false
     },
     setupNodeEvents(on, config) {


### PR DESCRIPTION
apache/incubator-kie-issues#648

Adjusting cypress configuration files to save test reports into a location that is consumed by CI publishers.

Accounting for the wildcard `'**/junit.xml` to pick up the reports after the changes.

To be verified by the PR check test results.