### PR TITLE
[incubator-kie-issues#1858] Fixed missing data in jobs associated with User Tasks - Part 2

### DIFF
--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionDeserializer.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionDeserializer.java
@@ -75,11 +75,11 @@ public class JobDescriptionDeserializer extends StdDeserializer<JobDescription> 
 
                     ofNullable(node.get("userTaskInstanceId")).ifPresent(e -> builder.userTaskInstanceId(e.textValue()));
                     var metadata = new HashMap<String, Object>();
-                    ofNullable(node.get("processId")).ifPresent(e -> metadata.put("processId", e.textValue()));
-                    ofNullable(node.get("processInstanceId")).ifPresent(e -> metadata.put("processInstanceId", e.textValue()));
-                    ofNullable(node.get("nodeInstanceId")).ifPresent(e -> metadata.put("nodeInstanceId", e.textValue()));
-                    ofNullable(node.get("rootProcessInstanceId")).ifPresent(e -> metadata.put("rootProcessInstanceId", e.textValue()));
-                    ofNullable(node.get("rootProcessId")).ifPresent(e -> metadata.put("rootProcessId", e.textValue()));
+                    ofNullable(node.get("processId")).ifPresent(e -> metadata.put("ProcessId", e.textValue()));
+                    ofNullable(node.get("processInstanceId")).ifPresent(e -> metadata.put("ProcessInstanceId", e.textValue()));
+                    ofNullable(node.get("nodeInstanceId")).ifPresent(e -> metadata.put("NodeInstanceId", e.textValue()));
+                    ofNullable(node.get("rootProcessInstanceId")).ifPresent(e -> metadata.put("RootProcessInstanceId", e.textValue()));
+                    ofNullable(node.get("rootProcessId")).ifPresent(e -> metadata.put("RootProcessId", e.textValue()));
                     builder.metadata(metadata);
                     return builder.build();
                 }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionDeserializer.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionDeserializer.java
@@ -19,6 +19,7 @@
 package org.kie.kogito.jobs.service.json;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import org.kie.kogito.jobs.ExpirationTime;
 import org.kie.kogito.jobs.JobDescription;
@@ -73,9 +74,13 @@ public class JobDescriptionDeserializer extends StdDeserializer<JobDescription> 
                     builder.expirationTime((ExpirationTime) ctxt.readTreeAsValue(node.get("expirationTime"), Class.forName(expirationTimeType)));
 
                     ofNullable(node.get("userTaskInstanceId")).ifPresent(e -> builder.userTaskInstanceId(e.textValue()));
-                    ofNullable(node.get("processId")).ifPresent(e -> builder.processId(e.textValue()));
-                    ofNullable(node.get("processInstanceId")).ifPresent(e -> builder.processInstanceId(e.textValue()));
-                    ofNullable(node.get("nodeInstanceId")).ifPresent(e -> builder.nodeInstanceId(e.textValue()));
+                    var metadata = new HashMap<String, Object>();
+                    metadata.put("processId", node.get("processId").textValue());
+                    metadata.put("processInstanceId", node.get("processInstanceId").textValue());
+                    metadata.put("nodeInstanceId", node.get("nodeInstanceId").textValue());
+                    metadata.put("rootProcessInstanceId", node.get("rootProcessInstanceId").textValue());
+                    metadata.put("rootProcessId", node.get("rootProcessId").textValue());
+                    builder.metadata(metadata);
                     return builder.build();
                 }
             }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionDeserializer.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionDeserializer.java
@@ -75,11 +75,11 @@ public class JobDescriptionDeserializer extends StdDeserializer<JobDescription> 
 
                     ofNullable(node.get("userTaskInstanceId")).ifPresent(e -> builder.userTaskInstanceId(e.textValue()));
                     var metadata = new HashMap<String, Object>();
-                    metadata.put("processId", node.get("processId").textValue());
-                    metadata.put("processInstanceId", node.get("processInstanceId").textValue());
-                    metadata.put("nodeInstanceId", node.get("nodeInstanceId").textValue());
-                    metadata.put("rootProcessInstanceId", node.get("rootProcessInstanceId").textValue());
-                    metadata.put("rootProcessId", node.get("rootProcessId").textValue());
+                    ofNullable(node.get("processId")).ifPresent(e -> metadata.put("processId", e.textValue()));
+                    ofNullable(node.get("processInstanceId")).ifPresent(e -> metadata.put("processInstanceId", e.textValue()));
+                    ofNullable(node.get("nodeInstanceId")).ifPresent(e -> metadata.put("nodeInstanceId", e.textValue()));
+                    ofNullable(node.get("rootProcessInstanceId")).ifPresent(e -> metadata.put("rootProcessInstanceId", e.textValue()));
+                    ofNullable(node.get("rootProcessId")).ifPresent(e -> metadata.put("rootProcessId", e.textValue()));
                     builder.metadata(metadata);
                     return builder.build();
                 }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionDeserializer.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionDeserializer.java
@@ -73,6 +73,9 @@ public class JobDescriptionDeserializer extends StdDeserializer<JobDescription> 
                     builder.expirationTime((ExpirationTime) ctxt.readTreeAsValue(node.get("expirationTime"), Class.forName(expirationTimeType)));
 
                     ofNullable(node.get("userTaskInstanceId")).ifPresent(e -> builder.userTaskInstanceId(e.textValue()));
+                    ofNullable(node.get("processId")).ifPresent(e -> builder.processId(e.textValue()));
+                    ofNullable(node.get("processInstanceId")).ifPresent(e -> builder.processInstanceId(e.textValue()));
+                    ofNullable(node.get("nodeInstanceId")).ifPresent(e -> builder.nodeInstanceId(e.textValue()));
                     return builder.build();
                 }
             }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionSerializer.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionSerializer.java
