### PR TITLE
NO-ISSUE: Publish weekly JIT executor native packages with the "dev" tag and add the ability to manually trigger the workflow

### DIFF
--- a/.github/workflows/publish-jitexecutor-native.yml
+++ b/.github/workflows/publish-jitexecutor-native.yml
@@ -39,8 +39,9 @@ jobs:
             echo "NPM_VERSION=999.0.0-${{ steps.date.outputs.CURRENT_DATE }}-SNAPSHOT" >> "$GITHUB_OUTPUT"
             echo "NPM_TAG=dev" >> "$GITHUB_OUTPUT"
           else
-            echo "TAG=${{ github.event.inputs.kogito_runtime_version }}" >> "$GITHUB_OUTPUT"
-            echo "PROJECT_VERSION=${{ github.event.inputs.kogito_runtime_version }}" >> "$GITHUB_OUTPUT"
+            VERSION="${{ github.event.inputs.kogito_runtime_version }}"
+            echo "TAG=${VERSION//-SNAPSHOT/}" >> "$GITHUB_OUTPUT"
+            echo "PROJECT_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
             echo "NPM_VERSION=${{ github.event.inputs.npm_version }}" >> "$GITHUB_OUTPUT"
             echo "NPM_TAG=${{ github.event.inputs.npm_tag }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/publish-jitexecutor-native.yml
+++ b/.github/workflows/publish-jitexecutor-native.yml
@@ -152,4 +152,4 @@ jobs:
           mv ./dist/win32/jitexecutor-runner-${{ needs.build_jitexecutor_native_binaries.outputs.package_version }}-runner.exe ./dist/win32/jitexecutor.exe
           npm version ${{ needs.build_jitexecutor_native_binaries.outputs.npm_version }}
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          npm publish --access public
+          npm publish --tag dev --access public

--- a/.github/workflows/publish-jitexecutor-native.yml
+++ b/.github/workflows/publish-jitexecutor-native.yml
@@ -78,11 +78,9 @@ jobs:
           sudo mv graalvm-community-openjdk-17.0.9+9.1 /Library/Java/JavaVirtualMachines/graalvm-community-openjdk-17.0.9+9.1
           export PATH=/Library/Java/JavaVirtualMachines/graalvm-community-openjdk-17.0.9+9.1/Contents/Home/bin:$PATH && \
           export GRAALVM_HOME=/Library/Java/JavaVirtualMachines/graalvm-community-openjdk-17.0.9+9.1/Contents/Home && \
-          gu install native-image
-          if [ ${{ github.event_name }} == "schedule" ]; then
-            mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
-            mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
-          fi
+          gu install native-image && \
+          mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
+          mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
           mvn clean package -B -ntp -DskipTests -f ./jitexecutor && mvn clean package -B -ntp -DskipTests -Pnative -am -f ./jitexecutor
 
       - name: "Build Linux"
@@ -93,11 +91,9 @@ jobs:
           build-essential \
           libgtk-3-dev \
           libappindicator3-dev \
-          gir1.2-appindicator3-0.1
-          if [ ${{ github.event_name }} == "schedule" ]; then
-            mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
-            mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
-          fi
+          gir1.2-appindicator3-0.1 && \
+          mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
+          mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
           mvn clean package -B -ntp -DskipTests -f ./jitexecutor && mvn clean package -B -ntp -DskipTests -Pnative -am -f ./jitexecutor
 
       - name: "Configure Pagefile"
@@ -127,10 +123,8 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          if [ ${{ github.event_name }} == "schedule" ]; then
-            mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
-            mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
-          fi
+          mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
+          mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
           mvn clean package -B -ntp -DskipTests -f ./jitexecutor && mvn clean package -B -ntp -DskipTests -Pnative -am -f ./jitexecutor
 
       - name: "Upload JIT Executor binary"

--- a/.github/workflows/publish-jitexecutor-native.yml
+++ b/.github/workflows/publish-jitexecutor-native.yml
@@ -1,6 +1,17 @@
 name: "Publish jitexecutor-native"
 
 on:
+  workflow_dispatch:
+    inputs:
+      kogito_runtime_version:
+        description: "Kogito Runtime version"
+        required: true
+      npm_version:
+        description: "NPM Version"
+        required: true
+      npm_tag:
+        description: "NPM Tag"
+        required: true
   schedule:
     - cron: '0 16 * * 0' # Every sunday at 4:00PM
 
@@ -21,10 +32,19 @@ jobs:
       - name: Set version
         id: version
         run: | 
