### PR TITLE
[Incubator-kie-issues-1950] Added query capability based on slaDueDate

### DIFF
--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-common/src/main/resources/approval.bpmn
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-common/src/main/resources/approval.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_F0jB8En5EeqlfsIhq1UCRQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_aKYB4BIPED6Rud0qn1wfFA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_approverItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_travellerItem" structureRef="org.acme.travels.Traveller"/>
   <bpmn2:itemDefinition id="_firstLineApprovalItem" structureRef="Boolean"/>
@@ -34,8 +34,14 @@
   <bpmn2:itemDefinition id="__8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputXItem" structureRef="org.acme.travels.Traveller"/>
   <bpmn2:itemDefinition id="__8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputXItem" structureRef="Boolean"/>
-  <bpmn2:process id="approvals" drools:packageName="org.acme.travels" drools:version="1.0" drools:adHoc="false" name="approvals" isExecutable="true">
+  <bpmn2:collaboration id="_A839C6FA-401C-481A-910C-F9DDB7B1012A" name="Default Collaboration">
+    <bpmn2:participant id="_45BC1C20-0B38-40BC-8238-32131DF478A6" name="Pool Participant" processRef="approvals"/>
+  </bpmn2:collaboration>
+  <bpmn2:process id="approvals" drools:packageName="org.acme.travels" drools:version="1.0" drools:adHoc="false" name="approvals" isExecutable="true" processType="Public">
     <bpmn2:extensionElements>
+      <drools:metaData name="customSLADueDate">
+        <drools:metaValue><![CDATA[60m]]></drools:metaValue>
+      </drools:metaData>
       <drools:import name="org.acme.travels.Traveller"/>
     </bpmn2:extensionElements>
     <bpmn2:property id="approver" itemSubjectRef="_approverItem" name="approver"/>
@@ -80,60 +86,60 @@
       </bpmn2:extensionElements>
       <bpmn2:incoming>_9EAFE6C1-69B4-4908-B764-EF3C4A55BEE3</bpmn2:incoming>
       <bpmn2:outgoing>_C13522F1-230A-4C26-B5A9-533A5D9FEE9D</bpmn2:outgoing>
-      <bpmn2:ioSpecification id="_F0jB8Un5EeqlfsIhq1UCRQ">
+      <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputXItem" name="TaskName"/>
         <bpmn2:dataInput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputX" drools:dtype="org.acme.travels.Traveller" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputXItem" name="traveller"/>
         <bpmn2:dataInput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX" drools:dtype="Object" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputXItem" name="Skippable"/>
         <bpmn2:dataInput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX" drools:dtype="Object" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputXItem" name="GroupId"/>
         <bpmn2:dataOutput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputX" drools:dtype="String" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputXItem" name="ActorId"/>
         <bpmn2:dataOutput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputX" drools:dtype="Boolean" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputXItem" name="approved"/>
-        <bpmn2:inputSet id="_F0jB8kn5EeqlfsIhq1UCRQ">
+        <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
-        <bpmn2:outputSet id="_F0jB80n5EeqlfsIhq1UCRQ">
+        <bpmn2:outputSet>
           <bpmn2:dataOutputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputX</bpmn2:dataOutputRefs>
           <bpmn2:dataOutputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputX</bpmn2:dataOutputRefs>
         </bpmn2:outputSet>
       </bpmn2:ioSpecification>
