### PR TITLE
[NO_ISSUE] Fixing named datasource's configuration for `data-index-inmemory` & `jobs-service-embedded`

### DIFF
--- a/data-index/data-index-storage/data-index-storage-jpa/src/test/resources/application.properties
+++ b/data-index/data-index-storage/data-index-storage-jpa/src/test/resources/application.properties
@@ -28,3 +28,9 @@ quarkus.hibernate-orm.database.generation.halt-on-error=true
 quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 quarkus.hibernate-orm.jdbc.timezone=UTC
 quarkus.hibernate-orm.log.sql=true
+
+# Disabling Security for tests
+quarkus.oidc.enabled=false
+quarkus.oidc.tenant-enabled=false
+quarkus.oidc.auth-server-url=none
+quarkus.keycloak.devservices.enabled=false

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/test/resources/application.properties
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/test/resources/application.properties
@@ -32,3 +32,9 @@ quarkus.log.level=INFO
 quarkus.mongodb.database=kogito
 quarkus.mongodb.devservices.enabled=false
 kogito.apps.persistence.type=mongodb
+
+# Disabling Security for tests
+quarkus.oidc.enabled=false
+quarkus.oidc.tenant-enabled=false
+quarkus.oidc.auth-server-url=none
+quarkus.keycloak.devservices.enabled=false

--- a/data-index/data-index-storage/data-index-storage-postgresql-reporting/src/test/resources/application.properties
+++ b/data-index/data-index-storage/data-index-storage-postgresql-reporting/src/test/resources/application.properties
@@ -31,3 +31,9 @@ quarkus.hibernate-orm.database.generation.halt-on-error=true
 quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 quarkus.hibernate-orm.jdbc.timezone=UTC
 quarkus.hibernate-orm.log.sql=true
+
+# Disabling Security for tests
+quarkus.oidc.enabled=false
+quarkus.oidc.tenant-enabled=false
+quarkus.oidc.auth-server-url=none
+quarkus.keycloak.devservices.enabled=false

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/test/resources/application.properties
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/test/resources/application.properties
@@ -30,3 +30,9 @@ quarkus.hibernate-orm.database.generation.halt-on-error=true
 quarkus.hibernate-orm.physical-naming-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 quarkus.hibernate-orm.jdbc.timezone=UTC
 quarkus.hibernate-orm.log.sql=true
+
+# Disabling Security for tests
+quarkus.oidc.enabled=false
+quarkus.oidc.tenant-enabled=false
+quarkus.oidc.auth-server-url=none
+quarkus.keycloak.devservices.enabled=false

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/runtime/src/main/resources/application.properties
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-inmemory/runtime/src/main/resources/application.properties
@@ -23,8 +23,8 @@ kogito.data-index.domain-indexing=false
 kogito.data-index.blocking=true
 
 #PostgreSql
-quarkus.datasource.data_index.db-kind=postgresql
-quarkus.datasource.data_index.devservices.enabled=false
+quarkus.datasource."data_index".db-kind=postgresql
+quarkus.datasource."data_index".devservices.enabled=false
 
 #Hibernate
 quarkus.hibernate-orm.jdbc.timezone=UTC

--- a/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/DMN15Test.java
+++ b/jitexecutor/jitexecutor-dmn/src/test/java/org/kie/kogito/jitexecutor/dmn/DMN15Test.java
@@ -22,11 +22,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.type.CollectionType;
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
-import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.jitexecutor.common.requests.MultipleResourcesPayload;
@@ -35,6 +30,13 @@ import org.kie.kogito.jitexecutor.dmn.requests.JITDMNPayload;
 import org.kie.kogito.jitexecutor.dmn.responses.JITDMNMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.type.CollectionType;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
@@ -75,7 +77,7 @@ class DMN15Test {
         Map<String, Object> context =
                 Map.of("A Person", Map.of("name", "John", "age", 47));
         JITDMNPayload jitdmnpayload = new JITDMNPayload(importingModelRef, List.of(model1, model2),
-                                                        context);
+                context);
         given()
                 .contentType(ContentType.JSON)
                 .body(jitdmnpayload)

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/runtime/src/main/resources/application.properties
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/runtime/src/main/resources/application.properties
@@ -20,8 +20,8 @@ quarkus.arc.selected-alternatives=org.kie.kogito.addons.quarkus.jobs.service.emb
 
 %dev.quarkus.log.category."org.kie.kogito.jobs".level=INFO
 
-quarkus.datasource.jobs_service.db-kind=postgresql
-quarkus.datasource.jobs_service.devservices.enabled=false
+quarkus.datasource."jobs_service".db-kind=postgresql
+quarkus.datasource."jobs_service".devservices.enabled=false
 quarkus.datasource.devservices.enabled=false
 quarkus.flyway.jobs_service.locations=db/jobs-service
 quarkus.flyway.jobs_service.migrate-at-start=true


### PR DESCRIPTION
This PR adds missing quotes to the named datasource's for `data-index-inmemory` & `jobs-service-embedded` configuration. 

After Quarkus `3.8.4` upgrade without this quotes the datasource configuration generated  by `quarkus-embedded-posgresql` extension isn't available at startup, making the quarkus not being able to initialize the named DataSources.

Ensemble:
https://github.com/apache/incubator-kie-kogito-runtimes/pull/3499
https://github.com/apache/incubator-kie-kogito-apps/pull/2042
https://github.com/apache/incubator-kie-kogito-examples/pull/1913

Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/apache/incubator-kie-kogito-runtimes#contributing-to-kogito)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- for <b>pull request checks</b>  
  Please add comment: <b>Jenkins retest this</b>

- for a <b>specific pull request check</b>  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] tests</b>

- for <b>quarkus branch checks</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins run quarkus-branch</b>

- for a <b>quarkus branch specific check</b>  
  Run checks against Quarkus current used branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-branch</b>

- for <b>quarkus main checks</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins run quarkus-main</b>

- for a <b>specific quarkus main check</b>  
  Run checks against Quarkus main branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-main</b>

- for <b>quarkus lts checks</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins run quarkus-lts</b>

- for a <b>specific quarkus lts check</b>  
  Run checks against Quarkus lts branch  
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] quarkus-lts</b>
 
- for <b>native checks</b>  
  Run native checks  
  Please add comment: <b>Jenkins run native</b>

- for a <b>specific native check</b>  
  Run native checks 
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] native</b>

- for <b>native lts checks</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins run native-lts</b>

- for a <b>specific native lts check</b>  
  Run native checks against quarkus lts branch
  Please add comment: <b>Jenkins (re)run [kogito-apps|kogito-examples] native-lts</b>
 
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>

<details>
<summary>
Quarkus-3 PR check is failing ... what to do ?
</summary>
The Quarkus 3 check is applying patches from the `.ci/environments/quarkus-3/patches`.

The first patch, called `0001_before_sh.patch`, is generated from Openrewrite `.ci/environments/quarkus-3/quarkus3.yml` recipe. The patch is created to speed up the check. But it may be that some changes in the PR broke this patch.  
No panic, there is an easy way to regenerate it. You just need to comment on the PR:
```
jenkins rewrite quarkus-3
```
and it should, after some minutes (~20/30min) apply a commit on the PR with the patch regenerated.

Other patches were generated manually. If any of it fails, you will need to manually update it... and push your changes.
</details>