### PR TITLE
[incubator-kie-issues-1682] Test cases in kogito repos GHA fail with …

### DIFF
--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/src/test/resources/application.properties
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/src/test/resources/application.properties
@@ -17,13 +17,4 @@
 # under the License.
 #
 
-quarkus.http.test-port=0
-# Outgoing events for the event based API integration tests
-%kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.connector=smallrye-kafka
-%kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.topic=kogito-job-service-job-request-events
-%kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-
-quarkus.datasource.devservices.enabled=false
-quarkus.kogito.devservices.enabled=false
-
 quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/data-index/data-index-service/data-index-service-infinispan/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-infinispan/src/test/resources/application.properties
@@ -54,3 +54,5 @@ kogito.data-index.vertx-graphql.ui.tenant=web-app-tenant
 
 # Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
 quarkus.keycloak.devservices.enabled=false
+
+quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/data-index/data-index-service/data-index-service-mongodb/src/test/resources/application.properties
+++ b/data-index/data-index-service/data-index-service-mongodb/src/test/resources/application.properties
@@ -62,3 +62,5 @@ kogito.data-index.vertx-graphql.ui.tenant=web-app-tenant
 
 # Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
 quarkus.keycloak.devservices.enabled=false
+
+quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/jobs-service/jobs-service-infinispan/src/test/resources/application.properties
+++ b/jobs-service/jobs-service-infinispan/src/test/resources/application.properties
@@ -36,3 +36,5 @@ quarkus.oidc.tenant-enabled=false
 %kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.connector=smallrye-kafka
 %kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.topic=kogito-job-service-job-request-events
 %kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/jobs-service/jobs-service-messaging-kafka/src/test/resources/application.properties
+++ b/jobs-service/jobs-service-messaging-kafka/src/test/resources/application.properties
@@ -17,13 +17,5 @@
 # under the License.
 #
 
-quarkus.http.test-port=0
-# Outgoing events for the event based API integration tests
-%kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.connector=smallrye-kafka
-%kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.topic=kogito-job-service-job-request-events
-%kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.value.serializer=org.apache.kafka.common.serialization.StringSerializer
-
-quarkus.datasource.devservices.enabled=false
-quarkus.kogito.devservices.enabled=false
-
 quarkus.kafka.devservices.image-name=${container.image.kafka}
+

--- a/jobs-service/jobs-service-mongodb/src/test/resources/application.properties
+++ b/jobs-service/jobs-service-mongodb/src/test/resources/application.properties
@@ -39,3 +39,5 @@ quarkus.mongodb.database=kogito
 %kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.connector=smallrye-kafka
 %kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.topic=kogito-job-service-job-request-events
 %kafka-events-support.mp.messaging.outgoing.kogito-job-service-job-request-events-emitter.value.serializer=org.apache.kafka.common.serialization.StringSerializer
+
+quarkus.kafka.devservices.image-name=${container.image.kafka}

--- a/kogito-apps-build-parent/pom.xml
+++ b/kogito-apps-build-parent/pom.xml
@@ -127,6 +127,7 @@
                     <configuration>
                         <systemPropertyVariables>
                             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                            <container.image.kafka>${container.image.kafka}</container.image.kafka>
                         </systemPropertyVariables>
                     </configuration>
                 </plugin>

--- a/trusty/trusty-service/trusty-service-common/src/test/resources/application.properties
+++ b/trusty/trusty-service/trusty-service-common/src/test/resources/application.properties
@@ -54,3 +54,5 @@ mp.messaging.incoming.trusty-explainability-result.auto.offset.reset=earliest
 
 # Not using Dev service in test, but rather org.kie.kogito.testcontainers.quarkus.KeycloakQuarkusTestResource
 quarkus.keycloak.devservices.enabled=false
+
+quarkus.kafka.devservices.image-name=${container.image.kafka}


### PR DESCRIPTION
…"pull access denied for vectorized/redpanda"

### Issue:
- https://github.com/apache/incubator-kie-issues/issues/1682

### Cross repo PRs
- https://github.com/apache/incubator-kie-kogito-runtimes/pull/3812
- https://github.com/apache/incubator-kie-kogito-apps/pull/2162 (This one)
- https://github.com/apache/incubator-kie-kogito-examples/pull/2043

---
- [x] You have read the [contributors guide](https://github.com/apache/incubator-kie-kogito-runtimes#contributing-to-kogito)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains link to any dependent or related Pull Request
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
