### PR TITLE
[Fix apache/incubator-kie-issues#1892] Adding execution summary

### DIFF
--- a/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
+++ b/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
@@ -101,6 +101,7 @@ type ProcessInstance {
     identity: String
     createdBy: String
     updatedBy: String
+    executionSummary: [String]
     slaDueDate: DateTime
 }
 

--- a/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/service/graphql/GraphQLSchemaManagerImpl.java
+++ b/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/service/graphql/GraphQLSchemaManagerImpl.java
@@ -122,6 +122,7 @@ public class GraphQLSchemaManagerImpl extends AbstractGraphQLSchemaManager {
                     builder.dataFetcher("source", this::getProcessInstanceSource);
                     builder.dataFetcher("nodeDefinitions", this::getProcessInstanceNodes);
                     builder.dataFetcher("definition", this::getProcessDefinition);
+                    builder.dataFetcher("executionSummary", this::getExecutionSummary);
                     return builder;
                 })
                 .type("UserTaskInstance", builder -> {

--- a/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/src/main/java/org/kie/kogito/index/addon/graphql/GraphQLAddonSchemaManagerImpl.java
+++ b/data-index/kogito-addons-quarkus-data-index/kogito-addons-quarkus-data-index-common/runtime/src/main/java/org/kie/kogito/index/addon/graphql/GraphQLAddonSchemaManagerImpl.java
@@ -74,6 +74,7 @@ public class GraphQLAddonSchemaManagerImpl extends AbstractGraphQLSchemaManager 
                     builder.dataFetcher("source", this::getProcessInstanceSource);
                     builder.dataFetcher("nodeDefinitions", this::getProcessInstanceNodes);
                     builder.dataFetcher("definition", this::getProcessDefinition);
+                    builder.dataFetcher("executionSummary", this::getExecutionSummary);
                     return builder;
                 })
                 .type("ProcessInstanceState", builder -> {


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-issues/issues/1892
Adding new calculated field to graphql schema called "executionSummary"

Output examples: 

1. a workflow that failed and was retriggered with modified data

```
  "executionSummary": [
          "Workflow started at 2025-04-02T15:26:54.231Z",
          "Workflow failed with error net.thisptr.jackson.jq.exception.JsonQueryException - number (2) and number (0) cannot be divided because the divisor is zero at 2025-04-02T15:26:54.228Z",
          "Workflow retriggered at 2025-04-02T15:34:56.124Z",
          "Workflow completed at 2025-04-02T15:34:56.126Z"
        ],
```
2. a straightthrough workflow that completed sucessfully 
```
"executionSummary": [
          "Workflow started at 2025-03-27T13:18:39.773Z",
          "Workflow completed at 2025-03-27T13:18:39.771Z"
        ]
```
Notice that the dates are imprecise, opened a different [issue](https://github.com/apache/incubator-kie-kogito-runtimes/issues/3883) for that, since the problem is unrelated with the PR

3. a process waiting for a timeout
```
"executionSummary": [
          "Workflow started at 2025-04-03T11:02:14.900Z",
          "Workflow waiting at node sleep since 2025-04-03T11:02:14.899Z"
        ],
```