-          VERSION="999-${{ steps.date.outputs.CURRENT_DATE }}"
-          echo "TAG=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "PROJECT_VERSION=$VERSION-SNAPSHOT" >> "$GITHUB_OUTPUT"
-          echo "NPM_VERSION=999.0.0-${{ steps.date.outputs.CURRENT_DATE }}-SNAPSHOT" >> "$GITHUB_OUTPUT"
+          if [ ${{ github.event_name }} == "schedule" ]; then
+            VERSION="999-${{ steps.date.outputs.CURRENT_DATE }}"
+            echo "TAG=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "PROJECT_VERSION=$VERSION-SNAPSHOT" >> "$GITHUB_OUTPUT"
+            echo "NPM_VERSION=999.0.0-${{ steps.date.outputs.CURRENT_DATE }}-SNAPSHOT" >> "$GITHUB_OUTPUT"
+            echo "NPM_TAG=dev" >> "$GITHUB_OUTPUT"
+          else
+            VERSION="${{ github.event.inputs.npm_version }}"
+            echo "TAG=${{ github.event.inputs.kogito_runtime_version }}" >> "$GITHUB_OUTPUT"
+            echo "PROJECT_VERSION=${{ github.event.inputs.kogito_runtime_version }}" >> "$GITHUB_OUTPUT"
+            echo "NPM_VERSION=${{ github.event.inputs.npm_version }}" >> "$GITHUB_OUTPUT"
+            echo "NPM_TAG=${{ github.event.inputs.npm_tag }}" >> "$GITHUB_OUTPUT"
+          fi
         shell: bash
 
       - name: "Set long paths for Windows"
@@ -58,9 +78,11 @@ jobs:
           sudo mv graalvm-community-openjdk-17.0.9+9.1 /Library/Java/JavaVirtualMachines/graalvm-community-openjdk-17.0.9+9.1
           export PATH=/Library/Java/JavaVirtualMachines/graalvm-community-openjdk-17.0.9+9.1/Contents/Home/bin:$PATH && \
           export GRAALVM_HOME=/Library/Java/JavaVirtualMachines/graalvm-community-openjdk-17.0.9+9.1/Contents/Home && \
-          gu install native-image && \
-          mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
-          mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
+          gu install native-image
+          if [ ${{ github.event_name }} == "schedule" ]; then
+            mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
+            mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
+          fi
           mvn clean package -B -ntp -DskipTests -f ./jitexecutor && mvn clean package -B -ntp -DskipTests -Pnative -am -f ./jitexecutor
 
       - name: "Build Linux"
@@ -71,9 +93,11 @@ jobs:
           build-essential \
           libgtk-3-dev \
           libappindicator3-dev \
-          gir1.2-appindicator3-0.1 && \
-          mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
-          mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
+          gir1.2-appindicator3-0.1
+          if [ ${{ github.event_name }} == "schedule" ]; then
+            mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
+            mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
+          fi
           mvn clean package -B -ntp -DskipTests -f ./jitexecutor && mvn clean package -B -ntp -DskipTests -Pnative -am -f ./jitexecutor
 
       - name: "Configure Pagefile"
@@ -103,8 +127,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
-          mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
+          if [ ${{ github.event_name }} == "schedule" ]; then
+            mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
+            mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
+          fi
           mvn clean package -B -ntp -DskipTests -f ./jitexecutor && mvn clean package -B -ntp -DskipTests -Pnative -am -f ./jitexecutor
 
       - name: "Upload JIT Executor binary"
@@ -116,6 +142,7 @@ jobs:
     outputs:
       package_version: ${{ steps.version.outputs.PROJECT_VERSION }}
       npm_version: ${{ steps.version.outputs.NPM_VERSION }}
+      npm_tag: ${{ steps.version.outputs.NPM_TAG }}
 
   pack_and_publish:
     runs-on: ubuntu-latest
@@ -152,4 +179,4 @@ jobs:
           mv ./dist/win32/jitexecutor-runner-${{ needs.build_jitexecutor_native_binaries.outputs.package_version }}-runner.exe ./dist/win32/jitexecutor.exe
           npm version ${{ needs.build_jitexecutor_native_binaries.outputs.npm_version }}
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          npm publish --tag dev --access public
+          npm publish --tag ${{ needs.build_jitexecutor_native_binaries.outputs.npm_tag }} --access public

--- a/.github/workflows/publish-jitexecutor-native.yml
+++ b/.github/workflows/publish-jitexecutor-native.yml
@@ -39,7 +39,6 @@ jobs:
             echo "NPM_VERSION=999.0.0-${{ steps.date.outputs.CURRENT_DATE }}-SNAPSHOT" >> "$GITHUB_OUTPUT"
             echo "NPM_TAG=dev" >> "$GITHUB_OUTPUT"
           else
-            VERSION="${{ github.event.inputs.npm_version }}"
             echo "TAG=${{ github.event.inputs.kogito_runtime_version }}" >> "$GITHUB_OUTPUT"
             echo "PROJECT_VERSION=${{ github.event.inputs.kogito_runtime_version }}" >> "$GITHUB_OUTPUT"
             echo "NPM_VERSION=${{ github.event.inputs.npm_version }}" >> "$GITHUB_OUTPUT"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@actions/core": "^1.10.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "devDependencies": {
-    "@actions/core": "^1.10.1"
-  }
-}


### PR DESCRIPTION
This PR adds updates the npm publish command to set a `dev` tag for the JIT executor native weekly snapshot packages.

It also adds the ability to manually trigger the workflow.