### PR TITLE
[NO-ISSUE] Upgrade kafka-clients to 3.9.1. 

### DIFF
--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus/pom.xml
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus/pom.xml
@@ -60,6 +60,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.reactivemessaging.http</groupId>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/pom.xml
@@ -61,6 +61,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-management/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-management/pom.xml
@@ -68,6 +68,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-messaging/pom.xml
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-messaging/pom.xml
@@ -68,6 +68,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>

--- a/data-index/data-index-quarkus/data-index-service-mongodb/pom.xml
+++ b/data-index/data-index-quarkus/data-index-service-mongodb/pom.xml
@@ -52,6 +52,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/data-index/data-index-quarkus/data-index-service-postgresql/pom.xml
+++ b/data-index/data-index-quarkus/data-index-service-postgresql/pom.xml
@@ -52,6 +52,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/explainability/explainability-service-messaging/pom.xml
+++ b/explainability/explainability-service-messaging/pom.xml
@@ -48,6 +48,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
@@ -93,11 +105,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-test-utils</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jobs-service/jobs-service-messaging-kafka/pom.xml
+++ b/jobs-service/jobs-service-messaging-kafka/pom.xml
@@ -64,6 +64,18 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-messaging-kafka</artifactId>
+            <exclusions>
+                <!-- Overriding kafka-clients to fix a vulnerability.
+                     This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka-clients</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
             <groupId>io.smallrye.reactive</groupId>

--- a/trusty/trusty-service/trusty-service-common/pom.xml
+++ b/trusty/trusty-service/trusty-service-common/pom.xml
@@ -56,6 +56,18 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-messaging-kafka</artifactId>
+      <exclusions>
+        <!-- Overriding kafka-clients to fix a vulnerability.
+             This exclusion can be removed when Quarkus will contain kafka-clients in at least version 3.9.1. -->
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.kogito</groupId>
@@ -112,11 +124,6 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-quarkus-test-utils</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR upgrades kafka-clients to 3.9.1 due to vulnerabilities.

Related PRs:
drools: https://github.com/apache/incubator-kie-drools/pull/6404
kogito-runtimes: https://github.com/apache/incubator-kie-kogito-runtimes/pull/3985