-      <bpmn2:dataInputAssociation id="_F0jB9En5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jB9Un5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jB9kn5EeqlfsIhq1UCRQ"><![CDATA[firstLineApproval]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jB90n5EeqlfsIhq1UCRQ">_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[firstLineApproval]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jB-En5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>traveller</bpmn2:sourceRef>
         <bpmn2:targetRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jB-Un5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jB-kn5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jB-0n5EeqlfsIhq1UCRQ"><![CDATA[true]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jB_En5EeqlfsIhq1UCRQ">_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[true]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jB_Un5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jB_kn5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jB_0n5EeqlfsIhq1UCRQ"><![CDATA[managers]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jCAEn5EeqlfsIhq1UCRQ">_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[managers]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataOutputAssociation id="_F0jCAUn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataOutputAssociation>
         <bpmn2:sourceRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputX</bpmn2:sourceRef>
         <bpmn2:targetRef>approver</bpmn2:targetRef>
       </bpmn2:dataOutputAssociation>
-      <bpmn2:dataOutputAssociation id="_F0jCAkn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataOutputAssociation>
         <bpmn2:sourceRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputX</bpmn2:sourceRef>
         <bpmn2:targetRef>firstLineApproval</bpmn2:targetRef>
       </bpmn2:dataOutputAssociation>
-      <bpmn2:potentialOwner id="_2f7befe6-4b21-43e9-a59c-71fb1fc296c8">
-        <bpmn2:resourceAssignmentExpression id="_F0jCA0n5EeqlfsIhq1UCRQ">
-          <bpmn2:formalExpression id="_F0jCBEn5EeqlfsIhq1UCRQ">manager</bpmn2:formalExpression>
+      <bpmn2:potentialOwner id="_aKZQABIPED6Rud0qn1wfFA">
+        <bpmn2:resourceAssignmentExpression id="_aKZQARIPED6Rud0qn1wfFA">
+          <bpmn2:formalExpression>manager</bpmn2:formalExpression>
         </bpmn2:resourceAssignmentExpression>
       </bpmn2:potentialOwner>
     </bpmn2:userTask>
@@ -145,54 +151,54 @@
       </bpmn2:extensionElements>
       <bpmn2:incoming>_C13522F1-230A-4C26-B5A9-533A5D9FEE9D</bpmn2:incoming>
       <bpmn2:outgoing>_078F46FB-B7A1-4DBB-BE9A-75C7CB0CCD03</bpmn2:outgoing>
-      <bpmn2:ioSpecification id="_F0jCBUn5EeqlfsIhq1UCRQ">
+      <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputXItem" name="TaskName"/>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_ExcludedOwnerIdInputX" drools:dtype="String" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_ExcludedOwnerIdInputXItem" name="ExcludedOwnerId"/>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_travellerInputX" drools:dtype="org.acme.travels.Traveller" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_travellerInputXItem" name="traveller"/>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX" drools:dtype="Object" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputXItem" name="Skippable"/>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX" drools:dtype="Object" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputXItem" name="GroupId"/>
         <bpmn2:dataOutput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_approvedOutputX" drools:dtype="Boolean" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_approvedOutputXItem" name="approved"/>
-        <bpmn2:inputSet id="_F0jCBkn5EeqlfsIhq1UCRQ">
+        <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_ExcludedOwnerIdInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_travellerInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
-        <bpmn2:outputSet id="_F0jCB0n5EeqlfsIhq1UCRQ">
+        <bpmn2:outputSet>
           <bpmn2:dataOutputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_approvedOutputX</bpmn2:dataOutputRefs>
         </bpmn2:outputSet>
       </bpmn2:ioSpecification>
-      <bpmn2:dataInputAssociation id="_F0jCCEn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jCCUn5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jCCkn5EeqlfsIhq1UCRQ"><![CDATA[secondLineApproval]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jCC0n5EeqlfsIhq1UCRQ">_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[secondLineApproval]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jCDEn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>approver</bpmn2:sourceRef>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_ExcludedOwnerIdInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jCDUn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>traveller</bpmn2:sourceRef>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_travellerInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jCDkn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jCD0n5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jCEEn5EeqlfsIhq1UCRQ"><![CDATA[true]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jCEUn5EeqlfsIhq1UCRQ">_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[true]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jCEkn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jCE0n5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jCFEn5EeqlfsIhq1UCRQ"><![CDATA[managers]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jCFUn5EeqlfsIhq1UCRQ">_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[managers]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataOutputAssociation id="_F0jCFkn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataOutputAssociation>
         <bpmn2:sourceRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_approvedOutputX</bpmn2:sourceRef>
         <bpmn2:targetRef>secondLineApproval</bpmn2:targetRef>
       </bpmn2:dataOutputAssociation>
@@ -200,8 +206,7 @@
     <bpmn2:startEvent id="_9861B686-DF6B-4B1C-B370-F9898EEB47FD" name="StartProcess">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
-          <drools:metaValue><![CDATA[StartProcess
-]]></drools:metaValue>
+          <drools:metaValue><![CDATA[StartProcess]]></drools:metaValue>
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:outgoing>_9EAFE6C1-69B4-4908-B764-EF3C4A55BEE3</bpmn2:outgoing>
@@ -215,90 +220,90 @@
       <bpmn2:incoming>_078F46FB-B7A1-4DBB-BE9A-75C7CB0CCD03</bpmn2:incoming>
     </bpmn2:endEvent>
   </bpmn2:process>
-  <bpmndi:BPMNDiagram id="_F0jCF0n5EeqlfsIhq1UCRQ">
-    <bpmndi:BPMNPlane id="_F0jCGEn5EeqlfsIhq1UCRQ" bpmnElement="approvals">
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="approvals">
       <bpmndi:BPMNShape id="shape__125D9683-9218-4BBC-94C2-59DDD449ADC6" bpmnElement="_125D9683-9218-4BBC-94C2-59DDD449ADC6">
-        <dc:Bounds height="56.0" width="56.0" x="923.0" y="280.0"/>
+        <dc:Bounds height="56" width="56" x="923" y="280"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__9861B686-DF6B-4B1C-B370-F9898EEB47FD" bpmnElement="_9861B686-DF6B-4B1C-B370-F9898EEB47FD">
-        <dc:Bounds height="56.0" width="56.0" x="319.0" y="280.0"/>
+        <dc:Bounds height="56" width="56" x="319" y="280"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__0DBFABE8-92B0-46E6-B52E-A9593AFA4371" bpmnElement="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371">
-        <dc:Bounds height="102.0" width="154.0" x="689.0" y="257.0"/>
+        <dc:Bounds height="102" width="154" x="689" y="257"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__8B62D3CA-5D03-4B2B-832B-126469288BB4" bpmnElement="_8B62D3CA-5D03-4B2B-832B-126469288BB4">
-        <dc:Bounds height="102.0" width="154.0" x="455.0" y="257.0"/>
+        <dc:Bounds height="102" width="154" x="455" y="257"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="edge_shape__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_to_shape__125D9683-9218-4BBC-94C2-59DDD449ADC6" bpmnElement="_078F46FB-B7A1-4DBB-BE9A-75C7CB0CCD03">
-        <di:waypoint xsi:type="dc:Point" x="843.0" y="308.0"/>
-        <di:waypoint xsi:type="dc:Point" x="923.0" y="308.0"/>
+        <di:waypoint x="843" y="308"/>
+        <di:waypoint x="923" y="308"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__9861B686-DF6B-4B1C-B370-F9898EEB47FD_to_shape__8B62D3CA-5D03-4B2B-832B-126469288BB4" bpmnElement="_9EAFE6C1-69B4-4908-B764-EF3C4A55BEE3">
-        <di:waypoint xsi:type="dc:Point" x="375.0" y="308.0"/>
-        <di:waypoint xsi:type="dc:Point" x="455.0" y="308.0"/>
+        <di:waypoint x="375" y="308"/>
+        <di:waypoint x="455" y="308"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__8B62D3CA-5D03-4B2B-832B-126469288BB4_to_shape__0DBFABE8-92B0-46E6-B52E-A9593AFA4371" bpmnElement="_C13522F1-230A-4C26-B5A9-533A5D9FEE9D">
-        <di:waypoint xsi:type="dc:Point" x="609.0" y="308.0"/>
-        <di:waypoint xsi:type="dc:Point" x="689.0" y="308.0"/>
+        <di:waypoint x="609" y="308"/>
+        <di:waypoint x="689" y="308"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
-  <bpmn2:relationship id="_F0jCGUn5EeqlfsIhq1UCRQ" type="BPSimData">
+  <bpmn2:relationship type="BPSimData">
     <bpmn2:extensionElements>
       <bpsim:BPSimData>
-        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
-          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9861B686-DF6B-4B1C-B370-F9898EEB47FD" id="_F0jpAEn5EeqlfsIhq1UCRQ">
-            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
-              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_9861B686-DF6B-4B1C-B370-F9898EEB47FD">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
               </bpsim:ProcessingTime>
             </bpsim:TimeParameters>
           </bpsim:ElementParameters>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371" id="_F0jpAUn5EeqlfsIhq1UCRQ">
-            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
-              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+          <bpsim:ElementParameters elementRef="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
               </bpsim:ProcessingTime>
             </bpsim:TimeParameters>
-            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
-              <bpsim:Availability xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:Availability>
-              <bpsim:Quantity xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:Quantity>
             </bpsim:ResourceParameters>
-            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
-              <bpsim:UnitCost xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:UnitCost>
             </bpsim:CostParameters>
           </bpsim:ElementParameters>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_8B62D3CA-5D03-4B2B-832B-126469288BB4" id="_F0jpAkn5EeqlfsIhq1UCRQ">
-            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
-              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+          <bpsim:ElementParameters elementRef="_8B62D3CA-5D03-4B2B-832B-126469288BB4">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
               </bpsim:ProcessingTime>
             </bpsim:TimeParameters>
-            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
-              <bpsim:Availability xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:Availability>
-              <bpsim:Quantity xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:Quantity>
             </bpsim:ResourceParameters>
-            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
-              <bpsim:UnitCost xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:UnitCost>
             </bpsim:CostParameters>
           </bpsim:ElementParameters>
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_F0jB8En5EeqlfsIhq1UCRQ</bpmn2:source>
-    <bpmn2:target>_F0jB8En5EeqlfsIhq1UCRQ</bpmn2:target>
+    <bpmn2:source>_aKYB4BIPED6Rud0qn1wfFA</bpmn2:source>
+    <bpmn2:target>_aKYB4BIPED6Rud0qn1wfFA</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-common/src/test/java/org/kie/kogito/index/AbstractProcessDataIndexIT.java
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-common/src/test/java/org/kie/kogito/index/AbstractProcessDataIndexIT.java
@@ -168,6 +168,20 @@ public abstract class AbstractProcessDataIndexIT {
 
         await()
                 .atMost(TIMEOUT)
+                .untilAsserted(() -> given().spec(dataIndexSpec()).contentType(ContentType.JSON)
+                        .body("{ \"query\" : \"{ProcessInstances(where:{slaDueDate:{isNull: false}})" +
+                                "{ id, processId, state, createdBy, slaDueDate} }\" }")
+                        .when().post("/graphql")
+                        .then().statusCode(200)
+                        .body("data.ProcessInstances.size()", is(1))
+                        .body("data.ProcessInstances[0].id", is(pId))
+                        .body("data.ProcessInstances[0].processId", is("approvals"))
+                        .body("data.ProcessInstances[0].state", is("ACTIVE"))
+                        .body("data.ProcessInstances[0].createdBy", nullValue())
+                        .body("data.ProcessInstances[0].slaDueDate", notNullValue()));
+
+        await()
+                .atMost(TIMEOUT)
                 .untilAsserted(() -> addCheck(given().spec(dataIndexSpec()).contentType(ContentType.JSON)
                         .body("{ \"query\" : \"{ProcessDefinitions{ id, version, name, source} }\" }")
                         .when().post("/graphql")

--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus/src/test/resources/approval.bpmn
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus/src/test/resources/approval.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_F0jB8En5EeqlfsIhq1UCRQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_aKYB4BIPED6Rud0qn1wfFA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
   <bpmn2:itemDefinition id="_approverItem" structureRef="String"/>
   <bpmn2:itemDefinition id="_travellerItem" structureRef="org.acme.travels.Traveller"/>
   <bpmn2:itemDefinition id="_firstLineApprovalItem" structureRef="Boolean"/>
@@ -34,8 +34,14 @@
   <bpmn2:itemDefinition id="__8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputXItem" structureRef="org.acme.travels.Traveller"/>
   <bpmn2:itemDefinition id="__8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputXItem" structureRef="Boolean"/>
-  <bpmn2:process id="approvals" drools:packageName="org.acme.travels" drools:version="1.0" drools:adHoc="false" name="approvals" isExecutable="true">
+  <bpmn2:collaboration id="_A839C6FA-401C-481A-910C-F9DDB7B1012A" name="Default Collaboration">
+    <bpmn2:participant id="_45BC1C20-0B38-40BC-8238-32131DF478A6" name="Pool Participant" processRef="approvals"/>
+  </bpmn2:collaboration>
+  <bpmn2:process id="approvals" drools:packageName="org.acme.travels" drools:version="1.0" drools:adHoc="false" name="approvals" isExecutable="true" processType="Public">
     <bpmn2:extensionElements>
+      <drools:metaData name="customSLADueDate">
+        <drools:metaValue><![CDATA[60m]]></drools:metaValue>
+      </drools:metaData>
       <drools:import name="org.acme.travels.Traveller"/>
     </bpmn2:extensionElements>
     <bpmn2:property id="approver" itemSubjectRef="_approverItem" name="approver"/>
@@ -80,60 +86,60 @@
       </bpmn2:extensionElements>
       <bpmn2:incoming>_9EAFE6C1-69B4-4908-B764-EF3C4A55BEE3</bpmn2:incoming>
       <bpmn2:outgoing>_C13522F1-230A-4C26-B5A9-533A5D9FEE9D</bpmn2:outgoing>
-      <bpmn2:ioSpecification id="_F0jB8Un5EeqlfsIhq1UCRQ">
+      <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputXItem" name="TaskName"/>
         <bpmn2:dataInput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputX" drools:dtype="org.acme.travels.Traveller" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputXItem" name="traveller"/>
         <bpmn2:dataInput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX" drools:dtype="Object" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputXItem" name="Skippable"/>
         <bpmn2:dataInput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX" drools:dtype="Object" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputXItem" name="GroupId"/>
         <bpmn2:dataOutput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputX" drools:dtype="String" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputXItem" name="ActorId"/>
         <bpmn2:dataOutput id="_8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputX" drools:dtype="Boolean" itemSubjectRef="__8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputXItem" name="approved"/>
-        <bpmn2:inputSet id="_F0jB8kn5EeqlfsIhq1UCRQ">
+        <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
-        <bpmn2:outputSet id="_F0jB80n5EeqlfsIhq1UCRQ">
+        <bpmn2:outputSet>
           <bpmn2:dataOutputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputX</bpmn2:dataOutputRefs>
           <bpmn2:dataOutputRefs>_8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputX</bpmn2:dataOutputRefs>
         </bpmn2:outputSet>
       </bpmn2:ioSpecification>
-      <bpmn2:dataInputAssociation id="_F0jB9En5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jB9Un5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jB9kn5EeqlfsIhq1UCRQ"><![CDATA[firstLineApproval]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jB90n5EeqlfsIhq1UCRQ">_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[firstLineApproval]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_8B62D3CA-5D03-4B2B-832B-126469288BB4_TaskNameInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jB-En5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>traveller</bpmn2:sourceRef>
         <bpmn2:targetRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_travellerInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jB-Un5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jB-kn5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jB-0n5EeqlfsIhq1UCRQ"><![CDATA[true]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jB_En5EeqlfsIhq1UCRQ">_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[true]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_8B62D3CA-5D03-4B2B-832B-126469288BB4_SkippableInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jB_Un5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jB_kn5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jB_0n5EeqlfsIhq1UCRQ"><![CDATA[managers]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jCAEn5EeqlfsIhq1UCRQ">_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[managers]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_8B62D3CA-5D03-4B2B-832B-126469288BB4_GroupIdInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataOutputAssociation id="_F0jCAUn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataOutputAssociation>
         <bpmn2:sourceRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_ActorIdOutputX</bpmn2:sourceRef>
         <bpmn2:targetRef>approver</bpmn2:targetRef>
       </bpmn2:dataOutputAssociation>
-      <bpmn2:dataOutputAssociation id="_F0jCAkn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataOutputAssociation>
         <bpmn2:sourceRef>_8B62D3CA-5D03-4B2B-832B-126469288BB4_approvedOutputX</bpmn2:sourceRef>
         <bpmn2:targetRef>firstLineApproval</bpmn2:targetRef>
       </bpmn2:dataOutputAssociation>
-      <bpmn2:potentialOwner id="_2f7befe6-4b21-43e9-a59c-71fb1fc296c8">
-        <bpmn2:resourceAssignmentExpression id="_F0jCA0n5EeqlfsIhq1UCRQ">
-          <bpmn2:formalExpression id="_F0jCBEn5EeqlfsIhq1UCRQ">manager</bpmn2:formalExpression>
+      <bpmn2:potentialOwner id="_aKZQABIPED6Rud0qn1wfFA">
+        <bpmn2:resourceAssignmentExpression id="_aKZQARIPED6Rud0qn1wfFA">
+          <bpmn2:formalExpression>manager</bpmn2:formalExpression>
         </bpmn2:resourceAssignmentExpression>
       </bpmn2:potentialOwner>
     </bpmn2:userTask>
@@ -145,54 +151,54 @@
       </bpmn2:extensionElements>
       <bpmn2:incoming>_C13522F1-230A-4C26-B5A9-533A5D9FEE9D</bpmn2:incoming>
       <bpmn2:outgoing>_078F46FB-B7A1-4DBB-BE9A-75C7CB0CCD03</bpmn2:outgoing>
-      <bpmn2:ioSpecification id="_F0jCBUn5EeqlfsIhq1UCRQ">
+      <bpmn2:ioSpecification>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX" drools:dtype="Object" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputXItem" name="TaskName"/>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_ExcludedOwnerIdInputX" drools:dtype="String" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_ExcludedOwnerIdInputXItem" name="ExcludedOwnerId"/>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_travellerInputX" drools:dtype="org.acme.travels.Traveller" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_travellerInputXItem" name="traveller"/>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX" drools:dtype="Object" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputXItem" name="Skippable"/>
         <bpmn2:dataInput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX" drools:dtype="Object" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputXItem" name="GroupId"/>
         <bpmn2:dataOutput id="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_approvedOutputX" drools:dtype="Boolean" itemSubjectRef="__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_approvedOutputXItem" name="approved"/>
-        <bpmn2:inputSet id="_F0jCBkn5EeqlfsIhq1UCRQ">
+        <bpmn2:inputSet>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_ExcludedOwnerIdInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_travellerInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX</bpmn2:dataInputRefs>
           <bpmn2:dataInputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX</bpmn2:dataInputRefs>
         </bpmn2:inputSet>
-        <bpmn2:outputSet id="_F0jCB0n5EeqlfsIhq1UCRQ">
+        <bpmn2:outputSet>
           <bpmn2:dataOutputRefs>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_approvedOutputX</bpmn2:dataOutputRefs>
         </bpmn2:outputSet>
       </bpmn2:ioSpecification>
-      <bpmn2:dataInputAssociation id="_F0jCCEn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jCCUn5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jCCkn5EeqlfsIhq1UCRQ"><![CDATA[secondLineApproval]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jCC0n5EeqlfsIhq1UCRQ">_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[secondLineApproval]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_TaskNameInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jCDEn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>approver</bpmn2:sourceRef>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_ExcludedOwnerIdInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jCDUn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:sourceRef>traveller</bpmn2:sourceRef>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_travellerInputX</bpmn2:targetRef>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jCDkn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jCD0n5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jCEEn5EeqlfsIhq1UCRQ"><![CDATA[true]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jCEUn5EeqlfsIhq1UCRQ">_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[true]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_SkippableInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="_F0jCEkn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataInputAssociation>
         <bpmn2:targetRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX</bpmn2:targetRef>
-        <bpmn2:assignment id="_F0jCE0n5EeqlfsIhq1UCRQ">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_F0jCFEn5EeqlfsIhq1UCRQ"><![CDATA[managers]]></bpmn2:from>
-          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_F0jCFUn5EeqlfsIhq1UCRQ">_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX</bpmn2:to>
+        <bpmn2:assignment>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression"><![CDATA[managers]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression"><![CDATA[_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_GroupIdInputX]]></bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
-      <bpmn2:dataOutputAssociation id="_F0jCFkn5EeqlfsIhq1UCRQ">
+      <bpmn2:dataOutputAssociation>
         <bpmn2:sourceRef>_0DBFABE8-92B0-46E6-B52E-A9593AFA4371_approvedOutputX</bpmn2:sourceRef>
         <bpmn2:targetRef>secondLineApproval</bpmn2:targetRef>
       </bpmn2:dataOutputAssociation>
@@ -200,8 +206,7 @@
     <bpmn2:startEvent id="_9861B686-DF6B-4B1C-B370-F9898EEB47FD" name="StartProcess">
       <bpmn2:extensionElements>
         <drools:metaData name="elementname">
-          <drools:metaValue><![CDATA[StartProcess
-]]></drools:metaValue>
+          <drools:metaValue><![CDATA[StartProcess]]></drools:metaValue>
         </drools:metaData>
       </bpmn2:extensionElements>
       <bpmn2:outgoing>_9EAFE6C1-69B4-4908-B764-EF3C4A55BEE3</bpmn2:outgoing>
@@ -215,90 +220,90 @@
       <bpmn2:incoming>_078F46FB-B7A1-4DBB-BE9A-75C7CB0CCD03</bpmn2:incoming>
     </bpmn2:endEvent>
   </bpmn2:process>
-  <bpmndi:BPMNDiagram id="_F0jCF0n5EeqlfsIhq1UCRQ">
-    <bpmndi:BPMNPlane id="_F0jCGEn5EeqlfsIhq1UCRQ" bpmnElement="approvals">
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="approvals">
       <bpmndi:BPMNShape id="shape__125D9683-9218-4BBC-94C2-59DDD449ADC6" bpmnElement="_125D9683-9218-4BBC-94C2-59DDD449ADC6">
-        <dc:Bounds height="56.0" width="56.0" x="923.0" y="280.0"/>
+        <dc:Bounds height="56" width="56" x="923" y="280"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__9861B686-DF6B-4B1C-B370-F9898EEB47FD" bpmnElement="_9861B686-DF6B-4B1C-B370-F9898EEB47FD">
-        <dc:Bounds height="56.0" width="56.0" x="319.0" y="280.0"/>
+        <dc:Bounds height="56" width="56" x="319" y="280"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__0DBFABE8-92B0-46E6-B52E-A9593AFA4371" bpmnElement="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371">
-        <dc:Bounds height="102.0" width="154.0" x="689.0" y="257.0"/>
+        <dc:Bounds height="102" width="154" x="689" y="257"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="shape__8B62D3CA-5D03-4B2B-832B-126469288BB4" bpmnElement="_8B62D3CA-5D03-4B2B-832B-126469288BB4">
-        <dc:Bounds height="102.0" width="154.0" x="455.0" y="257.0"/>
+        <dc:Bounds height="102" width="154" x="455" y="257"/>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="edge_shape__0DBFABE8-92B0-46E6-B52E-A9593AFA4371_to_shape__125D9683-9218-4BBC-94C2-59DDD449ADC6" bpmnElement="_078F46FB-B7A1-4DBB-BE9A-75C7CB0CCD03">
-        <di:waypoint xsi:type="dc:Point" x="843.0" y="308.0"/>
-        <di:waypoint xsi:type="dc:Point" x="923.0" y="308.0"/>
+        <di:waypoint x="843" y="308"/>
+        <di:waypoint x="923" y="308"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__9861B686-DF6B-4B1C-B370-F9898EEB47FD_to_shape__8B62D3CA-5D03-4B2B-832B-126469288BB4" bpmnElement="_9EAFE6C1-69B4-4908-B764-EF3C4A55BEE3">
-        <di:waypoint xsi:type="dc:Point" x="375.0" y="308.0"/>
-        <di:waypoint xsi:type="dc:Point" x="455.0" y="308.0"/>
+        <di:waypoint x="375" y="308"/>
+        <di:waypoint x="455" y="308"/>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="edge_shape__8B62D3CA-5D03-4B2B-832B-126469288BB4_to_shape__0DBFABE8-92B0-46E6-B52E-A9593AFA4371" bpmnElement="_C13522F1-230A-4C26-B5A9-533A5D9FEE9D">
-        <di:waypoint xsi:type="dc:Point" x="609.0" y="308.0"/>
-        <di:waypoint xsi:type="dc:Point" x="689.0" y="308.0"/>
+        <di:waypoint x="609" y="308"/>
+        <di:waypoint x="689" y="308"/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
-  <bpmn2:relationship id="_F0jCGUn5EeqlfsIhq1UCRQ" type="BPSimData">
+  <bpmn2:relationship type="BPSimData">
     <bpmn2:extensionElements>
       <bpsim:BPSimData>
-        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
-          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters"/>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9861B686-DF6B-4B1C-B370-F9898EEB47FD" id="_F0jpAEn5EeqlfsIhq1UCRQ">
-            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
-              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+        <bpsim:Scenario id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters/>
+          <bpsim:ElementParameters elementRef="_9861B686-DF6B-4B1C-B370-F9898EEB47FD">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
               </bpsim:ProcessingTime>
             </bpsim:TimeParameters>
           </bpsim:ElementParameters>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371" id="_F0jpAUn5EeqlfsIhq1UCRQ">
-            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
-              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+          <bpsim:ElementParameters elementRef="_0DBFABE8-92B0-46E6-B52E-A9593AFA4371">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
               </bpsim:ProcessingTime>
             </bpsim:TimeParameters>
-            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
-              <bpsim:Availability xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:Availability>
-              <bpsim:Quantity xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:Quantity>
             </bpsim:ResourceParameters>
-            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
-              <bpsim:UnitCost xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:UnitCost>
             </bpsim:CostParameters>
           </bpsim:ElementParameters>
-          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_8B62D3CA-5D03-4B2B-832B-126469288BB4" id="_F0jpAkn5EeqlfsIhq1UCRQ">
-            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
-              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
-                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+          <bpsim:ElementParameters elementRef="_8B62D3CA-5D03-4B2B-832B-126469288BB4">
+            <bpsim:TimeParameters>
+              <bpsim:ProcessingTime>
+                <bpsim:NormalDistribution mean="0" standardDeviation="0"/>
               </bpsim:ProcessingTime>
             </bpsim:TimeParameters>
-            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
-              <bpsim:Availability xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+            <bpsim:ResourceParameters>
+              <bpsim:Availability>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:Availability>
-              <bpsim:Quantity xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+              <bpsim:Quantity>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:Quantity>
             </bpsim:ResourceParameters>
-            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
-              <bpsim:UnitCost xsi:type="bpsim:Parameter">
-                <bpsim:FloatingParameter value="0.0"/>
+            <bpsim:CostParameters>
+              <bpsim:UnitCost>
+                <bpsim:FloatingParameter value="0"/>
               </bpsim:UnitCost>
             </bpsim:CostParameters>
           </bpsim:ElementParameters>
         </bpsim:Scenario>
       </bpsim:BPSimData>
     </bpmn2:extensionElements>
-    <bpmn2:source>_F0jB8En5EeqlfsIhq1UCRQ</bpmn2:source>
-    <bpmn2:target>_F0jB8En5EeqlfsIhq1UCRQ</bpmn2:target>
+    <bpmn2:source>_aKYB4BIPED6Rud0qn1wfFA</bpmn2:source>
+    <bpmn2:target>_aKYB4BIPED6Rud0qn1wfFA</bpmn2:target>
   </bpmn2:relationship>
 </bpmn2:definitions>

--- a/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
+++ b/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
@@ -203,6 +203,7 @@ input ProcessInstanceArgument {
     createdBy: StringArgument
     updatedBy: StringArgument
     definition: ProcessDefinitionArgument
+    slaDueDate: DateArgument
 }
 
 input ProcessInstanceErrorArgument {
@@ -223,6 +224,7 @@ input NodeInstanceArgument {
     exit: DateArgument
     errorMessage: StringArgument
     retrigger: BooleanArgument
+    slaDueDate: DateArgument
 }
 
 input MilestoneStatusArgument {
@@ -411,6 +413,7 @@ input UserTaskInstanceArgument {
     lastUpdate: DateArgument
     comments: CommentArgument
     attachments: AttachmentArgument
+    slaDueDate: DateArgument
 }
 
 input CommentArgument {


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/1950

SLAs are available in the graphql return data on both the process and node level:
```
{ProcessInstances(where:{state:{equal:ACTIVE}}){
  id,
  processName,
  end,
  state,
  variables,
  slaDueDate,
  nodes {
    name,
    id,
    type,
    enter,
    slaDueDate
  }
  }
}
```
However, it is currently not possible to use the slaDueDate in the query clause.