### PR TITLE
incubator-kie-issues#832: Exclude `quarkus-container-image-jib` dependency brought from `jobs-service-common` to `kogito-addons-quarkus-jobs`

### DIFF
--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/pom.xml
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/pom.xml
@@ -52,6 +52,10 @@
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-container-image-jib</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Testing dependencies -->


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/832

incubator-kie-issues#832: Exclude `quarkus-container-image-jib` dependency brought from `jobs-service-common` to `kogito-addons-quarkus-jobs`
