### PR TITLE
NO-ISSUE: Revert the removal of repositories in the pom.xml file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,24 @@
     </pluginManagement>
   </build>
 
+  <repositories>
+    <!-- Bootstrap repository to locate the parent pom when the parent pom has not been build locally. -->
+    <repository>
+        <id>apache-public-repository-group</id>
+        <name>Apache Public Repository Group</name>
+        <url>https://repository.apache.org/content/groups/public/</url>
+        <layout>default</layout>
+        <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>daily</updatePolicy>
+        </snapshots>
+    </repository>
+  </repositories>
+
   <modules>
     <module>kogito-apps-bom</module>
     <module>kogito-apps-build-parent</module>

--- a/pom.xml
+++ b/pom.xml
@@ -109,20 +109,14 @@
   </build>
 
   <repositories>
-    <!-- Bootstrap repository to locate the parent pom when the parent pom has not been build locally. -->
+    <!-- useful to resolve parent pom when it is a SNAPSHOT -->
     <repository>
-        <id>apache-public-repository-group</id>
-        <name>Apache Public Repository Group</name>
-        <url>https://repository.apache.org/content/groups/public/</url>
-        <layout>default</layout>
-        <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-        </releases>
-        <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>daily</updatePolicy>
-        </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <id>apache.snapshots</id>
+      <name>Apache Snapshot Repository</name>
+      <url>https://repository.apache.org/snapshots</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Removing the repositories from the pom.xml file caused errors when building kogito-apps:

```02:09:29  [FATAL] Non-resolvable parent POM for org.kie.kogito:kogito-apps:999-SNAPSHOT: The following artifacts could not be resolved: org.kie.kogito:kogito-build-parent:pom:999-SNAPSHOT (absent): Could not find artifact org.kie.kogito:kogito-build-parent:pom:999-SNAPSHOT and 'parent.relativePath' points at no local POM @ line 28, column 11
02:09:29   @ 
02:09:29  [ERROR] The build could not read 1 project -> [Help 1]
02:09:29  [ERROR]   
02:09:29  [ERROR]   The project org.kie.kogito:kogito-apps:999-SNAPSHOT (/home/jenkins/workspace/KIE/kogito/main/other/kogito-apps.weekly-deploy/incubator-kie-kogito-apps/pom.xml) has 1 error
02:09:29  [ERROR]     Non-resolvable parent POM for org.kie.kogito:kogito-apps:999-SNAPSHOT: The following artifacts could not be resolved: org.kie.kogito:kogito-build-parent:pom:999-SNAPSHOT (absent): Could not find artifact org.kie.kogito:kogito-build-parent:pom:999-SNAPSHOT and 'parent.relativePath' points at no local POM @ line 28, column 11 -> [Help 2]
```

This PR reverts [this change](https://github.com/apache/incubator-kie-kogito-apps/pull/2040/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L60-L77) back to avoid having this error.