### PR TITLE
[10.0.x] NO-ISSUE: Backport publish-jitexecutor-native-rc workflow to 10.0.x branch

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -182,6 +182,22 @@ pipeline {
                 }
             }
         }
+
+        stage('Trigger JIT Executor Native - Release Candidate - GH workflow') {
+            steps {
+                script {
+                    dir(getRepoName()) {
+                        withCredentials([usernamePassword(credentialsId: "${getGitAuthorPushCredsId()}", usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+                            sh """
+                            git config user.email ${GITHUB_USER}@jenkins.kie.apache.org
+                            git config user.name ${GITHUB_USER}
+                            gh workflow run "publish-jitexecutor-native-rc.yml" --ref "${getBuildBranch()}" -f release_candidate_version="${getProjectVersion()}" --repo="https://github.com/${getGitAuthor()}/${getRepoName()}"
+                            """
+                        }
+                    }
+                }
+            }
+        }
     }
     post {
         always {

--- a/.github/workflows/publish-jitexecutor-native-rc.yml
+++ b/.github/workflows/publish-jitexecutor-native-rc.yml
@@ -1,0 +1,169 @@
+name: "Publish jitexecutor-native - Release Candidate"
+
+on:
+  pull_request:
+    branches: ["**"]
+    paths:
+      - ".github/workflows/publish-jitexecutor-native-rc.yml"
+  workflow_dispatch:
+    inputs:
+      release_candidate_version:
+        description: "Release candidate version"
+        required: true
+
+jobs:
+  build_jitexecutor_native:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          if [ ${{ github.event_name }} == "pull_request" ]; then
+            echo "REPOSITORY=${{github.event.pull_request.head.repo.full_name}}" >> "$GITHUB_OUTPUT"
+            echo "REF=${{github.event.pull_request.head.ref}}" >> "$GITHUB_OUTPUT"
+            echo "PROJECT_VERSION=999-SNAPSHOT" >> "$GITHUB_OUTPUT"
+          else
+            VERSION="${{ github.event.inputs.release_candidate_version }}"
+            echo "REPOSITORY=apache/incubator-kie-kogito-apps" >> "$GITHUB_OUTPUT"
+            echo "REF=${VERSION//-SNAPSHOT/}" >> "$GITHUB_OUTPUT"
+            echo "PROJECT_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
+      - name: "Set long paths for Windows"
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
+      - name: "Checkout kie-kogito-apps"
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.version.outputs.REPOSITORY }}
+          ref: ${{ steps.version.outputs.REF }}
+
+      - name: "Set up Maven"
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.6
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_KEY }}
+
+      - name: "Set up JDK 17"
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          server-id: apache.releases.https
+          server-username: ${{ secrets.NEXUS_STAGE_DEPLOYER_USER }}
+          server-password: ${{ secrets.NEXUS_STAGE_DEPLOYER_PW }}
+          gpg-private-key: ${{ secrets.GPG_KEY }}
+          gpg-passphrase: ""
+
+      - name: "Setup Linux"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update && \
+          sudo apt install -y \
+          build-essential \
+          libgtk-3-dev \
+          libappindicator3-dev \
+          gir1.2-appindicator3-0.1
+
+      - name: "Setup macOS"
+        if: runner.os == 'macOS'
+        run: |
+          brew install make && \
+          wget https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-17.0.9/graalvm-community-jdk-17.0.9_macos-x64_bin.tar.gz && \
+          tar -xzf graalvm-community-jdk-17.0.9_macos-x64_bin.tar.gz && \
+          sudo mv graalvm-community-openjdk-17.0.9+9.1 /Library/Java/JavaVirtualMachines/graalvm-community-openjdk-17.0.9+9.1
+          export GRAALVM_HOME=/Library/Java/JavaVirtualMachines/graalvm-community-openjdk-17.0.9+9.1/Contents/Home
+          export PATH=${GRAALVM_HOME}/bin:$PATH
+          echo "${GRAALVM_HOME}/bin" >> $GITHUB_PATH && \
+          echo "GRAALVM_HOME=${GRAALVM_HOME}" >> $GITHUB_ENV && \
+          gu install native-image
+
+      - name: "Setup MSCV"
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: "Setup MSBUILD"
+        if: runner.os == 'Windows'
+        uses: microsoft/setup-msbuild@v2
+
+      - name: "Setup GraalVM"
+        if: runner.os == 'Windows'
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "17"
+          components: "native-image"
+
+      - name: "Configure Pagefile"
+        if: runner.os == 'Windows'
+        uses: al-cheb/configure-pagefile-action@a3b6ebd6b634da88790d9c58d4b37a7f4a7b8708 #v1.4
+        with:
+          minimum-size: 16GB
+          maximum-size: 16GB
+          disk-root: "C:"
+
+      - name: "Update versions (Linux and macOS)"
+        if: (runner.os == 'Linux' || runner.os == 'macOS') && github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
+          mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
+
+      - name: "Update versions Windows"
+        if: runner.os == 'Windows' && github.event_name != 'pull_request'
+        shell: pwsh
+        run: |
+          mvn -B -fae -ntp -N -e versions:update-parent -DparentVersion="[${{ steps.version.outputs.PROJECT_VERSION }}]" -DallowSnapshots=true -DgenerateBackupPoms=false
+          mvn -B -fae -ntp -N -e versions:update-child-modules -DallowSnapshots=true -DgenerateBackupPoms=false
+
+      - name: "Build macOS"
+        if: runner.os == 'macOS' && github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          mvn clean install -B -ntp -DskipTests -pl jitexecutor-native/jitexecutor-native-darwin -am -Pjitexecutor-native
+
+      - name: "Build and publish macOS"
+        if: runner.os == 'macOS' && github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          mvn clean deploy -B -ntp -DdeployAtEnd -DskipTests -pl jitexecutor-native/jitexecutor-native-darwin -am -Pjitexecutor-native -Prelease
+
+      - name: "Build Linux"
+        if: runner.os == 'Linux' && github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          mvn clean install -B -ntp -DskipTests -pl jitexecutor-native/jitexecutor-native-linux -am -Pjitexecutor-native
+
+      - name: "Build and Publish Linux"
+        if: runner.os == 'Linux' && github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          mvn clean deploy -B -ntp -DdeployAtEnd -DskipTests -pl jitexecutor-native/jitexecutor-native-linux -am -Pjitexecutor-native -Prelease
+
+      - name: "Build Windows"
+        if: runner.os == 'Windows' && github.event_name == 'pull_request'
+        shell: pwsh
+        run: |
+          mvn clean install -B -ntp -DskipTests -pl jitexecutor-native/jitexecutor-native-win32 -am -Pjitexecutor-native
+      
+      - name: "Build and Publish Windows"
+        if: runner.os == 'Windows' && github.event_name != 'pull_request'
+        shell: pwsh
+        run: |
+          mvn clean deploy -B -ntp -DdeployAtEnd -DskipTests -pl jitexecutor-native/jitexecutor-native-win32 -am -Pjitexecutor-native -Prelease
+
+      - name: "Upload JIT Executor binary"
+        uses: actions/upload-artifact@v4
+        with:
+          name: jitexecutor_${{ runner.os }}
+          path: ./jitexecutor-native/jitexecutor-native-*/target/jitexecutor-native-*-${{ steps.version.outputs.PROJECT_VERSION }}-run*


### PR DESCRIPTION
Cherry-pick: [450d01a1da3ea9255d36c6f149346f3de0854756](https://github.com/apache/incubator-kie-kogito-apps/commit/450d01a1da3ea9255d36c6f149346f3de0854756) and add a trigger for the publish-jitexecutor-native-rc workflow in the deploy Jenkins job.