### PR TITLE
[Fix_#2284] Adding back JSON support for postgresql

### DIFF
--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessInstanceEntityStorage.java
@@ -24,6 +24,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 import org.kie.kogito.event.process.MultipleProcessInstanceDataEvent;
@@ -50,6 +51,7 @@ import org.kie.kogito.index.model.MilestoneStatus;
 import org.kie.kogito.index.model.ProcessInstance;
 import org.kie.kogito.index.storage.ProcessInstanceStorage;
 import org.kie.kogito.persistence.api.StorageServiceCapability;
+import org.kie.kogito.persistence.api.StorageServiceCapabilityProvider;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
@@ -279,6 +281,8 @@ public class ProcessInstanceEntityStorage extends AbstractJPAStorageFetcher<Stri
 
     @Override
     public Set<StorageServiceCapability> capabilities() {
-        return EnumSet.of(StorageServiceCapability.COUNT);
+        Set<StorageServiceCapability> result = EnumSet.of(StorageServiceCapability.COUNT);
+        ServiceLoader.load(StorageServiceCapabilityProvider.class).forEach(s -> result.addAll(s.capabilities()));
+        return result;
     }
 }

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/java/org/kie/kogito/index/postgresql/PostgresqlStorageServiceCapabilities.java
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/java/org/kie/kogito/index/postgresql/PostgresqlStorageServiceCapabilities.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.index.postgresql;
+
+import java.util.Set;
+
+import org.kie.kogito.persistence.api.StorageServiceCapability;
+import org.kie.kogito.persistence.api.StorageServiceCapabilityProvider;
+
+public class PostgresqlStorageServiceCapabilities implements StorageServiceCapabilityProvider {
+
+    @Override
+    public Set<StorageServiceCapability> capabilities() {
+        return Set.of(StorageServiceCapability.JSON_QUERY);
+    }
+}

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/META-INF/services/org.kie.kogito.persistence.api.StorageServiceCapabilityProvider
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/META-INF/services/org.kie.kogito.persistence.api.StorageServiceCapabilityProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.kie.kogito.index.postgresql.PostgresqlStorageServiceCapabilities

--- a/persistence-commons/persistence-commons-api/src/main/java/org/kie/kogito/persistence/api/StorageServiceCapabilityProvider.java
+++ b/persistence-commons/persistence-commons-api/src/main/java/org/kie/kogito/persistence/api/StorageServiceCapabilityProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.persistence.api;
+
+import java.util.Set;
+
+public interface StorageServiceCapabilityProvider {
+    Set<StorageServiceCapability> capabilities();
+}


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-kogito-apps/issues/2284

Adds the possibility of loading additional capabilities from service loader. Therefore, when Postgresql module is on classpath, the JSON capability will be there.