@@ -52,7 +52,10 @@ public class JobDescriptionSerializer extends StdSerializer<JobDescription> {
             jgen.writeStringField("nodeInstanceId", jobDescription.nodeInstanceId());
             jgen.writeEndObject();
         } else if (value instanceof UserTaskInstanceJobDescription userTaskInstanceJobDescription) {
-            jgen.writeStringField("userTaskInstanceId", userTaskInstanceJobDescription.getUserTaskInstanceId());
+            jgen.writeStringField("userTaskInstanceId", userTaskInstanceJobDescription.userTaskInstanceId());
+            jgen.writeStringField("processId", userTaskInstanceJobDescription.processId());
+            jgen.writeStringField("processInstanceId", userTaskInstanceJobDescription.processInstanceId());
+            jgen.writeStringField("nodeInstanceId", userTaskInstanceJobDescription.nodeInstanceId());
         }
         jgen.writeEndObject();
     }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionSerializer.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/json/JobDescriptionSerializer.java
@@ -56,6 +56,8 @@ public class JobDescriptionSerializer extends StdSerializer<JobDescription> {
             jgen.writeStringField("processId", userTaskInstanceJobDescription.processId());
             jgen.writeStringField("processInstanceId", userTaskInstanceJobDescription.processInstanceId());
             jgen.writeStringField("nodeInstanceId", userTaskInstanceJobDescription.nodeInstanceId());
+            jgen.writeStringField("rootProcessInstanceId", userTaskInstanceJobDescription.rootProcessInstanceId());
+            jgen.writeStringField("rootProcessId", userTaskInstanceJobDescription.rootProcessId());
         }
         jgen.writeEndObject();
     }

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/src/main/java/org/kie/kogito/jobs/embedded/EmbeddedJobExecutor.java
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/src/main/java/org/kie/kogito/jobs/embedded/EmbeddedJobExecutor.java
@@ -82,7 +82,7 @@ public class EmbeddedJobExecutor implements JobExecutor {
 
     private Uni<JobExecutionResponse> processJobDescription(JobDetails jobDetails, UserTaskInstanceJobDescription userTaskInstanceJobDescription) {
         Supplier<Void> execute = () -> executeInUnitOfWork(application.unitOfWorkManager(), () -> {
-            Optional<UserTaskInstance> userTaskInstance = userTasks.get().instances().findById(userTaskInstanceJobDescription.getUserTaskInstanceId());
+            Optional<UserTaskInstance> userTaskInstance = userTasks.get().instances().findById(userTaskInstanceJobDescription.userTaskInstanceId());
             if (userTaskInstance.isEmpty()) {
                 return null;
             }

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/src/main/java/org/kie/kogito/jobs/embedded/JobInVMEventPublisher.java
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/src/main/java/org/kie/kogito/jobs/embedded/JobInVMEventPublisher.java
@@ -107,6 +107,8 @@ public class JobInVMEventPublisher implements JobEventPublisher {
                 scheduledJob.setProcessInstanceId(userTaskInstanceJobDescription.processInstanceId());
                 scheduledJob.setProcessId(userTaskInstanceJobDescription.processId());
                 scheduledJob.setNodeInstanceId(userTaskInstanceJobDescription.nodeInstanceId());
+                scheduledJob.setRootProcessInstanceId(userTaskInstanceJobDescription.rootProcessInstanceId());
+                scheduledJob.setRootProcessId(userTaskInstanceJobDescription.rootProcessId());
             }
 
             byte[] jsonContent = objectMapper.writeValueAsBytes(scheduledJob);

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/src/main/java/org/kie/kogito/jobs/embedded/JobInVMEventPublisher.java
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs/src/main/java/org/kie/kogito/jobs/embedded/JobInVMEventPublisher.java
@@ -27,6 +27,7 @@ import org.kie.kogito.event.EventPublisher;
 import org.kie.kogito.event.job.JobInstanceDataEvent;
 import org.kie.kogito.jobs.JobDescription;
 import org.kie.kogito.jobs.descriptors.ProcessInstanceJobDescription;
+import org.kie.kogito.jobs.descriptors.UserTaskInstanceJobDescription;
 import org.kie.kogito.jobs.service.adapter.ScheduledJobAdapter;
 import org.kie.kogito.jobs.service.api.Recipient;
 import org.kie.kogito.jobs.service.model.JobDetails;
@@ -102,6 +103,10 @@ public class JobInVMEventPublisher implements JobEventPublisher {
                 scheduledJob.setRootProcessInstanceId(processInstanceJobDescription.rootProcessInstanceId());
                 scheduledJob.setRootProcessId(processInstanceJobDescription.rootProcessId());
                 scheduledJob.setNodeInstanceId(processInstanceJobDescription.nodeInstanceId());
+            } else if (jobDescription instanceof UserTaskInstanceJobDescription userTaskInstanceJobDescription) {
+                scheduledJob.setProcessInstanceId(userTaskInstanceJobDescription.processInstanceId());
+                scheduledJob.setProcessId(userTaskInstanceJobDescription.processId());
+                scheduledJob.setNodeInstanceId(userTaskInstanceJobDescription.nodeInstanceId());
             }
 
             byte[] jsonContent = objectMapper.writeValueAsBytes(scheduledJob);


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1858

The Jobs scheduled by the UserTask Subsystem when registering the Deadlines/Reassignments are lacking of some fields processId, processInsanceId and nodeInstanceId when indexed in data-index.

Ensemble:
https://github.com/apache/incubator-kie-kogito-runtimes/pull/3857
https://github.com/apache/incubator-kie-kogito-apps/pull/2203