### PR TITLE
Remove warning regarding lazy and Not found usage

### DIFF
--- a/data-index/data-index-graphql/src/main/java/org/kie/kogito/index/graphql/AbstractGraphQLSchemaManager.java
+++ b/data-index/data-index-graphql/src/main/java/org/kie/kogito/index/graphql/AbstractGraphQLSchemaManager.java
@@ -175,7 +175,7 @@ public abstract class AbstractGraphQLSchemaManager implements GraphQLSchemaManag
 
     public ProcessDefinition getProcessDefinition(DataFetchingEnvironment env) {
         ProcessInstance source = env.getSource();
-        return source.getDefinition();
+        return cacheService.getProcessDefinitionStorage().get(new ProcessDefinitionKey(source.getProcessId(), source.getVersion()));
     }
 
     protected String getServiceUrl(String endpoint, String processId) {

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/service/AbstractIndexingServiceIT.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/service/AbstractIndexingServiceIT.java
@@ -114,8 +114,8 @@ public abstract class AbstractIndexingServiceIT extends AbstractIndexingIT {
     @Transactional
     void tearDown() {
         cacheService.getJobsStorage().clear();
-        cacheService.getProcessDefinitionStorage().clear();
         cacheService.getProcessInstanceStorage().clear();
+        cacheService.getProcessDefinitionStorage().clear();
         cacheService.getUserTaskInstanceStorage().clear();
     }
 
@@ -191,6 +191,9 @@ public abstract class AbstractIndexingServiceIT extends AbstractIndexingIT {
     @Test
     void testProcessInstancePagination() {
         String processId = "travels";
+        ProcessDefinitionDataEvent definitionDataEvent = getProcessDefinitionDataEvent(processId);
+        indexProcessCloudEvent(definitionDataEvent);
+        validateProcessDefinition(getProcessDefinitionByIdAndVersion(processId, definitionDataEvent.getData().getVersion()), definitionDataEvent);
         List<String> pIds = new ArrayList<>();
 
         IntStream.range(0, 100).forEach(i -> {
@@ -230,8 +233,10 @@ public abstract class AbstractIndexingServiceIT extends AbstractIndexingIT {
     @Test
     void testUserTaskInstancePagination() {
         String processId = "deals";
+        ProcessDefinitionDataEvent definitionDataEvent = getProcessDefinitionDataEvent(processId);
+        indexProcessCloudEvent(definitionDataEvent);
+        validateProcessDefinition(getProcessDefinitionByIdAndVersion(processId, definitionDataEvent.getData().getVersion()), definitionDataEvent);
         List<String> taskIds = new ArrayList<>();
-
         IntStream.range(0, 100).forEach(i -> {
             String taskId = UUID.randomUUID().toString();
             UserTaskInstanceStateDataEvent event = getUserTaskCloudEvent(taskId, processId, UUID.randomUUID().toString(), null, null, "InProgress");
@@ -286,6 +291,9 @@ public abstract class AbstractIndexingServiceIT extends AbstractIndexingIT {
     @Test
     void testConcurrentProcessInstanceIndex() throws Exception {
         String processId = "travels";
+        ProcessDefinitionDataEvent definitionDataEvent = getProcessDefinitionDataEvent(processId);
+        indexProcessCloudEvent(definitionDataEvent);
+        validateProcessDefinition(getProcessDefinitionByIdAndVersion(processId, definitionDataEvent.getData().getVersion()), definitionDataEvent);
         ExecutorService executorService = new ScheduledThreadPoolExecutor(8);
         int max_instance_events = 10;
         List<CompletableFuture<Void>> futures = new ArrayList<>();
@@ -329,6 +337,10 @@ public abstract class AbstractIndexingServiceIT extends AbstractIndexingIT {
         ProcessDefinitionDataEvent definitionDataEvent = getProcessDefinitionDataEvent(processId);
         indexProcessCloudEvent(definitionDataEvent);
         validateProcessDefinition(getProcessDefinitionByIdAndVersion(processId, definitionDataEvent.getData().getVersion()), definitionDataEvent);
+
+        ProcessDefinitionDataEvent subProcessdefinitionDataEvent = getProcessDefinitionDataEvent(subProcessId);
+        indexProcessCloudEvent(subProcessdefinitionDataEvent);
+        validateProcessDefinition(getProcessDefinitionByIdAndVersion(subProcessId, subProcessdefinitionDataEvent.getData().getVersion()), subProcessdefinitionDataEvent);
 
         ProcessInstanceStateDataEvent startEvent = getProcessCloudEvent(processId, processInstanceId, ACTIVE, null, null, null, CURRENT_USER);
         indexProcessCloudEvent(startEvent);

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/mapper/ProcessInstanceEntityMapper.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/mapper/ProcessInstanceEntityMapper.java
@@ -19,16 +19,13 @@
 package org.kie.kogito.index.jpa.mapper;
 
 import org.kie.kogito.index.jpa.model.MilestoneEntity;
-import org.kie.kogito.index.jpa.model.ProcessDefinitionEntity;
 import org.kie.kogito.index.jpa.model.ProcessInstanceEntity;
 import org.kie.kogito.index.model.Milestone;
-import org.kie.kogito.index.model.ProcessDefinition;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.factory.Mappers;
 
 @Mapper(componentModel = "cdi", suppressTimestampInGenerated = true)
 public interface ProcessInstanceEntityMapper {
@@ -42,10 +39,6 @@ public interface ProcessInstanceEntityMapper {
 
     @InheritInverseConfiguration
     ProcessInstance mapToModel(ProcessInstanceEntity pi);
-
-    default ProcessDefinition mapToDefinition(ProcessDefinitionEntity entity) {
-        return Mappers.getMapper(ProcessDefinitionEntityMapper.class).mapToModel(entity);
-    }
 
     @AfterMapping
     default void afterMapping(@MappingTarget ProcessInstanceEntity entity) {

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/ProcessInstanceEntity.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/ProcessInstanceEntity.java
@@ -90,7 +90,7 @@ public class ProcessInstanceEntity extends AbstractEntity {
     @Embedded
     private ProcessInstanceErrorEntity error;
 
-    @ManyToOne(targetEntity = ProcessDefinitionEntity.class, fetch = FetchType.LAZY)
+    @ManyToOne(targetEntity = ProcessDefinitionEntity.class)
     @JoinColumns({ @JoinColumn(name = "processId", referencedColumnName = "id", insertable = false, updatable = false),
             @JoinColumn(name = "version", referencedColumnName = "version", insertable = false, updatable = false) })
     @NotFound(action = NotFoundAction.IGNORE)

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/ProcessInstanceEntity.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/ProcessInstanceEntity.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import org.hibernate.annotations.NotFound;
-import org.hibernate.annotations.NotFoundAction;
 import org.kie.kogito.persistence.postgresql.hibernate.JsonBinaryConverter;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -90,10 +88,9 @@ public class ProcessInstanceEntity extends AbstractEntity {
     @Embedded
     private ProcessInstanceErrorEntity error;
 
-    @ManyToOne(targetEntity = ProcessDefinitionEntity.class)
+    @ManyToOne(targetEntity = ProcessDefinitionEntity.class, fetch = FetchType.LAZY)
     @JoinColumns({ @JoinColumn(name = "processId", referencedColumnName = "id", insertable = false, updatable = false),
             @JoinColumn(name = "version", referencedColumnName = "version", insertable = false, updatable = false) })
-    @NotFound(action = NotFoundAction.IGNORE)
     private ProcessDefinitionEntity definition;
 
     @Override
@@ -288,10 +285,6 @@ public class ProcessInstanceEntity extends AbstractEntity {
     @Override
     public int hashCode() {
         return Objects.hash(id);
-    }
-
-    public ProcessDefinitionEntity getDefinition() {
-        return definition;
     }
 
     @Override


### PR DESCRIPTION
Remote this warning at startup

2025-02-27 09:17:53,031 WARN  [org.hib.boo.mod.int.ToOneBinder] (Quarkus Main Thread) HHH000491:
'org.kie.kogito.index.jpa.model.ProcessInstanceEntity.definition' uses both @NotFound and FetchType.LAZY. @Man2025-02-27 09:17:

