### PR TITLE
kie-issues#650: increase timeout for default nightly

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -118,8 +118,14 @@ Closure setup4AMCronTriggerJobParamsGetter = { script ->
     return jobParams
 }
 
+Closure setupAdditionalTimeoutForDefaultNightly = { script ->
+    def jobParams = JobParamsUtils.DEFAULT_PARAMS_GETTER(script)
+    jobParams.env.put('ADDITIONAL_TIMEOUT', '480')
+    return jobParams
+}
+
 Closure nightlyJobParamsGetter = isMainStream() ? JobParamsUtils.DEFAULT_PARAMS_GETTER : setup4AMCronTriggerJobParamsGetter
-KogitoJobUtils.createNightlyBuildChainBuildAndDeployJobForCurrentRepo(this, '', true)
+KogitoJobUtils.createNightlyBuildChainBuildAndDeployJobForCurrentRepo(this, '', true, setupAdditionalTimeoutForDefaultNightly)
 setupSpecificBuildChainNightlyJob('sonarcloud', nightlyJobParamsGetter)
 setupSpecificBuildChainNightlyJob('native', nightlyJobParamsGetter)
 setupNightlyQuarkusIntegrationJob('quarkus-main', nightlyJobParamsGetter)

--- a/.github/workflows/pr-jenkins.yml
+++ b/.github/workflows/pr-jenkins.yml
@@ -35,7 +35,7 @@ jobs:
     name: DSL
     steps:
     - name: DSL tests
-      uses: apache/incubator-kie-kie-ci/.ci/actions/dsl-tests@main
+      uses: apache/incubator-kie-kogito-pipelines/.ci/actions/dsl-tests@main
       with:
         main-config-file-repo: apache/incubator-kie-kogito-pipelines
         main-config-file-path: .ci/jenkins/config/main.yaml


### PR DESCRIPTION
apache/incubator-kie-issues#650

Increasing job timeout for default variant of kogito-apps nightly build.

Didn't want to increase the default in seed config, not to increase also for kogito-runtimes, where the timeout is sufficient.


