### PR TITLE
[10.0.x] NO-ISSUE: Update release utils file 

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -117,7 +117,7 @@ pipeline {
                            .skipTests(skipTests)
 
                         if (isRelease()) {
-                            release.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
+                            releaseUtils.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
                             mavenCommand.withProfiles(['apache-release'])
                         }
 


### PR DESCRIPTION
The release.grovvy file has been renamed to releaseUtils.groovy on [jenkins-pipeline-shared-libraries](https://github.com/apache/incubator-kie-kogito-pipelines/tree/10.0.x/jenkins-pipeline-shared-libraries/vars).

This PR updates the deploy job to use the new name.