### PR TITLE
Avoid potential concurrent exception

### DIFF
--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/src/test/java/org/kie/kogito/jobs/embedded/EmbeddedJobsServiceTest.java
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/src/test/java/org/kie/kogito/jobs/embedded/EmbeddedJobsServiceTest.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.jobs.embedded;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
@@ -84,7 +85,7 @@ public class EmbeddedJobsServiceTest {
 
         latch.await();
 
-        List<DataEvent<?>> events = publisher.getEvents();
+        List<DataEvent<?>> events = new ArrayList<>(publisher.getEvents());
 
         Assertions.assertEquals(8, events.size());
 


### PR DESCRIPTION
If the list of events in the published (which global) gets modified by another test, then a concurrent exception will be thrown. In other words, the test is potentially flaky, so it is safer to copy the list to check it holds the expected data.

