### PR TITLE
NO-ISSUE: fix test failures on windows

### DIFF
--- a/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/service/vertx/VertxRouterSetupHelper.java
+++ b/data-index/data-index-service/data-index-service-common/src/main/java/org/kie/kogito/index/service/vertx/VertxRouterSetupHelper.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.index.service.vertx;
 
+import java.io.File;
 import java.util.function.Function;
 
 import io.vertx.core.MultiMap;
@@ -59,7 +60,7 @@ public class VertxRouterSetupHelper {
                             .end());
 
             final String normalized = indexUIPath.endsWith("/") ? indexUIPath.substring(0, indexUIPath.length() - 1) : indexUIPath;
-            final FileSystemAccess fsa = normalized.startsWith("/") ? FileSystemAccess.ROOT : FileSystemAccess.RELATIVE;
+            final FileSystemAccess fsa = new File(normalized).isAbsolute() ? FileSystemAccess.ROOT : FileSystemAccess.RELATIVE;
             final StaticHandler handler = StaticHandler.create(fsa, normalized)
                     .setDefaultContentEncoding("utf-8")
                     .setDirectoryListing(false)


### PR DESCRIPTION
Fixing an absolute path check in Vertx helper. This was causing several test failures when building on Windows.