### PR TITLE
bump to Optaplanner 999-SNAPSHOT

### DIFF
--- a/kogito-apps-build-parent/pom.xml
+++ b/kogito-apps-build-parent/pom.xml
@@ -65,7 +65,7 @@
         <container.image.integration-tests-trusty-service-quarkus>org.kie.kogito/integration-tests-trusty-service-quarkus:${project.version}</container.image.integration-tests-trusty-service-quarkus>
 
         <!-- OptaPlanner version -->
-        <version.org.optaplanner>9.44.0.Final</version.org.optaplanner>
+        <version.org.optaplanner>999-SNAPSHOT</version.org.optaplanner>
 
         <version.org.hibernate>6.2.13.Final</version.org.hibernate>
         <version.org.apache.opennlp>2.3.1</version.org.apache.opennlp>


### PR DESCRIPTION
The use of Optaplanner 9.44.0.Final was also breaking the native compilation with errors like:

```
[2024-02-02T03:41:03.179Z] Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing org.drools.core.reteoo.TupleFactory.createPeer(TupleFactory.java:29)
[2024-02-02T03:41:03.179Z] Parsing context:
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.RuleNetworkEvaluator.doRiaNode2(RuleNetworkEvaluator.java:694)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.RuleNetworkEvaluator.innerEval(RuleNetworkEvaluator.java:341)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.RuleNetworkEvaluator.outerEval(RuleNetworkEvaluator.java:189)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.TupleEvaluationUtil.forceFlushLeftTuple(TupleEvaluationUtil.java:133)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.TupleEvaluationUtil.forceFlushPath(TupleEvaluationUtil.java:108)
[2024-02-02T03:41:03.179Z]    at org.drools.core.reteoo.LeftInputAdapterNode.doInsertSegmentMemoryWithFlush(LeftInputAdapterNode.java:236)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.LazyPhreakBuilder.insertPeerLeftTuple(LazyPhreakBuilder.java:1000)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.LazyPhreakBuilder.visitChild(LazyPhreakBuilder.java:944)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.LazyPhreakBuilder.visitLeftTuple(LazyPhreakBuilder.java:902)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.LazyPhreakBuilder.processLeftTuples(LazyPhreakBuilder.java:841)
[2024-02-02T03:41:03.179Z]    at org.drools.core.phreak.LazyPhreakBuilder.removeRule(LazyPhreakBuilder.java:206)
[2024-02-02T03:41:03.179Z]    at org.drools.core.reteoo.ReteooBuilder.removeTerminalNode(ReteooBuilder.java:192)
[2024-02-02T03:41:03.179Z]    at org.drools.core.reteoo.ReteooBuilder.removeRules(ReteooBuilder.java:177)
[2024-02-02T03:41:03.179Z]    at org.drools.core.impl.KnowledgeBaseImpl.kBaseInternal_removeRules(KnowledgeBaseImpl.java:1095)
[2024-02-02T03:41:03.179Z]    at org.drools.core.impl.KnowledgeBaseImpl.mergePackage(KnowledgeBaseImpl.java:806)
[2024-02-02T03:41:03.179Z]    at org.drools.core.impl.KnowledgeBaseImpl.kBaseInternal_addPackages(KnowledgeBaseImpl.java:426)
[2024-02-02T03:41:03.179Z]    at org.drools.kiesession.rulebase.SessionsAwareKnowledgeBase.internalAddPackages(SessionsAwareKnowledgeBase.java:262)
[2024-02-02T03:41:03.179Z]    at org.drools.kiesession.rulebase.SessionsAwareKnowledgeBase$$Lambda$3307/0x00000007c26c7ce8.run(Unknown Source)
[2024-02-02T03:41:03.179Z]    at org.drools.kiesession.rulebase.SessionsAwareKnowledgeBase.enqueueModification(SessionsAwareKnowledgeBase.java:290)
[2024-02-02T03:41:03.179Z]    at org.drools.kiesession.rulebase.SessionsAwareKnowledgeBase.addPackages(SessionsAwareKnowledgeBase.java:229)
[2024-02-02T03:41:03.179Z]    at org.drools.modelcompiler.KieBaseBuilder.createKieBase(KieBaseBuilder.java:57)
[2024-02-02T03:41:03.179Z]    at org.drools.modelcompiler.KieBaseBuilder.createKieBaseFromModel(KieBaseBuilder.java:86)
[2024-02-02T03:41:03.179Z]    at org.drools.modelcompiler.KieBaseBuilder.createKieBaseFromModel(KieBaseBuilder.java:66)
[2024-02-02T03:41:03.179Z]    at org.optaplanner.constraint.streams.drools.DroolsConstraintStreamScoreDirectorFactory.buildKieBaseFromModel(DroolsConstraintStreamScoreDirectorFactory.java:94)
[2024-02-02T03:41:03.179Z]    at org.optaplanner.constraint.streams.drools.DroolsConstraintStreamScoreDirectorFactory.buildKieBase(DroolsConstraintStreamScoreDirectorFactory.java:85)
[2024-02-02T03:41:03.179Z]    at org.optaplanner.constraint.streams.drools.DroolsConstraintStreamScoreDirectorFactory.<init>(DroolsConstraintStreamScoreDirectorFactory.java:52)
[2024-02-02T03:41:03.179Z]    at org.optaplanner.constraint.streams.drools.DroolsConstraintStreamScoreDirectorFactoryService.buildScoreDirectorFactory(DroolsConstraintStreamScoreDirectorFactoryService.java:78)
[2024-02-02T03:41:03.179Z]    at org.optaplanner.constraint.streams.drools.DroolsConstraintStreamScoreDirectorFactoryService.lambda$buildScoreDirectorFactory$0(DroolsConstraintStreamScoreDirectorFactoryService.java:56)
[2024-02-02T03:41:03.179Z]    at org.optaplanner.constraint.streams.drools.DroolsConstraintStreamScoreDirectorFactoryService$$Lambda$3131/0x00000007c26a5ce0.get(Unknown Source)
[2024-02-02T03:41:03.179Z]    at io.smallrye.mutiny.groups.MultiCreate.lambda$item$4(MultiCreate.java:252)
[2024-02-02T03:41:03.179Z]    at io.smallrye.mutiny.groups.MultiCreate$$Lambda$3140/0x00000007c26a70a0.accept(Unknown Source)
[2024-02-02T03:41:03.179Z]    at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:300)
[2024-02-02T03:41:03.179Z]    at java.util.stream.StreamSpliterators$LongWrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:403)
[2024-02-02T03:41:03.179Z]    at java.util.stream.StreamSpliterators$LongWrappingSpliterator$$Lambda$1361/0x00000007c23766f0.getAsBoolean(Unknown Source)
[2024-02-02T03:41:03.179Z]    at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206)
[2024-02-02T03:41:03.179Z]    at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169)
[2024-02-02T03:41:03.179Z]    at java.util.stream.StreamSpliterators$LongWrappingSpliterator.tryAdvance(StreamSpliterators.java:414)
[2024-02-02T03:41:03.179Z]    at java.util.stream.LongPipeline.forEachWithCancel(LongPipeline.java:161)
[2024-02-02T03:41:03.179Z]    at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
[2024-02-02T03:41:03.179Z]    at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
[2024-02-02T03:41:03.179Z]    at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
[2024-02-02T03:41:03.179Z]    at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
[2024-02-02T03:41:03.179Z]    at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
[2024-02-02T03:41:03.179Z]    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
[2024-02-02T03:41:03.179Z]    at java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
[2024-02-02T03:41:03.179Z]    at org.kie.kogito.trusty.storage.api.model.Outcome.hasErrors(Outcome.java:128)
[2024-02-02T03:41:03.179Z]    at root method.(Unknown Source)
[2024-02-02T03:41:03.179Z]
[2024-02-02T03:41:03.179Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.AnalysisError.parsingError(AnalysisError.java:149)
[2024-02-02T03:41:03.179Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:178)
[2024-02-02T03:41:03.179Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureFlowsGraphCreated(MethodTypeFlow.java:152)
[2024-02-02T03:41:03.179Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.flow.MethodTypeFlow.getOrCreateMethodFlowsGraphInfo(MethodTypeFlow.java:110)
[2024-02-02T03:41:03.179Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.typestate.DefaultStaticInvokeTypeFlow.lambda$update$0(DefaultStaticInvokeTypeFlow.java:67)
[2024-02-02T03:41:03.179Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.LightImmutableCollection.forEach(LightImmutableCollection.java:90)
[2024-02-02T03:41:03.179Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.typestate.DefaultStaticInvokeTypeFlow.update(DefaultStaticInvokeTypeFlow.java:66)
[2024-02-02T03:41:03.179Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.PointsToAnalysis$1.run(PointsToAnalysis.java:474)
[2024-02-02T03:41:03.180Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:187)
[2024-02-02T03:41:03.180Z]  at org.graalvm.nativeimage.pointsto/com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:171)
[2024-02-02T03:41:03.180Z]  at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395)
[2024-02-02T03:41:03.180Z]  at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
[2024-02-02T03:41:03.180Z]  at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
[2024-02-02T03:41:03.180Z]  at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
[2024-02-02T03:41:03.180Z]  at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
[2024-02-02T03:41:03.180Z]  at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
[2024-02-02T03:41:03.180Z] Caused by: org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved method during parsing: org.drools.tms.agenda.TruthMaintenanceSystemRuleTerminalNodeLeftTuple.<init>(). This error is reported at image build time because class org.drools.tms.TruthMaintenanceSystemAgendaComponentFactory is registered for linking at image build time by command line
[2024-02-02T03:41:03.180Z]  at parsing org.drools.tms.TruthMaintenanceSystemAgendaComponentFactory.createTerminalTuple(TruthMaintenanceSystemAgendaComponentFactory.java:38)
[2024-02-02T03:41:03.180Z]  at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.throwParserError(BytecodeParser.java:2536)
[2024-02-02T03:41:03.180Z]  at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.throwParserError(SharedGraphBuilderPhase.java:169)
[2024-02-02T03:41:03.180Z]  at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3414)
[2024-02-02T03:41:03.180Z]  at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.iterateBytecodesForBlock(SharedGraphBuilderPhase.java:712)
```