### PR TITLE
kie-issues#667: fix cleanup and settingsXml handling

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     stages {
         stage('Initialize') {
             steps {
-                cleanWs()
+                cleanWs(disableDeferredWipeout: true)
                 script {
                     // load `pr_check.groovy` file from kogito-pipelines:main
                     dir('kogito-pipelines') {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -36,7 +36,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -176,7 +176,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -269,7 +269,6 @@ void setDeployPropertyIfNeeded(String key, def value) {
 
 MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
-            .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
             .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
             .withProperty('full')
 }
@@ -283,11 +282,14 @@ void runMavenDeploy(boolean skipTests = true, boolean localDeployment = false) {
         mvnCmd.withDeployRepository(env.MAVEN_DEPLOY_REPOSITORY)
     }
 
-    mvnCmd.withProperty('maven.test.failure.ignore', true)
-        .withOptions(env.BUILD_MVN_OPTS_CURRENT ? [ env.BUILD_MVN_OPTS_CURRENT ] : [])
-        .withOptions(env.KOGITO_APPS_BUILD_MVN_OPTS ? [ env.KOGITO_APPS_BUILD_MVN_OPTS ] : [])
-        .skipTests(skipTests)
-        .run('clean deploy')
+    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+        mvnCmd.withProperty('maven.test.failure.ignore', true)
+            .withOptions(env.BUILD_MVN_OPTS_CURRENT ? [ env.BUILD_MVN_OPTS_CURRENT ] : [])
+            .withOptions(env.KOGITO_APPS_BUILD_MVN_OPTS ? [ env.KOGITO_APPS_BUILD_MVN_OPTS ] : [])
+            .skipTests(skipTests)
+            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+            .run('clean deploy')
+    }
 }
 
 void runMavenStage() {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -90,7 +90,13 @@ pipeline {
             steps {
                 script {
                     dir(getRepoName()) {
-                        maven.mvnVersionsUpdateParentAndChildModules(getMavenCommand(), getProjectVersion(), !isRelease())
+                        configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                            maven.mvnVersionsUpdateParentAndChildModules(
+                                getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                                getProjectVersion(),
+                                !isRelease()
+                            )
+                        }
                     }
                 }
             }
@@ -293,13 +299,15 @@ void runMavenDeploy(boolean skipTests = true, boolean localDeployment = false) {
 }
 
 void runMavenStage() {
-    MavenStagingHelper stagingHelper = getStagingHelper()
-    deployProperties.putAll(stagingHelper.stageLocalArtifacts(env.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder()))
-    stagingHelper.promoteStagingRepository(env.NEXUS_BUILD_PROMOTION_PROFILE_ID)
+    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+        MavenStagingHelper stagingHelper = getStagingHelper(getMavenCommand().withSettingsXmlFile(MAVEN_SETTINGS_FILE))
+        deployProperties.putAll(stagingHelper.stageLocalArtifacts(env.NEXUS_STAGING_PROFILE_ID, getLocalDeploymentFolder()))
+        stagingHelper.promoteStagingRepository(env.NEXUS_BUILD_PROMOTION_PROFILE_ID)
+    }
 }
 
-MavenStagingHelper getStagingHelper() {
-    return new MavenStagingHelper(this, getMavenCommand())
+MavenStagingHelper getStagingHelper(MavenCommand mavenCommand) {
+    return new MavenStagingHelper(this, mavenCommand)
             .withNexusReleaseUrl(env.NEXUS_RELEASE_URL)
             .withNexusReleaseRepositoryId(env.NEXUS_RELEASE_REPOSITORY_ID)
 }

--- a/.ci/jenkins/Jenkinsfile.optaplanner
+++ b/.ci/jenkins/Jenkinsfile.optaplanner
@@ -35,18 +35,24 @@ pipeline {
         stage('Build Drools') {
             steps {
                 script {
-                    getMavenCommand(droolsRepo)
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(droolsRepo)
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
         stage('Build Optaplanner') {
             steps {
                 script {
-                    getMavenCommand(optaplannerRepo)
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(optaplannerRepo)
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
@@ -68,22 +74,28 @@ pipeline {
         stage('Build Runtimes') {
             steps {
                 script {
-                    getMavenCommand(kogitoRuntimesRepo)
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(kogitoRuntimesRepo)
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                        }
                 }
             }
         }
         stage('Build Apps') {
             steps {
                 script {
-                    getMavenCommand(kogitoAppsRepo)
-                        .withOptions(env.BUILD_MVN_OPTS_CURRENT ? [ env.BUILD_MVN_OPTS_CURRENT ] : [])
-                        .withProperty('skipUI')
-                        .withProperty('maven.test.failure.ignore', true)
-                        .withProperty('version.org.optaplanner', env.OPTAPLANNER_VERSION)
-                        .withProperty('optaplanner') // Use specific profile https://github.com/apache/incubator-kie-kogito-apps/blob/48a5c8f9a905a2c17b9d0e01cee744902a4824f0/pom.xml#L63
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(kogitoAppsRepo)
+                            .withOptions(env.BUILD_MVN_OPTS_CURRENT ? [ env.BUILD_MVN_OPTS_CURRENT ] : [])
+                            .withProperty('skipUI')
+                            .withProperty('maven.test.failure.ignore', true)
+                            .withProperty('version.org.optaplanner', env.OPTAPLANNER_VERSION)
+                            .withProperty('optaplanner') // Use specific profile https://github.com/apache/incubator-kie-kogito-apps/blob/48a5c8f9a905a2c17b9d0e01cee744902a4824f0/pom.xml#L63
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
             post {
@@ -92,11 +104,6 @@ pipeline {
                         archiveArtifacts artifacts: '**/target/*-runner.jar,**/target/*-runner', fingerprint: true, allowEmptyArchive: true
                         junit testResults: '**/target/surefire-reports/**/*.xml,**/target/failsafe-reports/**/*.xml', allowEmptyResults: true
                         util.archiveConsoleLog()
-                    }
-                }
-                cleanup {
-                    script {
-                        cleanContainers()
                     }
                 }
             }
@@ -108,7 +115,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -167,14 +174,9 @@ String getOptaPlannerBranch() {
 
 MavenCommand getMavenCommand(String directory) {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId('kie-release-settings')
                 .withProperty('java.net.preferIPv4Stack', true)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                 .inDirectory(directory)
-}
-
-void cleanContainers() {
-    cloud.cleanContainersAndImages('docker')
 }
 
 String getNativeBuilderImage() {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -25,7 +25,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -72,7 +72,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }

--- a/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.pr
+++ b/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.pr
@@ -21,7 +21,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     sh 'printenv > env_props'
                     archiveArtifacts artifacts: 'env_props'
@@ -41,7 +41,12 @@ pipeline {
                         dir(project) {
                             githubscm.checkoutIfExists(project, changeAuthor, changeBranch, 'apache', changeTarget, true)
                             sh '.ci/environments/update.sh quarkus-3'
-                            getMavenCommand().withProperty('quickly').run('clean install')
+                            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                                getMavenCommand()
+                                    .withProperty('quickly')
+                                    .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                    .run('clean install')
+                            }
                         }
                     }
                 }
@@ -72,10 +77,8 @@ pipeline {
         }
     }
     post {
-        always {
-            script {
-                cleanWs()
-            }
+        cleanup {
+            cleanWs()
         }
         unsuccessful {
             script {
@@ -95,7 +98,6 @@ String getGitAuthorCredsId() {
 
 MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                 .withProperty('enforcer.skip')
 }

--- a/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.standalone
+++ b/.ci/jenkins/Jenkinsfile.quarkus-3.rewrite.standalone
@@ -59,7 +59,12 @@ pipeline {
                         dir(project) {
                             githubscm.checkoutIfExists(project, getGitAuthor(), getBuildBranch(), getBaseAuthor(), getBaseBranch(), true)
                             sh '.ci/environments/update.sh quarkus-3'
-                            getMavenCommand().withProperty('quickly').run('clean install')
+                            configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                                getMavenCommand()
+                                    .withProperty('quickly')
+                                    .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                    .run('clean install')
+                            }
                         }
                     }
                 }
@@ -120,7 +125,7 @@ pipeline {
 
 void clean() {
     sh 'rm -rf ~/.rewrite-cache/'
-    util.cleanNode('docker')
+    util.cleanNode()
 }
 
 void sendErrorNotification() {
@@ -174,7 +179,6 @@ String getPRBranch() {
 
 MavenCommand getMavenCommand() {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                 .withProperty('enforcer.skip')
 }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -27,7 +27,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
@@ -42,22 +42,28 @@ pipeline {
         stage('Build Drools') {
             steps {
                 script {
-                    getMavenCommand(droolsRepo)
-                        .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withOptions(env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ? [ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(droolsRepo)
+                            .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withOptions(env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ? [ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
         stage('Build Kogito Runtimes') {
             steps {
                 script {
-                    getMavenCommand(kogitoRuntimesRepo)
-                        .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withOptions(env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM ? [ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM ] : [])
-                        .withProperty('quickly')
-                        .run('clean install')
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        getMavenCommand(kogitoRuntimesRepo)
+                            .withOptions(env.BUILD_MVN_OPTS_UPSTREAM ? [ env.BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withOptions(env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM ? [ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM ] : [])
+                            .withProperty('quickly')
+                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                            .run('clean install')
+                    }
                 }
             }
         }
@@ -91,7 +97,7 @@ pipeline {
         }
         cleanup {
             script {
-                util.cleanNode('docker')
+                util.cleanNode()
             }
         }
     }
@@ -149,7 +155,6 @@ String getGitAuthorCredsID() {
 
 MavenCommand getMavenCommand(String directory) {
     return new MavenCommand(this, ['-fae', '-ntp'])
-                .withSettingsXmlId(env.MAVEN_SETTINGS_CONFIG_FILE_ID)
                 .withOptions(env.BUILD_MVN_OPTS ? [ env.BUILD_MVN_OPTS ] : [])
                 .inDirectory(directory)
 }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -70,7 +70,13 @@ pipeline {
         stage('Update project version') {
             steps {
                 script {
-                    maven.mvnVersionsUpdateParentAndChildModules(getMavenCommand(getRepoName()), getKogitoVersion(), true)
+                    configFileProvider([configFile(fileId: env.MAVEN_SETTINGS_CONFIG_FILE_ID, variable: 'MAVEN_SETTINGS_FILE')]){
+                        maven.mvnVersionsUpdateParentAndChildModules(
+                            getMavenCommand(getRepoName()).withSettingsXmlFile(MAVEN_SETTINGS_FILE),
+                            getKogitoVersion(),
+                            true
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
apache/incubator-kie-issues#667

Fixing cleanup and settings.xml pipeline configuration to work correctly in ASF Jenkins.

* Deferred wipeout was causing issues when invoked in early stages
* Docker cleanup can't be done since the overall build is in docker container that uses the docker.sock from the host - it would attempt to erase itself.
* withSettingsXmlId shared library method does imply usage of a prohibited groovy method, thus replacing with explicit configFileProvider and passing as withSettingsXmlFile goes around that part of code. 

Complete list:
apache/incubator-kie-kogito-pipelines#1113
apache/incubator-kie-kogito-runtimes#3272
apache/incubator-kie-kogito-apps#1909
apache/incubator-kie-kogito-examples#1820
apache/incubator-kie-drools#5572
apache/incubator-kie-optaplanner#3010
apache/incubator-kie-optaplanner-quickstarts#613
apache/incubator-kie-kogito-docs#514
apache/incubator-kie-docs#4531
apache/incubator-kie-benchmarks#273