### PR TITLE
kie-issues#677: Data Index shows error when querying for ProcessInstances that contain nodes with null enter property.

### DIFF
--- a/data-index/data-index-common/src/main/java/org/kie/kogito/index/event/mapper/ProcessInstanceNodeDataEventMerger.java
+++ b/data-index/data-index-common/src/main/java/org/kie/kogito/index/event/mapper/ProcessInstanceNodeDataEventMerger.java
@@ -36,6 +36,8 @@ import org.kie.kogito.index.model.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.kie.kogito.event.process.ProcessInstanceNodeEventBody.EVENT_TYPE_ENTER;
+import static org.kie.kogito.event.process.ProcessInstanceNodeEventBody.EVENT_TYPE_EXIT;
 import static org.kie.kogito.index.DateTimeUtils.toZonedDateTime;
 
 @ApplicationScoped
@@ -65,11 +67,16 @@ public class ProcessInstanceNodeDataEventMerger implements ProcessInstanceEventM
         nodeInstance.setName(body.getNodeName());
         nodeInstance.setType(body.getNodeType());
         switch (body.getEventType()) {
-            case 1:
+            case EVENT_TYPE_ENTER:
                 nodeInstance.setEnter(toZonedDateTime(body.getEventDate()));
                 break;
-            case 2:
+            case EVENT_TYPE_EXIT:
                 nodeInstance.setExit(toZonedDateTime(body.getEventDate()));
+
+                if (nodeInstance.getEnter() == null) {
+                    // Adding a default enter time for exit events triggered by EventNodeInstances
+                    nodeInstance.setEnter(nodeInstance.getExit());
+                }
                 break;
         }
         nodeInstances.add(nodeInstance);

