### PR TITLE
kie-issues_599: specify projectKey for sonar analysis

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
         BUILDCHAIN_PROJECT = 'apache/incubator-kie-kogito-apps'
 
         ENABLE_SONARCLOUD = 'false'
+        SONAR_PROJECT_KEY = 'apache_incubator-kie-kogito-apps'
         KOGITO_APPS_BUILD_MVN_OPTS = '-Dvalidate-formatting -Prun-code-coverage'
     }
     stages {


### PR DESCRIPTION
apache/incubator-kie-issues#599

Explicitly setting sonar.projectKey in PR checks and buildchain nightly.

apache/incubator-kie-drools#5573
apache/incubator-kie-kogito-apps#1910
apache/incubator-kie-kogito-pipelines#1116
apache/incubator-kie-kogito-runtimes#3274
apache/incubator-kie-optaplanner#3011