### PR TITLE
[incubator-kie-issues-2072] Add on cascade delete for few data-audit tables that have foreign key constraints

### DIFF
--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/h2/V1.4.4__Add_on_cascade_delete.sql
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/h2/V1.4.4__Add_on_cascade_delete.sql
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+alter table process_instance_state_roles_log drop constraint fk_process_instance_state_pid;
+alter table process_instance_state_roles_log add constraint fk_process_instance_state_pid foreign key (process_instance_state_log_id) references process_instance_state_log on delete cascade;
+
+alter table task_instance_assignment_users_log drop constraint fk_task_instance_assignment_log_tid;
+alter table task_instance_assignment_users_log add constraint fk_task_instance_assignment_log_tid foreign key (task_instance_assignment_log_id) references task_instance_assignment_log on delete cascade;
+
+alter table task_instance_deadline_notification_log drop constraint fk_task_instance_deadline_tid;
+alter table task_instance_deadline_notification_log add constraint fk_task_instance_deadline_tid foreign key (task_instance_deadline_log_id) references task_instance_deadline_log on delete cascade;

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/postgresql/V1.4.4__Add_on_cascade_delete.sql
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/postgresql/V1.4.4__Add_on_cascade_delete.sql
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+alter table process_instance_state_roles_log drop constraint fk_process_instance_state_pid;
+alter table process_instance_state_roles_log add constraint fk_process_instance_state_pid foreign key (process_instance_state_log_id) references process_instance_state_log on delete cascade;
+
+alter table task_instance_assignment_users_log drop constraint fk_task_instance_assignment_log_tid;
+alter table task_instance_assignment_users_log add constraint fk_task_instance_assignment_log_tid foreign key (task_instance_assignment_log_id) references task_instance_assignment_log on delete cascade;
+
+alter table task_instance_deadline_notification_log drop constraint fk_task_instance_deadline_tid;
+alter table task_instance_deadline_notification_log add constraint fk_task_instance_deadline_tid foreign key (task_instance_deadline_log_id) references task_instance_deadline_log on delete cascade;


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2072

Add on cascade delete for process_instance_state_roles_log, task_instance_assignment_users_log and task_instance_deadline_notification_log which have foreign key relationship with Process_Instance_State_Log, Task_Instance_Assignment_Log and Task_Instance_Deadline_Log respectively