### PR TITLE
[disabling_tracing-decision_module] Removing tracing-decision module from maven reactor

### DIFF
--- a/apps-integration-tests/integration-tests-trusty-service/pom.xml
+++ b/apps-integration-tests/integration-tests-trusty-service/pom.xml
@@ -32,7 +32,6 @@
 
   <modules>
     <module>integration-tests-trusty-service-common</module>
-    <module>integration-tests-trusty-service-quarkus</module>
     <module>integration-tests-trusty-service-springboot</module>
   </modules>
 


### PR DESCRIPTION
This is a follow-up on https://github.com/apache/incubator-kie-kogito-runtimes/pull/3531. More information in the kogito-runtimes PR. 

kogito-runtimes PR: https://github.com/apache/incubator-kie-kogito-runtimes/pull/3533
kogito-examples PR: https://github.com/apache/incubator-kie-kogito-examples/pull/1930