### PR TITLE
kie-issues#1237: stay on x.y.999-SNAPSHOT in release branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -34,7 +34,7 @@ pipeline {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
-                    checkoutRepo(droolsRepo, getDroolsTargetBranch())
+                    checkoutRepo(droolsRepo, getBuildBranch())
                     checkoutRepo(kogitoRuntimesRepo, getBuildBranch())
                     checkoutRepo(getRepoName(), getBuildBranch())
                 }
@@ -126,18 +126,6 @@ void checkoutRepo(String repository, String branch) {
         // need to manually checkout branch since on a detached branch after checkout command
         sh "git checkout ${branch}"
     }
-}
-
-String getDroolsTargetBranch() {
-    String targetBranch = getBuildBranch()
-    List versionSplit = targetBranch.split("\\.") as List
-
-    if (versionSplit[0].isNumber()) {
-        targetBranch = "${Integer.parseInt(versionSplit[0]) + 7}.${versionSplit.tail().join('.')}"
-    } else {
-        echo "Cannot parse targetBranch as release branch so going further with current value: ${targetBranch}"
-    }
-    return targetBranch
 }
 
 String getRepoName() {


### PR DESCRIPTION
Part of
* apache/incubator-kie-issues#1237

Adjusts the snapshot version changes to happen only in new branch when branching, not in main.

Ensemble:
* apache/incubator-kie-kogito-pipelines#1201
* apache/incubator-kie-drools#5967
* apache/incubator-kie-optaplanner#3089
* apache/incubator-kie-kogito-runtimes#3527
* apache/incubator-kie-kogito-apps#2059
* apache/incubator-kie-kogito-examples#1925
* apache/incubator-kie-optaplanner-quickstarts#630