### PR TITLE
kie-issues#1387: Adjust pipelines to use the gpg key provided by Apache to sign the artifacts

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -123,12 +123,9 @@ pipeline {
                             }
                         }
                         if (isRelease()) {
-                            release.gpgImportKeyFromFileWithPassword(getReleaseGpgSignKeyCredsId(), getReleaseGpgSignPassphraseCredsId())
-                            withCredentials([string(credentialsId: getReleaseGpgSignPassphraseCredsId(), variable: 'SIGNING_KEY_PASSWORD')]) {
-                                    mavenCommand.withProperty('gpg.passphrase', SIGNING_KEY_PASSWORD)
-                                    mavenCommand.withProfiles(['apache-release'])
-                                    mavenRunClosure()
-                            }
+                            release.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
+                            mavenCommand.withProfiles(['apache-release'])
+                            mavenRunClosure()
                         } else {
                             mavenRunClosure()
                         }


### PR DESCRIPTION
Part of: https://github.com/apache/incubator-kie-issues/issues/1387