### PR TITLE
[Fix_#3383] Setting metadata when using binary

### DIFF
--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/src/test/java/org/kie/kogito/it/jobs/SwitchStateTimeoutsIT.java
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/src/test/java/org/kie/kogito/it/jobs/SwitchStateTimeoutsIT.java
@@ -49,9 +49,9 @@ class SwitchStateTimeoutsIT extends BaseSwitchStateTimeoutsIT implements SinkMoc
                 .with().pollInterval(1, SECONDS)
                 .untilAsserted(() -> sink.verify(1,
                         postRequestedFor(urlEqualTo("/"))
-                                .withRequestBody(matchingJsonPath("kogitoprocinstanceid", equalTo(processInstanceId)))
-                                .withRequestBody(matchingJsonPath("type", equalTo(PROCESS_RESULT_EVENT_TYPE)))
-                                .withRequestBody(matchingJsonPath("data.decision", equalTo(DECISION_NO_DECISION)))));
+                                .withHeader("ce-kogitoprocinstanceid", equalTo(processInstanceId))
+                                .withHeader("ce-type", equalTo(PROCESS_RESULT_EVENT_TYPE))
+                                .withRequestBody(matchingJsonPath("decision", equalTo(DECISION_NO_DECISION)))));
 
     }
 


### PR DESCRIPTION
Since quarkus-http now uses binary as default the test condition for knative message has changed
Depends on https://github.com/apache/incubator-kie-kogito-runtimes/pull/3386