--- a/data-index/data-index-common/src/test/java/org/kie/kogito/index/event/mapper/ProcessInstanceNodeDataEventMergerTest.java
+++ b/data-index/data-index-common/src/test/java/org/kie/kogito/index/event/mapper/ProcessInstanceNodeDataEventMergerTest.java
@@ -1,0 +1,115 @@
+package org.kie.kogito.index.event.mapper;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.kie.kogito.event.process.ProcessInstanceNodeDataEvent;
+import org.kie.kogito.event.process.ProcessInstanceNodeEventBody;
+import org.kie.kogito.index.model.NodeInstance;
+import org.kie.kogito.index.model.ProcessInstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.kogito.event.process.ProcessInstanceNodeEventBody.EVENT_TYPE_ENTER;
+import static org.kie.kogito.event.process.ProcessInstanceNodeEventBody.EVENT_TYPE_EXIT;
+import static org.kie.kogito.index.DateTimeUtils.toZonedDateTime;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ProcessInstanceNodeDataEventMergerTest {
+
+    private static final String HIRING_PROCESS_ID = "hiring";
+    private static final String PROCESS_INSTANCE_ID = "7b8ea46e-ffe7-4fdd-8cf5-72a3f0353947";
+
+    private static final String START_NODE_INSTANCE_ID = "35d525eb-868a-4056-91cc-dbc3804d157c";
+    private static final String START = "Start";
+    private static final String START_NODE_DEFINITION_ID = "_1639F738-45F3-4CD6-A80E-CCEBAA605D56";
+    private static final String START_NODE_TYPE = "StartNode";
+
+    private static final String ACTION_NODE_INSTANCE_ID = "08ee9c9c-cf67-47e5-a7e6-901a6f556c0a";
+    private static final String ACTION_NODE = "New Hiring";
+    private static final String ACTION_NODE_DEFINITION_ID = "_5BDBE48C-CC83-46A9-9D56-F846F8FC1045";
+    private static final String ACTION_NODE_TYPE = "ActionNode";
+
+    private static final String BOUNDARY_EVENT_NODE_INSTANCE_ID = "f22510d2-e0e5-460a-901e-494cda3dea26";
+    private static final String BOUNDARY_EVENT_NODE_NODE = "BoundaryEvent";
+    private static final String BOUNDARY_EVENT_NODE_NODE_DEFINITION_ID = "_116F3C54-A10E-4952-9E08-1CACE74CED0B";
+    private static final String BOUNDARY_EVENT_NODE_NODE_TYPE = "BoundaryEventNode";
+
+    private ProcessInstanceNodeDataEventMerger merger;
+    private ProcessInstance pi;
+
+    @BeforeEach
+    public void setup() {
+        merger = new ProcessInstanceNodeDataEventMerger();
+        pi = new ProcessInstance();
+        pi.setProcessId(HIRING_PROCESS_ID);
+        pi.setProcessName(HIRING_PROCESS_ID);
+        pi.setId(PROCESS_INSTANCE_ID);
+        pi.setVersion("1.0");
+        pi.setStart(ZonedDateTime.now());
+        pi.setState(1);
+    }
+
+    @Test
+    public void testMergeProcessInstanceNodeDataEvents() {
+        ProcessInstanceNodeDataEvent startNodeEnter = buildNodeEvent(START_NODE_INSTANCE_ID, START, START_NODE_DEFINITION_ID, START_NODE_TYPE, EVENT_TYPE_ENTER);
+
+        merger.merge(pi, startNodeEnter);
+
+        ProcessInstanceNodeDataEvent startNodeExit = buildNodeEvent(START_NODE_INSTANCE_ID, START, START_NODE_DEFINITION_ID, START_NODE_TYPE, EVENT_TYPE_EXIT);
+
+        merger.merge(pi, startNodeExit);
+
+        ProcessInstanceNodeDataEvent actionNodeEnter = buildNodeEvent(ACTION_NODE_INSTANCE_ID, ACTION_NODE, ACTION_NODE_DEFINITION_ID, ACTION_NODE_TYPE, EVENT_TYPE_ENTER);
+
+        merger.merge(pi, actionNodeEnter);
+
+        ProcessInstanceNodeDataEvent actionNodeExit = buildNodeEvent(ACTION_NODE_INSTANCE_ID, ACTION_NODE, ACTION_NODE_DEFINITION_ID, ACTION_NODE_TYPE, EVENT_TYPE_EXIT);
+
+        merger.merge(pi, actionNodeExit);
+
+        assertThat(pi.getNodes()).hasSize(2);
+
+        verifyNode(pi.getNodes().get(0), startNodeEnter.getData(), startNodeEnter.getData().getEventDate(), startNodeExit.getData().getEventDate());
+        verifyNode(pi.getNodes().get(1), actionNodeEnter.getData(), actionNodeEnter.getData().getEventDate(), actionNodeExit.getData().getEventDate());
+    }
+
+    @Test
+    public void testMergeBoundaryNodeExitEvent() {
+        ProcessInstanceNodeDataEvent boundaryEvent =
+                buildNodeEvent(BOUNDARY_EVENT_NODE_INSTANCE_ID, BOUNDARY_EVENT_NODE_NODE, BOUNDARY_EVENT_NODE_NODE_DEFINITION_ID, BOUNDARY_EVENT_NODE_NODE_TYPE, EVENT_TYPE_EXIT);
+
+        merger.merge(pi, boundaryEvent);
+
+        assertThat(pi.getNodes()).hasSize(1);
+
+        verifyNode(pi.getNodes().get(0), boundaryEvent.getData(), boundaryEvent.getData().getEventDate(), boundaryEvent.getData().getEventDate());
+    }
+
+    private void verifyNode(NodeInstance nodeInstance, ProcessInstanceNodeEventBody eventBody, Date enter, Date exit) {
+        assertThat(nodeInstance)
+                .hasFieldOrPropertyWithValue("id", eventBody.getNodeInstanceId())
+                .hasFieldOrPropertyWithValue("nodeId", eventBody.getNodeDefinitionId())
+                .hasFieldOrPropertyWithValue("definitionId", eventBody.getNodeDefinitionId())
+                .hasFieldOrPropertyWithValue("name", eventBody.getNodeName())
+                .hasFieldOrPropertyWithValue("type", eventBody.getNodeType())
+                .hasFieldOrPropertyWithValue("enter", toZonedDateTime(enter))
+                .hasFieldOrPropertyWithValue("exit", toZonedDateTime(exit));
+    }
+
+    private ProcessInstanceNodeDataEvent buildNodeEvent(String nodeInstanceId, String nodeName, String nodeDefinitionId, String nodeType, Integer eventType) {
+        return new ProcessInstanceNodeDataEvent(HIRING_PROCESS_ID, "", "", new HashMap<>(), ProcessInstanceNodeEventBody.create()
+                .processId(HIRING_PROCESS_ID)
+                .processInstanceId(PROCESS_INSTANCE_ID)
+                .nodeInstanceId(nodeInstanceId)
+                .nodeName(nodeName)
+                .nodeDefinitionId(nodeDefinitionId)
+                .nodeType(nodeType)
+                .eventDate(new Date())
+                .eventType(eventType)
+                .build());
+    }
+}

--- a/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/service/json/ProcessInstanceMetaMapper.java
+++ b/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/service/json/ProcessInstanceMetaMapper.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 import org.kie.kogito.event.process.ProcessInstanceDataEvent;
 import org.kie.kogito.event.process.ProcessInstanceStateDataEvent;
 import org.kie.kogito.event.process.ProcessInstanceVariableDataEvent;
-import org.kie.kogito.index.service.IndexingService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +41,7 @@ import static org.kie.kogito.index.storage.Constants.PROCESS_NAME;
 
 public class ProcessInstanceMetaMapper implements Function<ProcessInstanceDataEvent<?>, ObjectNode> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(IndexingService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstanceMetaMapper.class);
 
     @Override
     public ObjectNode apply(ProcessInstanceDataEvent<?> event) {


### PR DESCRIPTION
Issue:  https://github.com/apache/incubator-kie-issues/issues/677

Adding a default `enter` time to the `NodeInstances` that only have `exit` time. This situation happens when the event is triggered by a `EventNodeInstance` (like a `BoundaryNodeInstance`)


Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/apache/incubator-kie-kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-lts</b>
 
- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] native-lts</b>
 
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details>