### PR TITLE
[Incubator kie issues#2177] Update existing job instances instead of inserting/replacing in data index 

### DIFF
--- a/data-index/data-index-common/src/main/java/org/kie/kogito/index/service/IndexingService.java
+++ b/data-index/data-index-common/src/main/java/org/kie/kogito/index/service/IndexingService.java
@@ -43,6 +43,7 @@ import org.kie.kogito.event.usertask.UserTaskInstanceVariableDataEvent;
 import org.kie.kogito.index.model.Job;
 import org.kie.kogito.index.model.ProcessDefinitionKey;
 import org.kie.kogito.index.storage.DataIndexStorageService;
+import org.kie.kogito.index.storage.JobInstanceStorage;
 import org.kie.kogito.index.storage.ProcessInstanceStorage;
 import org.kie.kogito.index.storage.UserTaskInstanceStorage;
 import org.kie.kogito.persistence.api.Storage;
@@ -118,7 +119,13 @@ public class IndexingService {
     }
 
     public void indexJob(Job job) {
-        manager.getJobsStorage().put(job.getId(), job);
+        Storage<String, Job> jobsStorage = manager.getJobsStorage();
+
+        if (jobsStorage instanceof JobInstanceStorage jobInstanceStorage) {
+            jobInstanceStorage.indexJob(job);
+        } else {
+            jobsStorage.put(job.getId(), job);
+        }
     }
 
     public void indexModel(ObjectNode updateData) {

--- a/data-index/data-index-common/src/main/java/org/kie/kogito/index/service/IndexingService.java
+++ b/data-index/data-index-common/src/main/java/org/kie/kogito/index/service/IndexingService.java
@@ -43,7 +43,6 @@ import org.kie.kogito.event.usertask.UserTaskInstanceVariableDataEvent;
 import org.kie.kogito.index.model.Job;
 import org.kie.kogito.index.model.ProcessDefinitionKey;
 import org.kie.kogito.index.storage.DataIndexStorageService;
-import org.kie.kogito.index.storage.JobInstanceStorage;
 import org.kie.kogito.index.storage.ProcessInstanceStorage;
 import org.kie.kogito.index.storage.UserTaskInstanceStorage;
 import org.kie.kogito.persistence.api.Storage;
@@ -119,13 +118,7 @@ public class IndexingService {
     }
 
     public void indexJob(Job job) {
-        Storage<String, Job> jobsStorage = manager.getJobsStorage();
-
-        if (jobsStorage instanceof JobInstanceStorage jobInstanceStorage) {
-            jobInstanceStorage.indexJob(job);
-        } else {
-            jobsStorage.put(job.getId(), job);
-        }
+        manager.getJobsStorage().indexJob(job);
     }
 
     public void indexModel(ObjectNode updateData) {

--- a/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/storage/DataIndexStorageService.java
+++ b/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/storage/DataIndexStorageService.java
@@ -21,7 +21,6 @@ package org.kie.kogito.index.storage;
 import java.util.EnumSet;
 import java.util.Set;
 
-import org.kie.kogito.index.model.Job;
 import org.kie.kogito.index.model.ProcessDefinition;
 import org.kie.kogito.index.model.ProcessDefinitionKey;
 import org.kie.kogito.persistence.api.Storage;
@@ -36,7 +35,7 @@ public interface DataIndexStorageService {
 
     UserTaskInstanceStorage getUserTaskInstanceStorage();
 
-    Storage<String, Job> getJobsStorage();
+    JobInstanceStorage getJobsStorage();
 
     Storage<String, ObjectNode> getDomainModelCache(String processId);
 

--- a/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/storage/JobInstanceStorage.java
+++ b/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/storage/JobInstanceStorage.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.index.storage;
+
+import org.kie.kogito.index.model.Job;
+
+public interface JobInstanceStorage {
+    void indexJob(Job job);
+}

--- a/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/ModelDataIndexStorageService.java
+++ b/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/ModelDataIndexStorageService.java
@@ -59,8 +59,8 @@ public class ModelDataIndexStorageService implements DataIndexStorageService {
     }
 
     @Override
-    public Storage<String, Job> getJobsStorage() {
-        return storageService.getCache(JOBS_STORAGE, Job.class);
+    public JobInstanceStorage getJobsStorage() {
+        return new ModelJobInstanceStorage(storageService.getCache(JOBS_STORAGE, Job.class));
     }
 
     @Override

--- a/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/ModelJobInstanceStorage.java
+++ b/data-index/data-index-storage/data-index-storage-common/src/main/java/org/kie/kogito/index/storage/ModelJobInstanceStorage.java
@@ -18,9 +18,44 @@
  */
 package org.kie.kogito.index.storage;
 
+import java.util.Map;
+
 import org.kie.kogito.index.model.Job;
 import org.kie.kogito.persistence.api.Storage;
 
-public interface JobInstanceStorage extends Storage<String, Job> {
-    void indexJob(Job job);
+public class ModelJobInstanceStorage extends ModelStorageFetcher<String, Job> implements JobInstanceStorage {
+
+    public ModelJobInstanceStorage(Storage<String, Job> storage) {
+        super(storage, key -> key, key -> key);
+    }
+
+    @Override
+    public void indexJob(Job job) {
+        put(job.getId(), job);
+    }
+
+    @Override
+    public Job put(String key, Job value) {
+        return storage.put(key, value);
+    }
+
+    @Override
+    public Job remove(String key) {
+        return storage.remove(key);
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return storage.containsKey(key);
+    }
+
+    @Override
+    public Map<String, Job> entries() {
+        return storage.entries();
+    }
+
+    @Override
+    public String getRootType() {
+        return Job.class.getName();
+    }
 }

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/JPADataIndexStorageService.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/JPADataIndexStorageService.java
@@ -20,10 +20,10 @@ package org.kie.kogito.index.jpa.storage;
 
 import java.util.Set;
 
-import org.kie.kogito.index.model.Job;
 import org.kie.kogito.index.model.ProcessDefinition;
 import org.kie.kogito.index.model.ProcessDefinitionKey;
 import org.kie.kogito.index.storage.DataIndexStorageService;
+import org.kie.kogito.index.storage.JobInstanceStorage;
 import org.kie.kogito.index.storage.ProcessInstanceStorage;
 import org.kie.kogito.index.storage.UserTaskInstanceStorage;
 import org.kie.kogito.persistence.api.Storage;
@@ -70,7 +70,7 @@ public class JPADataIndexStorageService implements DataIndexStorageService {
     }
 
     @Override
-    public Storage<String, Job> getJobsStorage() {
+    public JobInstanceStorage getJobsStorage() {
         return jobsStorage;
     }
 

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/JobEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/JobEntityStorage.java
@@ -43,23 +43,30 @@ public class JobEntityStorage extends AbstractStorage<String, JobEntity, Job> im
     @Transactional
     @Override
     public void indexJob(Job job) {
-        JobEntity entity = findOrInit(job.getId());
+        JobEntity entity = findOrInit(job.getId(), job);
         updateJobEntity(entity, job);
     }
 
-    private JobEntity findOrInit(String jobId) {
-        JobEntity job = em.find(JobEntity.class, jobId);
-        if (job == null) {
-            job = new JobEntity();
-            job.setId(jobId);
-            em.persist(job);
+    private JobEntity findOrInit(String jobId, Job job) {
+        JobEntity entity = em.find(JobEntity.class, jobId);
+        if (entity == null) {
+            entity = new JobEntity();
+            entity.setId(jobId);
+            entity.setProcessId(job.getProcessId());
+            entity.setRootProcessId(job.getRootProcessId());
+            em.persist(entity);
+        } else {
+            if (entity.getProcessId() == null) {
+                entity.setProcessId(job.getProcessId());
+            }
+            if (entity.getRootProcessId() == null) {
+                entity.setRootProcessId(job.getRootProcessId());
+            }
         }
-        return job;
+        return entity;
     }
 
     private void updateJobEntity(JobEntity entity, Job job) {
-        String existingProcessId = entity.getProcessId();
-        String existingRootProcessId = entity.getRootProcessId();
         entity.setProcessInstanceId(job.getProcessInstanceId());
         entity.setNodeInstanceId(job.getNodeInstanceId());
         entity.setRootProcessInstanceId(job.getRootProcessInstanceId());
@@ -74,17 +81,5 @@ public class JobEntityStorage extends AbstractStorage<String, JobEntity, Job> im
         entity.setLastUpdate(job.getLastUpdate());
         entity.setExecutionCounter(job.getExecutionCounter());
         entity.setEndpoint(job.getEndpoint());
-
-        if (existingProcessId != null) {
-            entity.setProcessId(existingProcessId);
-        } else {
-            entity.setProcessId(job.getProcessId());
-        }
-
-        if (existingRootProcessId != null) {
-            entity.setRootProcessId(existingRootProcessId);
-        } else {
-            entity.setRootProcessId(job.getRootProcessId());
-        }
     }
 }

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/JobEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/JobEntityStorage.java
@@ -22,13 +22,15 @@ import org.kie.kogito.index.jpa.mapper.JobEntityMapper;
 import org.kie.kogito.index.jpa.model.AbstractEntity;
 import org.kie.kogito.index.jpa.model.JobEntity;
 import org.kie.kogito.index.model.Job;
+import org.kie.kogito.index.storage.JobInstanceStorage;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 
 @ApplicationScoped
-public class JobEntityStorage extends AbstractStorage<String, JobEntity, Job> {
+public class JobEntityStorage extends AbstractStorage<String, JobEntity, Job> implements JobInstanceStorage {
 
     protected JobEntityStorage() {
     }
@@ -36,5 +38,53 @@ public class JobEntityStorage extends AbstractStorage<String, JobEntity, Job> {
     @Inject
     public JobEntityStorage(EntityManager em) {
         super(em, Job.class, JobEntity.class, JobEntityMapper.INSTANCE::mapToModel, JobEntityMapper.INSTANCE::mapToEntity, AbstractEntity::getId);
+    }
+
+    @Transactional
+    @Override
+    public void indexJob(Job job) {
+        JobEntity entity = findOrInit(job.getId());
+        updateJobEntity(entity, job);
+    }
+
+    private JobEntity findOrInit(String jobId) {
+        JobEntity job = em.find(JobEntity.class, jobId);
+        if (job == null) {
+            job = new JobEntity();
+            job.setId(jobId);
+            em.persist(job);
+        }
+        return job;
+    }
+
+    private void updateJobEntity(JobEntity entity, Job job) {
+        String existingProcessId = entity.getProcessId();
+        String existingRootProcessId = entity.getRootProcessId();
+        entity.setProcessInstanceId(job.getProcessInstanceId());
+        entity.setNodeInstanceId(job.getNodeInstanceId());
+        entity.setRootProcessInstanceId(job.getRootProcessInstanceId());
+        entity.setExpirationTime(job.getExpirationTime());
+        entity.setPriority(job.getPriority());
+        entity.setCallbackEndpoint(job.getCallbackEndpoint());
+        entity.setRepeatInterval(job.getRepeatInterval());
+        entity.setRepeatLimit(job.getRepeatLimit());
+        entity.setScheduledId(job.getScheduledId());
+        entity.setRetries(job.getRetries());
+        entity.setStatus(job.getStatus());
+        entity.setLastUpdate(job.getLastUpdate());
+        entity.setExecutionCounter(job.getExecutionCounter());
+        entity.setEndpoint(job.getEndpoint());
+
+        if (existingProcessId != null) {
+            entity.setProcessId(existingProcessId);
+        } else {
+            entity.setProcessId(job.getProcessId());
+        }
+
+        if (existingRootProcessId != null) {
+            entity.setRootProcessId(existingRootProcessId);
+        } else {
+            entity.setRootProcessId(job.getRootProcessId());
+        }
     }
 }


### PR DESCRIPTION
Implements a "find or init" pattern for job indexing:

1. **Added `JobInstanceStorage` interface**: A new interface in `data-index-storage-api` supporting instance-based indexing.

2. **Updated `JobEntityStorage`**: The JPA implementation now implements `JobInstanceStorage` with the following behavior:
   - When indexing a job, it first checks if a job entity already exists in storage
   - If it exists, updates the existing entity with new values while preserving existing critical fields (such as `processId` and `rootProcessId` if they are already set)
   - If it doesn't exist, creates and persists a new entity

3. **Modified `IndexingService`**: Updated `indexJob()` method to use the new interface when available.

Closes https://github.com/apache/incubator-kie-issues/issues/2177