### PR TITLE
[incubator-kie-issues#2179] Failing async service task node pointing to wrong nodeInstanceId

### DIFF
--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/ErrorHandlingJobTimeoutInterceptor.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/ErrorHandlingJobTimeoutInterceptor.java
@@ -50,7 +50,8 @@ public class ErrorHandlingJobTimeoutInterceptor implements JobTimeoutInterceptor
             @Override
             public JobTimeoutExecution call() throws Exception {
                 JobTimeoutExecution execution = callable.call();
-                if (execution.getJobDetails() != null && JobStatus.ERROR.equals(execution.getJobDetails().getStatus())) {
+                if (execution.getJobDetails() != null
+                        && (JobStatus.ERROR.equals(execution.getJobDetails().getStatus()) || (JobStatus.RETRY.equals(execution.getJobDetails().getStatus()) && execution.getException() != null))) {
                     if (exceptionHandlers.isEmpty()) {
                         LOG.warn("there was an error in job {} but not handler were registered", execution.getJobDetails());
                     } else {


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2179

If an async node instance fails in execution (Servicetask throwing an exception), leaves the process in error state as expected, but the error state both in the process instance state and Data Index refer to an unexisting node instance id.

We suspect that this is happening because when triggering an async node, process engine generates a virtual async node instance that wraps the async execution. Probably the error state refers to that AsyncEventNodeInstance

Ensemble:
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4136
https://github.com/apache/incubator-kie-kogito-apps/pull/2283