### PR TITLE
[Fix_#2183] Removing quarkus test utils from common module

### DIFF
--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/pom.xml
@@ -52,10 +52,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-quarkus-test-utils</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>compile</scope>
@@ -84,17 +80,6 @@
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-test-utils</artifactId>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.testcontainers</groupId>
-          <artifactId>oracle-xe</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.oracle.database.jdbc</groupId>
-          <artifactId>ojdbc11</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
-
 </project>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/src/main/java/org/kie/kogito/test/TestUtils.java
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-common/src/main/java/org/kie/kogito/test/TestUtils.java
@@ -19,35 +19,17 @@
 package org.kie.kogito.test;
 
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.awaitility.Awaitility;
-import org.kie.kogito.test.quarkus.kafka.KafkaTestClient;
 
 import io.restassured.http.ContentType;
-import io.restassured.path.json.JsonPath;
 
 import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
 public class TestUtils {
 
     private TestUtils() {
-    }
-
-    public static JsonPath waitForEvent(KafkaTestClient kafkaClient, String topic, long seconds) throws Exception {
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
-        final AtomicReference<String> cloudEvent = new AtomicReference<>();
-        kafkaClient.consume(topic, rawCloudEvent -> {
-            cloudEvent.set(rawCloudEvent);
-            countDownLatch.countDown();
-        });
-        // give some time to consume the event.
-        assertThat(countDownLatch.await(seconds, TimeUnit.SECONDS)).isTrue();
-        return new JsonPath(cloudEvent.get());
     }
 
     public static void assertJobsAndProcessOnDataIndex(String dataIndexURL, String processId, String processInstanceId, String processStatus, String jobStatus, Duration timeout) {


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-kogito-apps/issues/2183

There was some code in the common test library that was incorrectly referencing quarkus