### PR TITLE
[NO_ISSUE] Reduce logging verbosity in Springboot for JobInstanceDataEvents

### DIFF
--- a/data-audit/kogito-addons-data-audit-springboot/src/main/java/org/kie/kogito/app/audit/springboot/SpringbootDataAuditEventPublisher.java
+++ b/data-audit/kogito-addons-data-audit-springboot/src/main/java/org/kie/kogito/app/audit/springboot/SpringbootDataAuditEventPublisher.java
@@ -65,7 +65,7 @@ public class SpringbootDataAuditEventPublisher implements EventPublisher {
             proxy.storeUserTaskInstanceDataEvent(dataAuditContextFactory.newDataAuditContext(), (UserTaskInstanceDataEvent<?>) event);
             return;
         } else if (event instanceof JobInstanceDataEvent) {
-            LOGGER.info("Processing job instance event {}", event);
+            LOGGER.debug("Processing job instance event {}", event);
             proxy.storeJobDataEvent(dataAuditContextFactory.newDataAuditContext(), (JobInstanceDataEvent) event);
             return;
         }


### PR DESCRIPTION
This fixes some inconsistency in the logging verbosity for different types of events, and reduces the logging output at INFO level.