### PR TITLE
NO-ISSUE: Increase macOS runner memory to fix native build of jitexecutor-native

### DIFF
--- a/.github/workflows/publish-jitexecutor-native-rc.yml
+++ b/.github/workflows/publish-jitexecutor-native-rc.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
       - name: Set version

--- a/.github/workflows/publish-jitexecutor-native.yml
+++ b/.github/workflows/publish-jitexecutor-native.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
       - name: Get current date


### PR DESCRIPTION
The macOS native build of the jitexecutor-native is failing due to the lack of memory. This PR changes the macOS runner to "macos-13" which has 14Gb instead of 7Gb from the "macos-latest" [1].

[1] https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners