### PR TITLE
[Fix apache/incubator-kie-issues#987] Update state to error

### DIFF
--- a/data-index/data-index-common/src/main/java/org/kie/kogito/index/CommonUtils.java
+++ b/data-index/data-index-common/src/main/java/org/kie/kogito/index/CommonUtils.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 public class CommonUtils {
 
+    public static final int ERROR_STATE = 5;
     private static final Set<String> finalStates = Set.of("Completed", "Aborted");
 
     public static boolean isTaskCompleted(String status) {

--- a/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/merger/ProcessInstanceErrorDataEventMerger.java
+++ b/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/merger/ProcessInstanceErrorDataEventMerger.java
@@ -20,6 +20,7 @@ package org.kie.kogito.index.storage.merger;
 
 import org.kie.kogito.event.process.ProcessInstanceDataEvent;
 import org.kie.kogito.event.process.ProcessInstanceErrorDataEvent;
+import org.kie.kogito.index.CommonUtils;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.kie.kogito.index.model.ProcessInstanceError;
 
@@ -36,6 +37,7 @@ public class ProcessInstanceErrorDataEventMerger extends ProcessInstanceEventMer
         error.setMessage(event.getData().getErrorMessage());
         error.setNodeDefinitionId(event.getData().getNodeDefinitionId());
         pi.setError(error);
+        pi.setState(CommonUtils.ERROR_STATE);
         return pi;
     }
 

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
@@ -33,6 +33,7 @@ import org.kie.kogito.event.process.ProcessInstanceStateDataEvent;
 import org.kie.kogito.event.process.ProcessInstanceStateEventBody;
 import org.kie.kogito.event.process.ProcessInstanceVariableDataEvent;
 import org.kie.kogito.event.process.ProcessInstanceVariableEventBody;
+import org.kie.kogito.index.CommonUtils;
 import org.kie.kogito.index.jpa.mapper.ProcessInstanceEntityMapper;
 import org.kie.kogito.index.jpa.model.MilestoneEntity;
 import org.kie.kogito.index.jpa.model.NodeInstanceEntity;
@@ -116,6 +117,7 @@ public class ProcessInstanceEntityStorage extends AbstractJPAStorageFetcher<Stri
         }
         errorEntity.setMessage(error.getErrorMessage());
         errorEntity.setNodeDefinitionId(error.getNodeDefinitionId());
+        pi.setState(CommonUtils.ERROR_STATE);
         repository.flush();
     }
 


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/987
Since error event is not longer paired with state event, when an error is received the state has to be updated to error. 
Merge with https://github.com/apache/incubator-kie-drools/pull/5766 and https://github.com/apache/incubator-kie-kogito-runtimes/pull/3428