### PR TITLE
[incubator-kie-issues-989] Add a null check on milestones attribute in ProcessDetails component

### DIFF
--- a/ui-packages/packages/process-details/src/envelope/components/ProcessDetails/ProcessDetails.tsx
+++ b/ui-packages/packages/process-details/src/envelope/components/ProcessDetails/ProcessDetails.tsx
@@ -350,7 +350,7 @@ const ProcessDetails: React.FC<ProcessDetailsProps> = ({
         <FlexItem>
           <ProcessDetailsPanel processInstance={data} driver={driver} />
         </FlexItem>
-        {data.milestones.length > 0 && (
+        {data.milestones?.length > 0 && (
           <FlexItem>
             <ProcessDetailsMilestonesPanel milestones={data.milestones} />
           </FlexItem>


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/989

Building and running the data-index service and the management console based on master branch, it seems that milestones attribute can be now null instead of being an empty array as before. 

I have the feeling that it is following this big refactor on the serialization of the process instance feed between the kogito runtime and the data-index service: https://github.com/apache/incubator-kie-kogito-apps/commit/ffc8500bbdfb979598392719d3b629a673ee5bdf

A simple optional chaining operator is resolving the issue.