### PR TITLE
[incubator-kie-issues-2012] Data-Index: Add 'cancelled' property to the NodeInstance output

### DIFF
--- a/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
+++ b/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
@@ -159,6 +159,14 @@ type NodeInstance {
     slaDueDate: DateTime
     retrigger: Boolean
     errorMessage: String
+    cancelledType: CancelledType
+}
+
+enum CancelledType {
+    ABORTED,
+    SKIPPED,
+    OBSOLETE,
+    ERROR
 }
 
 enum MilestoneStatus {

--- a/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
+++ b/data-index/data-index-graphql/src/main/resources/basic.schema.graphqls
@@ -159,10 +159,10 @@ type NodeInstance {
     slaDueDate: DateTime
     retrigger: Boolean
     errorMessage: String
-    cancelledType: CancelledType
+    cancelType: CancelType
 }
 
-enum CancelledType {
+enum CancelType {
     ABORTED,
     SKIPPED,
     OBSOLETE,

--- a/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/service/GraphQLUtils.java
+++ b/data-index/data-index-service/data-index-service-common/src/test/java/org/kie/kogito/index/service/GraphQLUtils.java
@@ -267,7 +267,7 @@ public class GraphQLUtils {
     }
 
     private static Stream<Field> getAllFieldsList(Class clazz) {
-        return FieldUtils.getAllFieldsList(clazz).stream().filter(getSoourcePredicate().or(getSoourcePredicate()));
+        return FieldUtils.getAllFieldsList(clazz).stream().filter(getSourcePredicate().or(getSourcePredicate()));
     }
 
     private static Function<Field, String> getFieldName() {
@@ -288,7 +288,7 @@ public class GraphQLUtils {
                 }
             }
 
-            if (field.getType().getName().startsWith("org.kie.kogito.index.model")) {
+            if (field.getType().getName().startsWith("org.kie.kogito.index.model") && !field.getType().isEnum()) {
                 return field.getName() + " { " + getAllFieldsList(field.getType()).map(f -> getFieldName().apply(f)).collect(joining(", ")) + " }";
             }
 
@@ -301,7 +301,7 @@ public class GraphQLUtils {
         return field -> !field.getName().equals("$jacocoData");
     }
 
-    private static Predicate<Field> getSoourcePredicate() {
+    private static Predicate<Field> getSourcePredicate() {
         return field -> !(field.getDeclaringClass().equals(ProcessDefinition.class) && (field.getName().equals("source") || field.getName().equals("nodes")));
     }
 }

--- a/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/CancelType.java
+++ b/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/CancelType.java
@@ -18,9 +18,24 @@
  */
 package org.kie.kogito.index.model;
 
-public enum CancelledType {
+import static org.kie.kogito.event.process.ProcessInstanceNodeEventBody.EVENT_TYPE_ABORTED;
+import static org.kie.kogito.event.process.ProcessInstanceNodeEventBody.EVENT_TYPE_ERROR;
+import static org.kie.kogito.event.process.ProcessInstanceNodeEventBody.EVENT_TYPE_OBSOLETE;
+import static org.kie.kogito.event.process.ProcessInstanceNodeEventBody.EVENT_TYPE_SKIPPED;
+
+public enum CancelType {
     ABORTED,
     SKIPPED,
     OBSOLETE,
-    ERROR
+    ERROR;
+
+    public static CancelType fromEventType(Integer eventType) {
+        return switch (eventType) {
+            case EVENT_TYPE_ABORTED -> ABORTED;
+            case EVENT_TYPE_SKIPPED -> SKIPPED;
+            case EVENT_TYPE_OBSOLETE -> OBSOLETE;
+            case EVENT_TYPE_ERROR -> ERROR;
+            default -> throw new IllegalStateException("Unexpected eventType: " + eventType);
+        };
+    }
 }

--- a/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/CancelledType.java
+++ b/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/CancelledType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.index.model;
+
+public enum CancelledType {
+    ABORTED,
+    SKIPPED,
+    OBSOLETE,
+    ERROR
+}

--- a/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/NodeInstance.java
+++ b/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/NodeInstance.java
@@ -44,7 +44,7 @@ public class NodeInstance {
 
     private String errorMessage;
 
-    private CancelledType cancelledType;
+    private CancelType cancelType;
 
     public Boolean isRetrigger() {
         return retrigger;
@@ -129,12 +129,12 @@ public class NodeInstance {
         this.slaDueDate = slaDueDate;
     }
 
-    public CancelledType getCancelledType() {
-        return cancelledType;
+    public CancelType getCancelType() {
+        return cancelType;
     }
 
-    public void setCancelledType(CancelledType cancelledType) {
-        this.cancelledType = cancelledType;
+    public void setCancelType(CancelType cancelType) {
+        this.cancelType = cancelType;
     }
 
     @Override

--- a/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/NodeInstance.java
+++ b/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/NodeInstance.java
@@ -44,6 +44,8 @@ public class NodeInstance {
 
     private String errorMessage;
 
+    private CancelledType cancelledType;
+
     public Boolean isRetrigger() {
         return retrigger;
     }
@@ -125,6 +127,14 @@ public class NodeInstance {
 
     public void setSlaDueDate(ZonedDateTime slaDueDate) {
         this.slaDueDate = slaDueDate;
+    }
+
+    public CancelledType getCancelledType() {
+        return cancelledType;
+    }
+
+    public void setCancelledType(CancelledType cancelledType) {
+        this.cancelledType = cancelledType;
     }
 
     @Override

--- a/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/merger/ProcessInstanceErrorDataEventMerger.java
+++ b/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/merger/ProcessInstanceErrorDataEventMerger.java
@@ -22,6 +22,7 @@ import org.kie.kogito.event.process.ProcessInstanceDataEvent;
 import org.kie.kogito.event.process.ProcessInstanceErrorDataEvent;
 import org.kie.kogito.event.process.ProcessInstanceErrorEventBody;
 import org.kie.kogito.index.CommonUtils;
+import org.kie.kogito.index.model.CancelType;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.kie.kogito.index.model.ProcessInstanceError;
 
@@ -42,7 +43,13 @@ public class ProcessInstanceErrorDataEventMerger extends ProcessInstanceEventMer
         pi.setError(error);
         pi.setState(CommonUtils.ERROR_STATE);
         if (pi.getNodes() != null) {
-            pi.getNodes().stream().filter(n -> n.getId().equals(error.getNodeInstanceId())).findAny().ifPresent(n -> n.setErrorMessage(data.getErrorMessage()));
+            pi.getNodes().stream()
+                    .filter(n -> n.getId().equals(error.getNodeInstanceId()))
+                    .findAny()
+                    .ifPresent(n -> {
+                        n.setErrorMessage(data.getErrorMessage());
+                        n.setCancelType(CancelType.ERROR);
+                    });
         }
         return pi;
     }

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/NodeInstanceEntity.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/NodeInstanceEntity.java
@@ -23,9 +23,12 @@ import java.util.Objects;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import org.kie.kogito.index.model.CancelledType;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -47,6 +50,8 @@ public class NodeInstanceEntity extends AbstractEntity {
     private String definitionId;
     private Boolean retrigger;
     private String errorMessage;
+    @Enumerated(EnumType.STRING)
+    private CancelledType cancelledType;
 
     @ManyToOne(cascade = CascadeType.ALL, optional = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
@@ -132,6 +137,14 @@ public class NodeInstanceEntity extends AbstractEntity {
 
     public void setSlaDueDate(ZonedDateTime slaDueDate) {
         this.slaDueDate = slaDueDate;
+    }
+
+    public CancelledType getCancelledType() {
+        return cancelledType;
+    }
+
+    public void setCancelledType(final CancelledType cancelledType) {
+        this.cancelledType = cancelledType;
     }
 
     public ProcessInstanceEntity getProcessInstance() {

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/NodeInstanceEntity.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/NodeInstanceEntity.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
-import org.kie.kogito.index.model.CancelledType;
+import org.kie.kogito.index.model.CancelType;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -51,7 +51,7 @@ public class NodeInstanceEntity extends AbstractEntity {
     private Boolean retrigger;
     private String errorMessage;
     @Enumerated(EnumType.STRING)
-    private CancelledType cancelledType;
+    private CancelType cancelType;
 
     @ManyToOne(cascade = CascadeType.ALL, optional = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
@@ -139,12 +139,12 @@ public class NodeInstanceEntity extends AbstractEntity {
         this.slaDueDate = slaDueDate;
     }
 
-    public CancelledType getCancelledType() {
-        return cancelledType;
+    public CancelType getCancelType() {
+        return cancelType;
     }
 
-    public void setCancelledType(final CancelledType cancelledType) {
-        this.cancelledType = cancelledType;
+    public void setCancelType(final CancelType cancelType) {
+        this.cancelType = cancelType;
     }
 
     public ProcessInstanceEntity getProcessInstance() {

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
@@ -210,7 +210,6 @@ public class ProcessInstanceEntityStorage extends AbstractJPAStorageFetcher<Stri
             case EVENT_TYPE_OBSOLETE:
             case EVENT_TYPE_ERROR:
                 nodeInstance.setCancelType(CancelType.fromEventType(body.getEventType()));
-                nodeInstance.setExit(eventDate);
                 break;
             case EVENT_TYPE_ENTER:
                 nodeInstance.setEnter(eventDate);

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
@@ -155,7 +155,13 @@ public class ProcessInstanceEntityStorage extends AbstractJPAStorageFetcher<Stri
         errorEntity.setNodeDefinitionId(error.getNodeDefinitionId());
         errorEntity.setNodeInstanceId(error.getNodeInstanceId());
         pi.setState(CommonUtils.ERROR_STATE);
-        pi.getNodes().stream().filter(n -> n.getId().equals(error.getNodeInstanceId())).findAny().ifPresent(n -> n.setErrorMessage(error.getErrorMessage()));
+        pi.getNodes().stream()
+                .filter(n -> n.getId().equals(error.getNodeInstanceId()))
+                .findAny()
+                .ifPresent(n -> {
+                    n.setErrorMessage(error.getErrorMessage());
+                    n.setCancelType(CancelType.ERROR);
+                });
     }
 
     private void indexNode(ProcessInstanceEntity pi, ProcessInstanceNodeEventBody data) {

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
@@ -45,7 +45,7 @@ import org.kie.kogito.index.jpa.model.NodeInstanceEntity;
 import org.kie.kogito.index.jpa.model.ProcessInstanceEntity;
 import org.kie.kogito.index.jpa.model.ProcessInstanceErrorEntity;
 import org.kie.kogito.index.json.JsonUtils;
-import org.kie.kogito.index.model.CancelledType;
+import org.kie.kogito.index.model.CancelType;
 import org.kie.kogito.index.model.MilestoneStatus;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.kie.kogito.index.storage.ProcessInstanceStorage;
@@ -206,19 +206,10 @@ public class ProcessInstanceEntityStorage extends AbstractJPAStorageFetcher<Stri
         ZonedDateTime eventDate = toZonedDateTime(body.getEventDate());
         switch (body.getEventType()) {
             case EVENT_TYPE_ABORTED:
-                nodeInstance.setCancelledType(CancelledType.ABORTED);
-                nodeInstance.setExit(eventDate);
-                break;
             case EVENT_TYPE_SKIPPED:
-                nodeInstance.setCancelledType(CancelledType.SKIPPED);
-                nodeInstance.setExit(eventDate);
-                break;
             case EVENT_TYPE_OBSOLETE:
-                nodeInstance.setCancelledType(CancelledType.OBSOLETE);
-                nodeInstance.setExit(eventDate);
-                break;
             case EVENT_TYPE_ERROR:
-                nodeInstance.setCancelledType(CancelledType.ERROR);
+                nodeInstance.setCancelType(CancelType.fromEventType(body.getEventType()));
                 nodeInstance.setExit(eventDate);
                 break;
             case EVENT_TYPE_ENTER:

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/mapper/AbstractProcessInstanceEntityMapperIT.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/mapper/AbstractProcessInstanceEntityMapperIT.java
@@ -28,7 +28,7 @@ import org.kie.kogito.index.jpa.model.MilestoneEntityId;
 import org.kie.kogito.index.jpa.model.NodeInstanceEntity;
 import org.kie.kogito.index.jpa.model.ProcessInstanceEntity;
 import org.kie.kogito.index.jpa.model.ProcessInstanceErrorEntity;
-import org.kie.kogito.index.model.CancelledType;
+import org.kie.kogito.index.model.CancelType;
 import org.kie.kogito.index.model.Milestone;
 import org.kie.kogito.index.model.NodeInstance;
 import org.kie.kogito.index.model.ProcessInstance;
@@ -56,7 +56,7 @@ public abstract class AbstractProcessInstanceEntityMapperIT {
     void setup() {
         String nodeInstanceId = "testNodeInstanceId";
         String nodeInstanceName = "testNodeInstanceName";
-        CancelledType cancelledType = CancelledType.ERROR;
+        CancelType cancelType = CancelType.ERROR;
         String nodeInstanceNodeId = "testNodeInstanceNodeId";
         String nodeInstanceType = "testNodeInstanceType";
         String nodeInstanceDefinitionId = "testNodeInstanceDefinitionId";
@@ -93,7 +93,7 @@ public abstract class AbstractProcessInstanceEntityMapperIT {
         nodeInstance.setType(nodeInstanceType);
         nodeInstance.setNodeId(nodeInstanceNodeId);
         nodeInstance.setName(nodeInstanceName);
-        nodeInstance.setCancelledType(cancelledType);
+        nodeInstance.setCancelType(cancelType);
 
         ProcessInstanceError processInstanceError = new ProcessInstanceError();
         processInstanceError.setMessage(processInstanceErrorMessage);
@@ -134,7 +134,7 @@ public abstract class AbstractProcessInstanceEntityMapperIT {
         nodeInstanceEntity.setNodeId(nodeInstanceNodeId);
         nodeInstanceEntity.setType(nodeInstanceType);
         nodeInstanceEntity.setProcessInstance(processInstanceEntity);
-        nodeInstanceEntity.setCancelledType(cancelledType);
+        nodeInstanceEntity.setCancelType(cancelType);
 
         ProcessInstanceErrorEntity processInstanceErrorEntity = new ProcessInstanceErrorEntity();
         processInstanceErrorEntity.setMessage(processInstanceErrorMessage);

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/mapper/AbstractProcessInstanceEntityMapperIT.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/mapper/AbstractProcessInstanceEntityMapperIT.java
@@ -28,6 +28,7 @@ import org.kie.kogito.index.jpa.model.MilestoneEntityId;
 import org.kie.kogito.index.jpa.model.NodeInstanceEntity;
 import org.kie.kogito.index.jpa.model.ProcessInstanceEntity;
 import org.kie.kogito.index.jpa.model.ProcessInstanceErrorEntity;
+import org.kie.kogito.index.model.CancelledType;
 import org.kie.kogito.index.model.Milestone;
 import org.kie.kogito.index.model.NodeInstance;
 import org.kie.kogito.index.model.ProcessInstance;
@@ -55,6 +56,7 @@ public abstract class AbstractProcessInstanceEntityMapperIT {
     void setup() {
         String nodeInstanceId = "testNodeInstanceId";
         String nodeInstanceName = "testNodeInstanceName";
+        CancelledType cancelledType = CancelledType.ERROR;
         String nodeInstanceNodeId = "testNodeInstanceNodeId";
         String nodeInstanceType = "testNodeInstanceType";
         String nodeInstanceDefinitionId = "testNodeInstanceDefinitionId";
@@ -91,6 +93,7 @@ public abstract class AbstractProcessInstanceEntityMapperIT {
         nodeInstance.setType(nodeInstanceType);
         nodeInstance.setNodeId(nodeInstanceNodeId);
         nodeInstance.setName(nodeInstanceName);
+        nodeInstance.setCancelledType(cancelledType);
 
         ProcessInstanceError processInstanceError = new ProcessInstanceError();
         processInstanceError.setMessage(processInstanceErrorMessage);
@@ -131,6 +134,7 @@ public abstract class AbstractProcessInstanceEntityMapperIT {
         nodeInstanceEntity.setNodeId(nodeInstanceNodeId);
         nodeInstanceEntity.setType(nodeInstanceType);
         nodeInstanceEntity.setProcessInstance(processInstanceEntity);
+        nodeInstanceEntity.setCancelledType(cancelledType);
 
         ProcessInstanceErrorEntity processInstanceErrorEntity = new ProcessInstanceErrorEntity();
         processInstanceErrorEntity.setMessage(processInstanceErrorMessage);

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractProcessInstanceStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractProcessInstanceStorageIT.java
@@ -109,7 +109,7 @@ public abstract class AbstractProcessInstanceStorageIT {
                 .hasSize(1);
 
         Assertions.assertThat(processInstance.getNodes().get(0))
-                .hasNoNullFieldsOrPropertiesExcept("exit", "slaDueDate", "errorMessage", "retrigger", "cancelledType")
+                .hasNoNullFieldsOrPropertiesExcept("exit", "slaDueDate", "errorMessage", "retrigger", "cancelType")
                 .hasFieldOrPropertyWithValue("name", "nodeName")
                 .hasFieldOrPropertyWithValue("type", "BoundaryEventNode")
                 .hasFieldOrPropertyWithValue("definitionId", nodeDefinitionId)
@@ -125,7 +125,7 @@ public abstract class AbstractProcessInstanceStorageIT {
                 .hasSize(1);
 
         Assertions.assertThat(processInstance.getNodes().get(0))
-                .hasNoNullFieldsOrPropertiesExcept("slaDueDate", "errorMessage", "retrigger", "cancelledType")
+                .hasNoNullFieldsOrPropertiesExcept("slaDueDate", "errorMessage", "retrigger", "cancelType")
                 .hasFieldOrPropertyWithValue("name", "nodeName")
                 .hasFieldOrPropertyWithValue("type", "BoundaryEventNode")
                 .hasFieldOrPropertyWithValue("definitionId", nodeDefinitionId)

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractProcessInstanceStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractProcessInstanceStorageIT.java
@@ -40,7 +40,7 @@ public abstract class AbstractProcessInstanceStorageIT {
 
     @Test
     @Transactional
-    void testProcessInstanceStateEvent() {
+    public void testProcessInstanceStateEvent() {
         String processInstanceId = createNewProcessInstance();
 
         ProcessInstance processInstance = storage.get(processInstanceId);
@@ -68,7 +68,7 @@ public abstract class AbstractProcessInstanceStorageIT {
 
     @Test
     @Transactional
-    void testProcessInstanceErrorEvent() {
+    public void testProcessInstanceErrorEvent() {
         String processInstanceId = createNewProcessInstance();
 
         ProcessInstance processInstance = storage.get(processInstanceId);
@@ -89,7 +89,7 @@ public abstract class AbstractProcessInstanceStorageIT {
 
     @Test
     @Transactional
-    void testProcessInstanceNodeEvent() {
+    public void testProcessInstanceNodeEvent() {
         String processInstanceId = createNewProcessInstance();
 
         ProcessInstance processInstance = storage.get(processInstanceId);
@@ -135,7 +135,7 @@ public abstract class AbstractProcessInstanceStorageIT {
 
     @Test
     @Transactional
-    void testProcessInstanceVariableEvent() {
+    public void testProcessInstanceVariableEvent() {
         String processInstanceId = createNewProcessInstance();
 
         ProcessInstance processInstance = storage.get(processInstanceId);

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractProcessInstanceStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractProcessInstanceStorageIT.java
@@ -40,7 +40,7 @@ public abstract class AbstractProcessInstanceStorageIT {
 
     @Test
     @Transactional
-    public void testProcessInstanceStateEvent() {
+    void testProcessInstanceStateEvent() {
         String processInstanceId = createNewProcessInstance();
 
         ProcessInstance processInstance = storage.get(processInstanceId);
@@ -68,7 +68,7 @@ public abstract class AbstractProcessInstanceStorageIT {
 
     @Test
     @Transactional
-    public void testProcessInstanceErrorEvent() {
+    void testProcessInstanceErrorEvent() {
         String processInstanceId = createNewProcessInstance();
 
         ProcessInstance processInstance = storage.get(processInstanceId);
@@ -89,7 +89,7 @@ public abstract class AbstractProcessInstanceStorageIT {
 
     @Test
     @Transactional
-    public void testProcessInstanceNodeEvent() {
+    void testProcessInstanceNodeEvent() {
         String processInstanceId = createNewProcessInstance();
 
         ProcessInstance processInstance = storage.get(processInstanceId);
@@ -109,7 +109,7 @@ public abstract class AbstractProcessInstanceStorageIT {
                 .hasSize(1);
 
         Assertions.assertThat(processInstance.getNodes().get(0))
-                .hasNoNullFieldsOrPropertiesExcept("exit", "slaDueDate", "errorMessage", "retrigger")
+                .hasNoNullFieldsOrPropertiesExcept("exit", "slaDueDate", "errorMessage", "retrigger", "cancelledType")
                 .hasFieldOrPropertyWithValue("name", "nodeName")
                 .hasFieldOrPropertyWithValue("type", "BoundaryEventNode")
                 .hasFieldOrPropertyWithValue("definitionId", nodeDefinitionId)
@@ -125,7 +125,7 @@ public abstract class AbstractProcessInstanceStorageIT {
                 .hasSize(1);
 
         Assertions.assertThat(processInstance.getNodes().get(0))
-                .hasNoNullFieldsOrPropertiesExcept("slaDueDate", "errorMessage", "retrigger")
+                .hasNoNullFieldsOrPropertiesExcept("slaDueDate", "errorMessage", "retrigger", "cancelledType")
                 .hasFieldOrPropertyWithValue("name", "nodeName")
                 .hasFieldOrPropertyWithValue("type", "BoundaryEventNode")
                 .hasFieldOrPropertyWithValue("definitionId", nodeDefinitionId)
@@ -135,7 +135,7 @@ public abstract class AbstractProcessInstanceStorageIT {
 
     @Test
     @Transactional
-    public void testProcessInstanceVariableEvent() {
+    void testProcessInstanceVariableEvent() {
         String processInstanceId = createNewProcessInstance();
 
         ProcessInstance processInstance = storage.get(processInstanceId);

--- a/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.45.1.3__add_cancelled_type_nodes.sql
+++ b/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.45.1.3__add_cancelled_type_nodes.sql
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-ALTER TABLE IF EXISTS nodes ADD COLUMN IF NOT EXISTS cancelled_type varchar (255);
+ALTER TABLE IF EXISTS nodes ADD COLUMN IF NOT EXISTS cancel_type varchar (255);

--- a/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.45.1.3__add_cancelled_type_nodes.sql
+++ b/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.45.1.3__add_cancelled_type_nodes.sql
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+ALTER TABLE IF EXISTS nodes ADD COLUMN IF NOT EXISTS cancelled_type varchar (255);

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntity.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntity.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.bson.Document;
 import org.bson.codecs.pojo.annotations.BsonId;
-import org.kie.kogito.index.model.CancelledType;
+import org.kie.kogito.index.model.CancelType;
 
 public class ProcessInstanceEntity {
 
@@ -304,7 +304,7 @@ public class ProcessInstanceEntity {
 
         Long slaDueDate;
 
-        CancelledType cancelledType;
+        CancelType cancelType;
 
         private Boolean isRetrigger;
 
@@ -374,12 +374,12 @@ public class ProcessInstanceEntity {
             this.slaDueDate = slaDueDate;
         }
 
-        public CancelledType getCancelledType() {
-            return cancelledType;
+        public CancelType getCancelType() {
+            return cancelType;
         }
 
-        public void setCancelledType(CancelledType cancelledType) {
-            this.cancelledType = cancelledType;
+        public void setCancelType(CancelType cancelType) {
+            this.cancelType = cancelType;
         }
 
         @Override

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntity.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntity.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import org.bson.Document;
 import org.bson.codecs.pojo.annotations.BsonId;
+import org.kie.kogito.index.model.CancelledType;
 
 public class ProcessInstanceEntity {
 
@@ -303,6 +304,8 @@ public class ProcessInstanceEntity {
 
         Long slaDueDate;
 
+        CancelledType cancelledType;
+
         private Boolean isRetrigger;
 
         private String errorMessage;
@@ -369,6 +372,14 @@ public class ProcessInstanceEntity {
 
         public void setSlaDueDate(Long slaDueDate) {
             this.slaDueDate = slaDueDate;
+        }
+
+        public CancelledType getCancelledType() {
+            return cancelledType;
+        }
+
+        public void setCancelledType(CancelledType cancelledType) {
+            this.cancelledType = cancelledType;
         }
 
         @Override

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapper.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapper.java
@@ -155,6 +155,7 @@ public class ProcessInstanceEntityMapper implements MongoEntityMapper<ProcessIns
         instance.setSlaDueDate(instantToZonedDateTime(entity.getSlaDueDate()));
         instance.setRetrigger(entity.isRetrigger());
         instance.setErrorMessage(entity.getErrorMessage());
+        instance.setCancelledType(entity.getCancelledType());
         return instance;
     }
 
@@ -174,6 +175,7 @@ public class ProcessInstanceEntityMapper implements MongoEntityMapper<ProcessIns
         entity.setSlaDueDate(zonedDateTimeToInstant(instance.getSlaDueDate()));
         entity.setRetrigger(instance.isRetrigger());
         entity.setErrorMessage(instance.getErrorMessage());
+        entity.setCancelledType(instance.getCancelledType());
         return entity;
     }
 

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapper.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapper.java
@@ -155,7 +155,7 @@ public class ProcessInstanceEntityMapper implements MongoEntityMapper<ProcessIns
         instance.setSlaDueDate(instantToZonedDateTime(entity.getSlaDueDate()));
         instance.setRetrigger(entity.isRetrigger());
         instance.setErrorMessage(entity.getErrorMessage());
-        instance.setCancelledType(entity.getCancelledType());
+        instance.setCancelType(entity.getCancelType());
         return instance;
     }
 
@@ -175,7 +175,7 @@ public class ProcessInstanceEntityMapper implements MongoEntityMapper<ProcessIns
         entity.setSlaDueDate(zonedDateTimeToInstant(instance.getSlaDueDate()));
         entity.setRetrigger(instance.isRetrigger());
         entity.setErrorMessage(instance.getErrorMessage());
-        entity.setCancelledType(instance.getCancelledType());
+        entity.setCancelType(instance.getCancelType());
         return entity;
     }
 

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/test/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapperTest.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/test/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapperTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.kie.kogito.index.model.CancelledType;
+import org.kie.kogito.index.model.CancelType;
 import org.kie.kogito.index.model.Milestone;
 import org.kie.kogito.index.model.NodeInstance;
 import org.kie.kogito.index.model.ProcessInstance;
@@ -54,7 +54,7 @@ class ProcessInstanceEntityMapperTest {
         String nodeInstanceNodeId = "testNodeInstanceNodeId";
         String nodeInstanceType = "testNodeInstanceType";
         String nodeInstanceDefinitionId = "testNodeInstanceDefinitionId";
-        CancelledType cancelledType = CancelledType.ABORTED;
+        CancelType cancelType = CancelType.ABORTED;
 
         String processInstanceErrorMessage = "testProcessInstanceErrorMessage";
         String processInstanceErrorNodeDefinitionId = "testProcessInstanceErrorNodeDefinitionId";
@@ -88,7 +88,7 @@ class ProcessInstanceEntityMapperTest {
         nodeInstance.setType(nodeInstanceType);
         nodeInstance.setNodeId(nodeInstanceNodeId);
         nodeInstance.setName(nodeInstanceName);
-        nodeInstance.setCancelledType(cancelledType);
+        nodeInstance.setCancelType(cancelType);
 
         ProcessInstanceError processInstanceError = new ProcessInstanceError();
         processInstanceError.setMessage(processInstanceErrorMessage);
@@ -129,7 +129,7 @@ class ProcessInstanceEntityMapperTest {
         nodeInstanceEntity.setName(nodeInstanceName);
         nodeInstanceEntity.setNodeId(nodeInstanceNodeId);
         nodeInstanceEntity.setType(nodeInstanceType);
-        nodeInstanceEntity.setCancelledType(cancelledType);
+        nodeInstanceEntity.setCancelType(cancelType);
 
         ProcessInstanceEntity.ProcessInstanceErrorEntity processInstanceErrorEntity = new ProcessInstanceEntity.ProcessInstanceErrorEntity();
         processInstanceErrorEntity.setMessage(processInstanceErrorMessage);

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/test/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapperTest.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/test/java/org/kie/kogito/index/mongodb/model/ProcessInstanceEntityMapperTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.kie.kogito.index.model.CancelledType;
 import org.kie.kogito.index.model.Milestone;
 import org.kie.kogito.index.model.NodeInstance;
 import org.kie.kogito.index.model.ProcessInstance;
@@ -53,6 +54,7 @@ class ProcessInstanceEntityMapperTest {
         String nodeInstanceNodeId = "testNodeInstanceNodeId";
         String nodeInstanceType = "testNodeInstanceType";
         String nodeInstanceDefinitionId = "testNodeInstanceDefinitionId";
+        CancelledType cancelledType = CancelledType.ABORTED;
 
         String processInstanceErrorMessage = "testProcessInstanceErrorMessage";
         String processInstanceErrorNodeDefinitionId = "testProcessInstanceErrorNodeDefinitionId";
@@ -86,6 +88,7 @@ class ProcessInstanceEntityMapperTest {
         nodeInstance.setType(nodeInstanceType);
         nodeInstance.setNodeId(nodeInstanceNodeId);
         nodeInstance.setName(nodeInstanceName);
+        nodeInstance.setCancelledType(cancelledType);
 
         ProcessInstanceError processInstanceError = new ProcessInstanceError();
         processInstanceError.setMessage(processInstanceErrorMessage);
@@ -126,6 +129,7 @@ class ProcessInstanceEntityMapperTest {
         nodeInstanceEntity.setName(nodeInstanceName);
         nodeInstanceEntity.setNodeId(nodeInstanceNodeId);
         nodeInstanceEntity.setType(nodeInstanceType);
+        nodeInstanceEntity.setCancelledType(cancelledType);
 
         ProcessInstanceEntity.ProcessInstanceErrorEntity processInstanceErrorEntity = new ProcessInstanceEntity.ProcessInstanceErrorEntity();
         processInstanceErrorEntity.setMessage(processInstanceErrorMessage);

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.45.1.3__add_cancelled_type_nodes.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.45.1.3__add_cancelled_type_nodes.sql
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+ALTER TABLE IF EXISTS nodes ADD COLUMN IF NOT EXISTS cancelled_type varchar (255);

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.45.1.3__add_cancelled_type_nodes.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.45.1.3__add_cancelled_type_nodes.sql
@@ -18,4 +18,4 @@
  */
 
 
-ALTER TABLE IF EXISTS nodes ADD COLUMN IF NOT EXISTS cancelled_type varchar (255);
+ALTER TABLE IF EXISTS nodes ADD COLUMN IF NOT EXISTS cancel_type varchar (255);


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2012

Currently, the frontend (Management Console) has no way of knowing if a Node was Canceled/Aborted.

The current workaround is to check if all related Jobs are canceled, but this is not ideal since a Node can have multiple related Jobs with different statuses.

Adding a 'canceled' property will help properly display the Node status in the timeline.

The property could reflect the way the node was cancelled