### PR TITLE
[Fix apache/incubator-kie-issues#1952]  Adding cloud event id and source

### DIFF
--- a/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
+++ b/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
@@ -103,6 +103,8 @@ type ProcessInstance {
     updatedBy: String
     executionSummary: [String]
     slaDueDate: DateTime
+    cloudEventId: String
+    cloudEventSource: String
 }
 
 type ProcessInstanceError {
@@ -203,6 +205,8 @@ input ProcessInstanceArgument {
     createdBy: StringArgument
     updatedBy: StringArgument
     definition: ProcessDefinitionArgument
+    cloudEventId: StringArgument
+    cloudEventSource: StringArgument
 }
 
 input ProcessInstanceErrorArgument {

--- a/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/ProcessInstanceMeta.java
+++ b/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/ProcessInstanceMeta.java
@@ -50,6 +50,8 @@ public class ProcessInstanceMeta {
     private String updatedBy;
     private ZonedDateTime lastUpdate;
     private ZonedDateTime slaDueDate;
+    private String cloudEventId;
+    private String cloudEventSource;
 
     public String getId() {
         return id;
@@ -193,6 +195,22 @@ public class ProcessInstanceMeta {
 
     public void setSlaDueDate(ZonedDateTime slaDueDate) {
         this.slaDueDate = slaDueDate;
+    }
+
+    public String getCloudEventId() {
+        return cloudEventId;
+    }
+
+    public void setCloudEventId(String cloudEventId) {
+        this.cloudEventId = cloudEventId;
+    }
+
+    public String getCloudEventSource() {
+        return cloudEventSource;
+    }
+
+    public void setCloudEventSource(String cloudEventSource) {
+        this.cloudEventSource = cloudEventSource;
     }
 
     @Override

--- a/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/merger/ProcessInstanceStateDataEventMerger.java
+++ b/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/merger/ProcessInstanceStateDataEventMerger.java
@@ -66,6 +66,8 @@ public class ProcessInstanceStateDataEventMerger extends ProcessInstanceEventMer
         pi.setDefinition(definitions(event));
         pi.setUpdatedBy(event.getData().getEventUser());
         pi.setSlaDueDate(toZonedDateTime(event.getData().getSlaDueDate()));
+        pi.setCloudEventId(event.getData().getCloudEventId());
+        pi.setCloudEventSource(event.getData().getCloudEventSource());
         LOGGER.debug("Value after merging: {}", pi);
         return pi;
     }

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/ProcessInstanceEntity.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/ProcessInstanceEntity.java
@@ -93,6 +93,9 @@ public class ProcessInstanceEntity extends AbstractEntity {
             @JoinColumn(name = "version", referencedColumnName = "version", insertable = false, updatable = false) })
     private ProcessDefinitionEntity definition;
 
+    private String cloudEventId;
+    private String cloudEventSource;
+
     @Override
     public String getId() {
         return id;
@@ -268,6 +271,22 @@ public class ProcessInstanceEntity extends AbstractEntity {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public String getCloudEventId() {
+        return cloudEventId;
+    }
+
+    public void setCloudEventId(String cloudEventId) {
+        this.cloudEventId = cloudEventId;
+    }
+
+    public String getCloudEventSource() {
+        return cloudEventSource;
+    }
+
+    public void setCloudEventSource(String cloudEventSource) {
+        this.cloudEventSource = cloudEventSource;
     }
 
     @Override

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
@@ -234,6 +234,8 @@ public class ProcessInstanceEntityStorage extends AbstractJPAStorageFetcher<Stri
         pi.setAddons(addons);
         pi.setEndpoint(endpoint);
         pi.setSlaDueDate(toZonedDateTime(data.getSlaDueDate()));
+        pi.setCloudEventId(data.getCloudEventId());
+        pi.setCloudEventSource(data.getCloudEventSource());
     }
 
     private void indexVariable(ProcessInstanceEntity pi, ProcessInstanceVariableEventBody data) {

--- a/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.45.1.2__cloudevent.sql
+++ b/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.45.1.2__cloudevent.sql
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+ALTER TABLE processes ADD COLUMN cloud_event_id VARCHAR(1000);
+ALTER TABLE processes ADD COLUMN cloud_event_source VARCHAR(1000);

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntity.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntity.java
@@ -30,47 +30,51 @@ public class ProcessInstanceEntity {
     @BsonId
     String id;
 
-    String processId;
+    private String processId;
 
-    Set<String> roles;
+    private Set<String> roles;
 
-    Document variables;
+    private Document variables;
 
-    String endpoint;
+    private String endpoint;
 
-    List<NodeInstanceEntity> nodes;
+    private List<NodeInstanceEntity> nodes;
 
-    Integer state;
+    private Integer state;
 
-    Long start;
+    private Long start;
 
-    Long end;
+    private Long end;
 
-    String rootProcessInstanceId;
+    private String rootProcessInstanceId;
 
-    String rootProcessId;
+    private String rootProcessId;
 
-    String parentProcessInstanceId;
+    private String parentProcessInstanceId;
 
-    String processName;
+    private String processName;
 
-    String version;
+    private String version;
 
-    ProcessInstanceErrorEntity error;
+    private ProcessInstanceErrorEntity error;
 
-    Set<String> addons;
+    private Set<String> addons;
 
-    Long lastUpdate;
+    private Long lastUpdate;
 
-    String businessKey;
+    private String businessKey;
 
-    List<MilestoneEntity> milestones;
+    private List<MilestoneEntity> milestones;
 
-    String createdBy;
+    private String createdBy;
 
-    String updatedBy;
+    private String updatedBy;
 
-    Long slaDueDate;
+    private Long slaDueDate;
+
+    private String cloudEventId;
+
+    private String cloudEventSource;
 
     public String getId() {
         return id;
@@ -246,6 +250,22 @@ public class ProcessInstanceEntity {
 
     public void setSlaDueDate(Long slaDueDate) {
         this.slaDueDate = slaDueDate;
+    }
+
+    public String getCloudEventId() {
+        return cloudEventId;
+    }
+
+    public void setCloudEventId(String cloudEventId) {
+        this.cloudEventId = cloudEventId;
+    }
+
+    public String getCloudEventSource() {
+        return cloudEventSource;
+    }
+
+    public void setCloudEventSource(String cloudEventSource) {
+        this.cloudEventSource = cloudEventSource;
     }
 
     @Override

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapper.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapper.java
@@ -78,6 +78,8 @@ public class ProcessInstanceEntityMapper implements MongoEntityMapper<ProcessIns
         entity.setCreatedBy(instance.getCreatedBy());
         entity.setUpdatedBy(instance.getUpdatedBy());
         entity.setSlaDueDate(zonedDateTimeToInstant(instance.getSlaDueDate()));
+        entity.setCloudEventId(instance.getCloudEventId());
+        entity.setCloudEventSource(instance.getCloudEventSource());
         return entity;
     }
 
@@ -110,6 +112,8 @@ public class ProcessInstanceEntityMapper implements MongoEntityMapper<ProcessIns
         instance.setCreatedBy(entity.getCreatedBy());
         instance.setUpdatedBy(entity.getCreatedBy());
         instance.setSlaDueDate(instantToZonedDateTime(entity.getSlaDueDate()));
+        instance.setCloudEventId(entity.getCloudEventId());
+        instance.setCloudEventSource(entity.getCloudEventSource());
         return instance;
     }
 

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.45.1.2__cloudevent.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.45.1.2__cloudevent.sql
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+ALTER TABLE processes ADD COLUMN cloud_event_id VARCHAR(1000),  ADD COLUMN cloud_event_source VARCHAR(1000);


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-issues/issues/1952

Depends on https://github.com/apache/incubator-kie-kogito-runtimes/pull/3916

These fields can now be queried to associate a process instance with an starting cloud event

