### PR TITLE
[incubator-kie-issues#2231] capture job execution exception details when enabled

### DIFF
--- a/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus-devservice/src/test/java/org/kie/kogito/index/inmemory/KogitoDevServiceTest.java
+++ b/apps-integration-tests/integration-tests-data-index-service/integration-tests-data-index-service-quarkus-devservice/src/test/java/org/kie/kogito/index/inmemory/KogitoDevServiceTest.java
@@ -112,6 +112,7 @@ public class KogitoDevServiceTest {
     private static String getApplicationPropertiesContent() {
         return "quarkus.http.port=" + httpPort + "\n"
                 + "quarkus.kogito.devservices.port=" + dataIndexHttpPort + "\n"
+                + "quarkus.keycloak.devservices.enabled=false" + "\n"
                 + getKogitoDevServicesImageName();
     }
 

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/src/test/resources/application.properties
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/src/test/resources/application.properties
@@ -18,3 +18,6 @@
 #
 
 quarkus.kafka.devservices.image-name=${container.image.kafka}
+
+# This devservice is not needed in Kogito tests
+quarkus.keycloak.devservices.enabled=false

--- a/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/src/main/resources/application.properties
+++ b/apps-integration-tests/integration-tests-jobs-service/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/src/main/resources/application.properties
@@ -22,6 +22,8 @@ quarkus.smallrye-health.check."org.kie.kogito.addons.quarkus.knative.eventing.KS
 
 quarkus.kafka.devservices.enabled=false
 quarkus.kogito.devservices.enabled=false
+# This devservice is not needed in Kogito tests
+quarkus.keycloak.devservices.enabled=false
 
 # Events produced by kogito-addons-quarkus-jobs-knative-eventing to program the timers on the jobs service.
 mp.messaging.outgoing.kogito-job-service-job-request-events.connector=quarkus-http

--- a/data-audit/data-audit-common/src/main/java/org/kie/kogito/app/audit/graphql/type/JobExecutionTO.java
+++ b/data-audit/data-audit-common/src/main/java/org/kie/kogito/app/audit/graphql/type/JobExecutionTO.java
@@ -48,12 +48,15 @@ public class JobExecutionTO {
 
     private OffsetDateTime eventDate;
 
+    private String exceptionMessage;
+    private String exceptionDetails;
+
     public JobExecutionTO() {
 
     }
 
     public JobExecutionTO(String jobId, Date expirationtime, Integer priority, String processInstanceId, String nodeInstanceId,
-            Long repeatInterval, Integer repeatLimit, String scheduledId, Integer retries, String status, Integer executionCounter, Date eventDate) {
+            Long repeatInterval, Integer repeatLimit, String scheduledId, Integer retries, String status, Integer executionCounter, Date eventDate, String exceptionMessage, String exceptionDetails) {
         this.jobId = jobId;
         this.expirationTime = OffsetDateTime.ofInstant(expirationtime.toInstant(), ZoneId.of("UTC"));
         this.priority = priority;
@@ -66,6 +69,8 @@ public class JobExecutionTO {
         this.status = status;
         this.executionCounter = executionCounter;
         this.eventDate = OffsetDateTime.ofInstant(eventDate.toInstant(), ZoneId.of("UTC"));
+        this.exceptionMessage = exceptionMessage;
+        this.exceptionDetails = exceptionDetails;
     }
 
     public String getJobId() {
@@ -164,4 +169,19 @@ public class JobExecutionTO {
         this.eventDate = eventDate;
     }
 
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public String getExceptionDetails() {
+        return exceptionDetails;
+    }
+
+    public void setExceptionDetails(String exceptionDetails) {
+        this.exceptionDetails = exceptionDetails;
+    }
 }

--- a/data-audit/data-audit-common/src/main/resources/META-INF/data-audit-job-query.graphqls
+++ b/data-audit/data-audit-common/src/main/resources/META-INF/data-audit-job-query.graphqls
@@ -5,8 +5,8 @@ type Query {
     GetJobById (jobId : String!) : [JobExecutionLog]
     GetJobByProcessInstanceId (processInstanceId : String!) : [JobExecutionLog]
 
-    GetJobHistoryById (jobId : String!) : [JobExecutionLog]
-    GetJobHistoryByProcessInstanceId (processInstanceId : String!) : [JobExecutionLog]
+    GetJobHistoryById (jobId : String!, pagination: Pagination) : [JobExecutionLog]
+    GetJobHistoryByProcessInstanceId (processInstanceId : String!, pagination: Pagination) : [JobExecutionLog]
 
     GetAllPendingJobs (pagination: Pagination): [JobExecutionLog]
     GetAllEligibleJobsForExecution (pagination: Pagination) : [JobExecutionLog]

--- a/data-audit/data-audit-common/src/main/resources/META-INF/data-audit-types.graphqls
+++ b/data-audit/data-audit-common/src/main/resources/META-INF/data-audit-types.graphqls
@@ -17,6 +17,8 @@ type JobExecutionLog {
     status : String
     executionCounter : Int
     eventDate : DateTime
+    exceptionMessage : String
+    exceptionDetails : String
 }
 
 type ProcessInstanceStateLog {

--- a/data-audit/data-audit-common/src/test/java/org/kie/kogito/app/audit/quarkus/DataAuditTestUtils.java
+++ b/data-audit/data-audit-common/src/test/java/org/kie/kogito/app/audit/quarkus/DataAuditTestUtils.java
@@ -72,6 +72,12 @@ public class DataAuditTestUtils {
     public static JobInstanceDataEvent newJobEvent(String jobId, String nodeInstanceId, Integer priority,
             String processId, String procesInstanceId, Long repeatInterval, Integer repeatLimit, String rootProcessId, String rootProcessInstanceId,
             JobStatus state, Integer executionCounter) throws Exception {
+        return newJobEvent(jobId, nodeInstanceId, priority, processId, procesInstanceId, repeatInterval, repeatLimit, rootProcessId, rootProcessInstanceId, state, executionCounter, null, null);
+    }
+
+    public static JobInstanceDataEvent newJobEvent(String jobId, String nodeInstanceId, Integer priority,
+            String processId, String procesInstanceId, Long repeatInterval, Integer repeatLimit, String rootProcessId, String rootProcessInstanceId,
+            JobStatus state, Integer executionCounter, String exceptionMessage, String exceptionDetails) throws Exception {
 
         ScheduledJob job = new ScheduledJob();
         job.setId(jobId);
@@ -89,8 +95,11 @@ public class DataAuditTestUtils {
                 .job(job)
                 .status(state)
                 .executionCounter(executionCounter)
+                .retries(executionCounter) // Set retries to match executionCounter for testing
                 .scheduledId("my scheduler")
                 .expirationTime(ZonedDateTime.now())
+                .exceptionMessage(exceptionMessage)
+                .exceptionDetails(exceptionDetails)
                 .build();
 
         JobInstanceDataEvent dataEvent =
@@ -100,13 +109,20 @@ public class DataAuditTestUtils {
     }
 
     public static JobInstanceDataEvent deriveNewState(JobInstanceDataEvent jobEvent, Integer executionCounter, JobStatus state) throws Exception {
+        return deriveNewState(jobEvent, executionCounter, state, null, null);
+    }
+
+    public static JobInstanceDataEvent deriveNewState(JobInstanceDataEvent jobEvent, Integer executionCounter, JobStatus state, String exceptionMessage, String exceptionDetails) throws Exception {
         ScheduledJob job = new ObjectMapper().registerModule(new JavaTimeModule()).readValue(jobEvent.getData(), ScheduledJob.class);
         job = ScheduledJob.builder()
                 .job(job)
                 .status(state)
                 .executionCounter(executionCounter)
+                .retries(executionCounter) // Set retries to match executionCounter for testing
                 .scheduledId("my scheduler")
                 .expirationTime(ZonedDateTime.now())
+                .exceptionMessage(exceptionMessage)
+                .exceptionDetails(exceptionDetails)
                 .build();
 
         JobInstanceDataEvent dataEvent = new JobInstanceDataEvent("JobEvent", jobEvent.getSource().toString(), new ObjectMapper().registerModule(new JavaTimeModule()).writeValueAsBytes(job),

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/JPADataAuditStore.java
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/JPADataAuditStore.java
@@ -363,6 +363,7 @@ public class JPADataAuditStore implements DataAuditStore {
         log.setRepeatInterval(job.getRepeatInterval());
         log.setRepeatLimit(job.getRepeatLimit());
         log.setScheduledId(job.getScheduledId());
+        log.setRetries(job.getRetries());
 
         if (job.getStatus() != null) {
             log.setStatus(job.getStatus().name());
@@ -370,6 +371,8 @@ public class JPADataAuditStore implements DataAuditStore {
 
         log.setExecutionCounter(job.getExecutionCounter());
         log.setEventDate(Timestamp.from(Instant.now()));
+        log.setExceptionMessage(job.getExceptionMessage());
+        log.setExceptionDetails(job.getExceptionDetails());
         EntityManager entityManager = context.getContext();
         entityManager.persist(log);
     }

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/model/JobExecutionLog.java
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/model/JobExecutionLog.java
@@ -81,6 +81,11 @@ public class JobExecutionLog {
     @Temporal(TemporalType.TIMESTAMP)
     private Date eventDate;
 
+    @Column(name = "exception_message")
+    private String exceptionMessage;
+    @Column(name = "exception_details")
+    private String exceptionDetails;
+
     public Long getId() {
         return id;
     }
@@ -183,5 +188,21 @@ public class JobExecutionLog {
 
     public void setEventDate(Timestamp eventDate) {
         this.eventDate = eventDate;
+    }
+
+    public String getExceptionDetails() {
+        return exceptionDetails;
+    }
+
+    public void setExceptionDetails(String exceptionDetails) {
+        this.exceptionDetails = exceptionDetails;
+    }
+
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
     }
 }

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/model/JobExecutionLog.java
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/model/JobExecutionLog.java
@@ -83,7 +83,8 @@ public class JobExecutionLog {
 
     @Column(name = "exception_message")
     private String exceptionMessage;
-    @Column(name = "exception_details")
+
+    @Column(name = "exception_details", columnDefinition = "TEXT")
     private String exceptionDetails;
 
     public Long getId() {

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/java/org/kie/kogito/app/audit/jpa/queries/JPAAbstractQuery.java
@@ -75,6 +75,7 @@ public abstract class JPAAbstractQuery<R> {
             }
             if (pagination.get("offset") != null) {
                 jpaQuery.setFirstResult((Integer) pagination.get("offset"));
+            } else {
                 jpaQuery.setFirstResult(0);
             }
         } else {

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/META-INF/data-audit-orm.xml
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/META-INF/data-audit-orm.xml
@@ -26,7 +26,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.status = 'SCHEDULED'
@@ -49,7 +51,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.job_id = :jobId
@@ -71,7 +75,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
              WHERE o1.job_id = :jobId
           ORDER BY o1.event_date DESC
@@ -94,7 +100,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
              WHERE o1.process_instance_id = :processInstanceId
           ORDER BY o1.event_date DESC
@@ -116,7 +124,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.status IN ('SCHEDULED', 'RETRY')
@@ -137,7 +147,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.status IN ('SCHEDULED')
@@ -158,7 +170,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.status IN ('RETRY', 'ERROR')
@@ -180,7 +194,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL 
@@ -202,7 +218,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.status = 'EXECUTED'
@@ -223,7 +241,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.status = 'ERROR'
@@ -244,7 +264,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.status = 'CANCELED'
@@ -266,7 +288,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.status IN (:status) 
@@ -288,7 +312,9 @@
                   o1.retries, 
                   o1.status, 
                   o1.execution_counter,  
-                  o1.event_date
+                  o1.event_date,
+                  o1.exception_message,
+                  o1.exception_details
               FROM Job_Execution_Log o1 
               LEFT JOIN Job_Execution_Log o2 ON o1.job_id = o2.job_id AND o1.event_date &lt; o2.event_date 
              WHERE o2.job_id IS NULL AND o1.process_instance_id = :processInstanceId

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/h2/V1.5.0__Add_job_exception_columns.sql
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/h2/V1.5.0__Add_job_exception_columns.sql
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+ALTER TABLE Job_Execution_Log ADD COLUMN exception_message VARCHAR(500);
+ALTER TABLE Job_Execution_Log ADD COLUMN exception_details VARCHAR(4000);
+

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/h2/V1.5.0__Add_job_exception_columns.sql
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/h2/V1.5.0__Add_job_exception_columns.sql
@@ -17,6 +17,9 @@
  * under the License.
  */
 
-ALTER TABLE Job_Execution_Log ADD COLUMN exception_message VARCHAR(500);
-ALTER TABLE Job_Execution_Log ADD COLUMN exception_details VARCHAR(4000);
+-- Add exception details columns to Job_Execution_Log table
+-- exception_message: VARCHAR without length constraint for full flexibility
+-- exception_details: TEXT type for large content without space reservation when NULL
+ALTER TABLE Job_Execution_Log ADD COLUMN exception_message VARCHAR;
+ALTER TABLE Job_Execution_Log ADD COLUMN exception_details TEXT;
 

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/postgresql/V1.5.0__Add_job_exception_columns.sql
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/postgresql/V1.5.0__Add_job_exception_columns.sql
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+ALTER TABLE Job_Execution_Log ADD COLUMN exception_message VARCHAR(500);
+ALTER TABLE Job_Execution_Log ADD COLUMN exception_details VARCHAR(4000);
+

--- a/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/postgresql/V1.5.0__Add_job_exception_columns.sql
+++ b/data-audit/kogito-addons-data-audit-jpa/kogito-addons-data-audit-jpa-common/src/main/resources/kie-flyway/db/data-audit/postgresql/V1.5.0__Add_job_exception_columns.sql
@@ -17,6 +17,9 @@
  * under the License.
  */
 
-ALTER TABLE Job_Execution_Log ADD COLUMN exception_message VARCHAR(500);
-ALTER TABLE Job_Execution_Log ADD COLUMN exception_details VARCHAR(4000);
+-- Add exception details columns to Job_Execution_Log table
+-- exception_message: VARCHAR without length constraint for full flexibility
+-- exception_details: TEXT type for large content without space reservation when NULL
+ALTER TABLE Job_Execution_Log ADD COLUMN exception_message VARCHAR;
+ALTER TABLE Job_Execution_Log ADD COLUMN exception_details TEXT;
 

--- a/data-audit/kogito-addons-data-audit-quarkus/src/test/resources/application.properties
+++ b/data-audit/kogito-addons-data-audit-quarkus/src/test/resources/application.properties
@@ -22,7 +22,7 @@ quarkus.datasource.username=hibernate
 quarkus.datasource.password=hibernate
 quarkus.datasource.jdbc.url=jdbc:h2:mem:test
 
-quarkus.hibernate-orm.database.generation=create-drop
+quarkus.hibernate-orm.database.generation=validate
 
 kie.flyway.enabled=true
 

--- a/data-audit/kogito-addons-data-audit-springboot/src/test/java/org/kie/kogito/app/audit/springboot/SpringbootAuditJobServiceTest.java
+++ b/data-audit/kogito-addons-data-audit-springboot/src/test/java/org/kie/kogito/app/audit/springboot/SpringbootAuditJobServiceTest.java
@@ -32,6 +32,7 @@ import org.kie.kogito.jobs.service.model.JobStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 
 import io.restassured.http.ContentType;
 
@@ -44,6 +45,7 @@ import static org.kie.kogito.app.audit.quarkus.DataAuditTestUtils.wrapQuery;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "server_port=0")
 @TestInstance(Lifecycle.PER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class SpringbootAuditJobServiceTest {
 
     @LocalServerPort

--- a/data-audit/kogito-addons-data-audit-springboot/src/test/java/org/kie/kogito/app/audit/springboot/SpringbootAuditJobServiceTest.java
+++ b/data-audit/kogito-addons-data-audit-springboot/src/test/java/org/kie/kogito/app/audit/springboot/SpringbootAuditJobServiceTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.kie.kogito.app.audit.quarkus;
+package org.kie.kogito.app.audit.springboot;
 
 import java.util.List;
 import java.util.Map;
@@ -29,11 +29,11 @@ import org.kie.kogito.app.audit.api.SubsystemConstants;
 import org.kie.kogito.event.EventPublisher;
 import org.kie.kogito.event.job.JobInstanceDataEvent;
 import org.kie.kogito.jobs.service.model.JobStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
-import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
-
-import jakarta.inject.Inject;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,11 +42,14 @@ import static org.kie.kogito.app.audit.quarkus.DataAuditTestUtils.deriveNewState
 import static org.kie.kogito.app.audit.quarkus.DataAuditTestUtils.newJobEvent;
 import static org.kie.kogito.app.audit.quarkus.DataAuditTestUtils.wrapQuery;
 
-@QuarkusTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "server_port=0")
 @TestInstance(Lifecycle.PER_CLASS)
-public class QuarkusAuditJobServiceTest {
+public class SpringbootAuditJobServiceTest {
 
-    @Inject
+    @LocalServerPort
+    private Integer port;
+
+    @Autowired
     EventPublisher publisher;
 
     @BeforeAll
@@ -117,6 +120,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> response = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -142,6 +146,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> response = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -178,6 +183,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> response = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -222,6 +228,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -246,6 +253,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -265,6 +273,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -287,6 +296,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -308,6 +318,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -330,6 +341,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -354,6 +366,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -378,6 +391,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -401,6 +415,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -422,6 +437,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> data = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -451,6 +467,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> response = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -479,6 +496,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> response = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -528,6 +546,7 @@ public class QuarkusAuditJobServiceTest {
         List<Map<String, Object>> response = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -551,6 +570,7 @@ public class QuarkusAuditJobServiceTest {
         response = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()
@@ -573,6 +593,7 @@ public class QuarkusAuditJobServiceTest {
         response = given()
                 .contentType(ContentType.JSON)
                 .body(query)
+                .port(port)
                 .when()
                 .post(SubsystemConstants.DATA_AUDIT_QUERY_PATH)
                 .then()

--- a/data-audit/kogito-addons-data-audit-springboot/src/test/java/org/kie/kogito/app/audit/springboot/SpringbootAuditProcessInstanceServiceTest.java
+++ b/data-audit/kogito-addons-data-audit-springboot/src/test/java/org/kie/kogito/app/audit/springboot/SpringbootAuditProcessInstanceServiceTest.java
@@ -32,6 +32,7 @@ import org.kie.kogito.process.ProcessInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 
 import io.restassured.http.ContentType;
 
@@ -42,6 +43,7 @@ import static org.kie.kogito.app.audit.quarkus.DataAuditTestUtils.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "server_port=0")
 @TestInstance(Lifecycle.PER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class SpringbootAuditProcessInstanceServiceTest {
 
     @LocalServerPort

--- a/data-audit/kogito-addons-data-audit-springboot/src/test/java/org/kie/kogito/app/audit/springboot/SpringbootAuditQueryRegistryServiceTest.java
+++ b/data-audit/kogito-addons-data-audit-springboot/src/test/java/org/kie/kogito/app/audit/springboot/SpringbootAuditQueryRegistryServiceTest.java
@@ -40,6 +40,7 @@ import org.kie.kogito.process.ProcessInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 
 import io.restassured.http.ContentType;
 
@@ -53,6 +54,7 @@ import static org.kie.kogito.app.audit.quarkus.DataAuditTestUtils.wrapQuery;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "server_port=0")
 @TestInstance(Lifecycle.PER_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class SpringbootAuditQueryRegistryServiceTest {
 
     @LocalServerPort

--- a/data-index/data-index-graphql/src/main/resources/graphql/basic.schema.graphqls
+++ b/data-index/data-index-graphql/src/main/resources/graphql/basic.schema.graphqls
@@ -497,6 +497,8 @@ type Job {
     lastUpdate: DateTime
     executionCounter: Int
     endpoint: String
+    exceptionMessage: String
+    exceptionDetails: String
 }
 
 enum JobStatus {
@@ -528,6 +530,7 @@ input JobArgument {
     priority: NumericArgument
     scheduledId: IdArgument
     lastUpdate: DateArgument
+    exceptionMessage: StringArgument
 }
 
 input JobOrderBy {
@@ -539,4 +542,5 @@ input JobOrderBy {
     retries: OrderBy
     lastUpdate: OrderBy
     executionCounter: OrderBy
+    exceptionMessage: OrderBy
 }

--- a/data-index/data-index-quarkus/data-index-service-quarkus-common/src/test/java/org/kie/kogito/index/service/messaging/BlockingMessagingEventConsumerTest.java
+++ b/data-index/data-index-quarkus/data-index-service-quarkus-common/src/test/java/org/kie/kogito/index/service/messaging/BlockingMessagingEventConsumerTest.java
@@ -115,6 +115,51 @@ class BlockingMessagingEventConsumerTest {
     }
 
     @Test
+    void testOnJobEventWithExceptionDetails() {
+        // Arrange
+        KogitoJobCloudEvent event = mock(KogitoJobCloudEvent.class);
+        Job mockJob = mock(Job.class);
+
+        when(event.getData()).thenReturn(mockJob);
+
+        // Act
+        consumer.onJobEvent(event);
+
+        // Assert
+        verify(indexingService, times(1)).indexJob(mockJob);
+    }
+
+    @Test
+    void testOnJobEventWithRetryAndExceptionDetails() {
+        // Arrange
+        KogitoJobCloudEvent event = mock(KogitoJobCloudEvent.class);
+        Job mockJob = mock(Job.class);
+
+        when(event.getData()).thenReturn(mockJob);
+
+        // Act
+        consumer.onJobEvent(event);
+
+        // Assert
+        verify(indexingService, times(1)).indexJob(mockJob);
+    }
+
+    @Test
+    void testOnJobEventWithNullExceptionDetails() {
+        // Arrange
+        KogitoJobCloudEvent event = mock(KogitoJobCloudEvent.class);
+        Job mockJob = mock(Job.class);
+
+        when(event.getData()).thenReturn(mockJob);
+
+        // Act
+        consumer.onJobEvent(event);
+
+        // Assert
+        verify(indexingService, times(1)).indexJob(mockJob);
+    }
+
+    @Test
     void testOnProcessDefinitionDataEvent() {
         // Arrange
         ProcessDefinitionDataEvent event1 = mock(ProcessDefinitionDataEvent.class);

--- a/data-index/data-index-quarkus/data-index-service-quarkus-common/src/test/java/org/kie/kogito/index/service/messaging/ReactiveMessagingEventConsumerTest.java
+++ b/data-index/data-index-quarkus/data-index-service-quarkus-common/src/test/java/org/kie/kogito/index/service/messaging/ReactiveMessagingEventConsumerTest.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ReactiveMessagingEventConsumerTest {
@@ -136,5 +137,44 @@ public class ReactiveMessagingEventConsumerTest {
 
         future.awaitFailure().assertFailedWith(RuntimeException.class, "");
         verify(service).indexJob(event.getData());
+    }
+
+    @Test
+    public void testOnJobEventWithExceptionDetails() {
+        KogitoJobCloudEvent event = mock(KogitoJobCloudEvent.class);
+        org.kie.kogito.index.model.Job mockJob = mock(org.kie.kogito.index.model.Job.class);
+
+        when(event.getData()).thenReturn(mockJob);
+
+        UniAssertSubscriber<Void> future = consumer.onJobEvent(event).subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        future.awaitItem().assertCompleted();
+        verify(service).indexJob(mockJob);
+    }
+
+    @Test
+    public void testOnJobEventWithRetryAndExceptionDetails() {
+        KogitoJobCloudEvent event = mock(KogitoJobCloudEvent.class);
+        org.kie.kogito.index.model.Job mockJob = mock(org.kie.kogito.index.model.Job.class);
+
+        when(event.getData()).thenReturn(mockJob);
+
+        UniAssertSubscriber<Void> future = consumer.onJobEvent(event).subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        future.awaitItem().assertCompleted();
+        verify(service).indexJob(mockJob);
+    }
+
+    @Test
+    public void testOnJobEventWithNullExceptionDetails() {
+        KogitoJobCloudEvent event = mock(KogitoJobCloudEvent.class);
+        org.kie.kogito.index.model.Job mockJob = mock(org.kie.kogito.index.model.Job.class);
+
+        when(event.getData()).thenReturn(mockJob);
+
+        UniAssertSubscriber<Void> future = consumer.onJobEvent(event).subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        future.awaitItem().assertCompleted();
+        verify(service).indexJob(mockJob);
     }
 }

--- a/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/Job.java
+++ b/data-index/data-index-storage/data-index-storage-api/src/main/java/org/kie/kogito/index/model/Job.java
@@ -47,6 +47,10 @@ public class Job {
     private Integer executionCounter;
     private String endpoint;
 
+    // Exception details for failed jobs
+    private String exceptionMessage;
+    private String exceptionDetails;
+
     public String getId() {
         return id;
     }
@@ -183,6 +187,22 @@ public class Job {
         this.nodeInstanceId = nodeInstanceId;
     }
 
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public String getExceptionDetails() {
+        return exceptionDetails;
+    }
+
+    public void setExceptionDetails(String exceptionDetails) {
+        this.exceptionDetails = exceptionDetails;
+    }
+
     @Override
     public String toString() {
         return "Job{" +
@@ -203,6 +223,8 @@ public class Job {
                 ", lastUpdate=" + lastUpdate +
                 ", executionCounter=" + executionCounter +
                 ", endpoint='" + endpoint + '\'' +
+                ", exceptionMessage='" + exceptionMessage + '\'' +
+                ", exceptionDetails='" + exceptionDetails + '\'' +
                 '}';
     }
 

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/JobEntity.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/model/JobEntity.java
@@ -47,6 +47,8 @@ public class JobEntity extends AbstractEntity {
     private ZonedDateTime lastUpdate;
     private Integer executionCounter;
     private String endpoint;
+    private String exceptionMessage;
+    private String exceptionDetails;
 
     @Override
     public String getId() {
@@ -185,6 +187,22 @@ public class JobEntity extends AbstractEntity {
         this.nodeInstanceId = nodeInstanceId;
     }
 
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public String getExceptionDetails() {
+        return exceptionDetails;
+    }
+
+    public void setExceptionDetails(String exceptionDetails) {
+        this.exceptionDetails = exceptionDetails;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -222,6 +240,8 @@ public class JobEntity extends AbstractEntity {
                 ", lastUpdate=" + lastUpdate +
                 ", executionCounter=" + executionCounter +
                 ", endpoint='" + endpoint + '\'' +
+                ", exceptionMessage='" + exceptionMessage + '\'' +
+                ", exceptionDetails='" + exceptionDetails + '\'' +
                 '}';
     }
 }

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/JobEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/JobEntityStorage.java
@@ -81,5 +81,7 @@ public class JobEntityStorage extends AbstractStorage<String, JobEntity, Job> im
         entity.setLastUpdate(job.getLastUpdate());
         entity.setExecutionCounter(job.getExecutionCounter());
         entity.setEndpoint(job.getEndpoint());
+        entity.setExceptionMessage(job.getExceptionMessage());
+        entity.setExceptionDetails(job.getExceptionDetails());
     }
 }

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractJobStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractJobStorageIT.java
@@ -56,4 +56,172 @@ public abstract class AbstractJobStorageIT extends AbstractStorageIT<String, Job
                         RandomStringUtils.randomAlphabetic(10), "SCHEDULED", 1000L);
         testStorage(jobId, job1, job2);
     }
+
+    @Test
+    public void testJobEntityWithExceptionDetails() {
+        String jobId = UUID.randomUUID().toString();
+        String processInstanceId = UUID.randomUUID().toString();
+
+        // Create job with ERROR status and exception details
+        Job jobWithError = TestUtils
+                .createJob(jobId, processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),
+                        RandomStringUtils.randomAlphabetic(10), "ERROR", 0L);
+        jobWithError.setExceptionMessage("java.lang.RuntimeException");
+        jobWithError.setExceptionDetails("Connection timeout after 30 seconds");
+
+        // Store the job
+        storage.put(jobId, jobWithError);
+
+        // Retrieve and verify exception details are persisted
+        Job retrievedJob = storage.get(jobId);
+        org.assertj.core.api.Assertions.assertThat(retrievedJob)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", jobId)
+                .hasFieldOrPropertyWithValue("status", "ERROR")
+                .hasFieldOrPropertyWithValue("exceptionMessage", "java.lang.RuntimeException")
+                .hasFieldOrPropertyWithValue("exceptionDetails", "Connection timeout after 30 seconds");
+    }
+
+    @Test
+    public void testJobEntityWithRetryAndExceptionDetails() {
+        String jobId = UUID.randomUUID().toString();
+        String processInstanceId = UUID.randomUUID().toString();
+
+        // Create job with RETRY status and exception details
+        Job jobWithRetry = TestUtils
+                .createJob(jobId, processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),
+                        RandomStringUtils.randomAlphabetic(10), "RETRY", 1000L);
+        jobWithRetry.setRetries(2);
+        jobWithRetry.setExceptionMessage("java.net.ConnectException");
+        jobWithRetry.setExceptionDetails("Connection refused: connect");
+
+        // Store the job
+        storage.put(jobId, jobWithRetry);
+
+        // Retrieve and verify exception details are persisted
+        Job retrievedJob = storage.get(jobId);
+        org.assertj.core.api.Assertions.assertThat(retrievedJob)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", jobId)
+                .hasFieldOrPropertyWithValue("status", "RETRY")
+                .hasFieldOrPropertyWithValue("retries", 2)
+                .hasFieldOrPropertyWithValue("exceptionMessage", "java.net.ConnectException")
+                .hasFieldOrPropertyWithValue("exceptionDetails", "Connection refused: connect");
+    }
+
+    @Test
+    public void testJobEntityExceptionDetailsClearedOnSuccess() {
+        String jobId = UUID.randomUUID().toString();
+        String processInstanceId = UUID.randomUUID().toString();
+
+        // First create job with ERROR status and exception details
+        Job jobWithError = TestUtils
+                .createJob(jobId, processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),
+                        RandomStringUtils.randomAlphabetic(10), "ERROR", 0L);
+        jobWithError.setExceptionMessage("java.lang.RuntimeException");
+        jobWithError.setExceptionDetails("Initial error");
+
+        storage.put(jobId, jobWithError);
+
+        // Update job to EXECUTED status with null exception details
+        Job jobExecuted = TestUtils
+                .createJob(jobId, processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),
+                        RandomStringUtils.randomAlphabetic(10), "EXECUTED", 0L);
+        jobExecuted.setExceptionMessage(null);
+        jobExecuted.setExceptionDetails(null);
+
+        storage.put(jobId, jobExecuted);
+
+        // Retrieve and verify exception details are cleared
+        Job retrievedJob = storage.get(jobId);
+        org.assertj.core.api.Assertions.assertThat(retrievedJob)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", jobId)
+                .hasFieldOrPropertyWithValue("status", "EXECUTED")
+                .hasFieldOrPropertyWithValue("exceptionMessage", null)
+                .hasFieldOrPropertyWithValue("exceptionDetails", null);
+    }
+
+    @Test
+    public void testJobEntityRetryToExecutedTransition() {
+        String jobId = UUID.randomUUID().toString();
+        String processInstanceId = UUID.randomUUID().toString();
+
+        // First create job with RETRY status and exception details
+        Job jobWithRetry = TestUtils
+                .createJob(jobId, processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),
+                        RandomStringUtils.randomAlphabetic(10), "RETRY", 0L);
+        jobWithRetry.setRetries(2);
+        jobWithRetry.setExceptionMessage("Temporary connection error");
+        jobWithRetry.setExceptionDetails("java.net.ConnectException: Connection refused\n\tat java.net.Socket.connect(Socket.java:123)");
+
+        storage.put(jobId, jobWithRetry);
+
+        // Verify RETRY state with exception details
+        Job retrievedRetry = storage.get(jobId);
+        org.assertj.core.api.Assertions.assertThat(retrievedRetry)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", jobId)
+                .hasFieldOrPropertyWithValue("status", "RETRY")
+                .hasFieldOrPropertyWithValue("retries", 2)
+                .hasFieldOrPropertyWithValue("exceptionMessage", "Temporary connection error")
+                .hasFieldOrPropertyWithValue("exceptionDetails", "java.net.ConnectException: Connection refused\n\tat java.net.Socket.connect(Socket.java:123)");
+
+        // Update job to EXECUTED status after successful retry (exception details cleared)
+        Job jobExecuted = TestUtils
+                .createJob(jobId, processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),
+                        RandomStringUtils.randomAlphabetic(10), "EXECUTED", 0L);
+        jobExecuted.setRetries(2); // Keep retry count for audit trail
+        jobExecuted.setExceptionMessage(null); // Clear exception on success
+        jobExecuted.setExceptionDetails(null); // Clear exception on success
+
+        storage.put(jobId, jobExecuted);
+
+        // Retrieve and verify exception details are cleared after successful retry
+        Job retrievedExecuted = storage.get(jobId);
+        org.assertj.core.api.Assertions.assertThat(retrievedExecuted)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", jobId)
+                .hasFieldOrPropertyWithValue("status", "EXECUTED")
+                .hasFieldOrPropertyWithValue("retries", 2) // Retry count preserved
+                .hasFieldOrPropertyWithValue("exceptionMessage", null) // Exception cleared
+                .hasFieldOrPropertyWithValue("exceptionDetails", null); // Exception cleared
+    }
+
+    @Test
+    public void testJobEntityWithLongExceptionDetails() {
+        String jobId = UUID.randomUUID().toString();
+        String processInstanceId = UUID.randomUUID().toString();
+
+        // Create job with long exception details (simulating stack trace)
+        String longStackTrace = "java.lang.RuntimeException: Error processing request\n" +
+                "\tat com.example.Service.process(Service.java:123)\n" +
+                "\tat com.example.Controller.handle(Controller.java:45)\n" +
+                "\tat org.springframework.web.method.support.InvocableHandlerMethod.invoke(InvocableHandlerMethod.java:219)\n" +
+                "Caused by: java.sql.SQLException: Connection timeout\n" +
+                "\tat com.example.Database.query(Database.java:89)\n" +
+                "\t... 15 more";
+
+        Job jobWithLongError = TestUtils
+                .createJob(jobId, processInstanceId, RandomStringUtils.randomAlphabetic(5), UUID.randomUUID().toString(),
+                        RandomStringUtils.randomAlphabetic(10), "ERROR", 0L);
+        jobWithLongError.setExceptionMessage("java.lang.RuntimeException");
+        jobWithLongError.setExceptionDetails(longStackTrace);
+
+        // Store the job
+        storage.put(jobId, jobWithLongError);
+
+        // Retrieve and verify long exception details are persisted
+        Job retrievedJob = storage.get(jobId);
+        org.assertj.core.api.Assertions.assertThat(retrievedJob)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("id", jobId)
+                .hasFieldOrPropertyWithValue("status", "ERROR")
+                .hasFieldOrPropertyWithValue("exceptionMessage", "java.lang.RuntimeException");
+
+        org.assertj.core.api.Assertions.assertThat(retrievedJob.getExceptionDetails())
+                .isNotNull()
+                .contains("java.lang.RuntimeException: Error processing request")
+                .contains("Caused by: java.sql.SQLException: Connection timeout");
+    }
 }

--- a/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.49.0__add_job_exception_details.sql
+++ b/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.49.0__add_job_exception_details.sql
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+-- Add exception details columns to jobs table
+ALTER TABLE jobs ADD exception_message character varying(500);
+ALTER TABLE jobs ADD exception_details varchar(max);
+

--- a/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.49.0__add_job_exception_details.sql
+++ b/data-index/data-index-storage/data-index-storage-jpa/src/main/resources/kie-flyway/db/data-index/ansi/V1.49.0__add_job_exception_details.sql
@@ -18,6 +18,8 @@
  */
 
 -- Add exception details columns to jobs table
-ALTER TABLE jobs ADD exception_message character varying(500);
-ALTER TABLE jobs ADD exception_details varchar(max);
+-- exception_message: VARCHAR without length constraint for full flexibility
+-- exception_details: TEXT type for large content without space reservation when NULL
+ALTER TABLE jobs ADD exception_message VARCHAR;
+ALTER TABLE jobs ADD exception_details TEXT;
 

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/JobEntity.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/JobEntity.java
@@ -59,6 +59,10 @@ public class JobEntity {
 
     String endpoint;
 
+    String exceptionMessage;
+
+    String exceptionDetails;
+
     public String getId() {
         return id;
     }
@@ -193,6 +197,22 @@ public class JobEntity {
 
     public void setNodeInstanceId(String nodeInstanceId) {
         this.nodeInstanceId = nodeInstanceId;
+    }
+
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public String getExceptionDetails() {
+        return exceptionDetails;
+    }
+
+    public void setExceptionDetails(String exceptionDetails) {
+        this.exceptionDetails = exceptionDetails;
     }
 
     @Override

--- a/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/JobEntityMapper.java
+++ b/data-index/data-index-storage/data-index-storage-mongodb/src/main/java/org/kie/kogito/index/mongodb/model/JobEntityMapper.java
@@ -55,6 +55,8 @@ public class JobEntityMapper implements MongoEntityMapper<Job, JobEntity> {
         entity.setExecutionCounter(job.getExecutionCounter());
         entity.setEndpoint(job.getEndpoint());
         entity.setNodeInstanceId(job.getNodeInstanceId());
+        entity.setExceptionMessage(job.getExceptionMessage());
+        entity.setExceptionDetails(job.getExceptionDetails());
         return entity;
     }
 
@@ -82,6 +84,8 @@ public class JobEntityMapper implements MongoEntityMapper<Job, JobEntity> {
         job.setExecutionCounter(entity.getExecutionCounter());
         job.setEndpoint(entity.getEndpoint());
         job.setNodeInstanceId(entity.getNodeInstanceId());
+        job.setExceptionMessage(entity.getExceptionMessage());
+        job.setExceptionDetails(entity.getExceptionDetails());
         return job;
     }
 }

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.49.0__add_job_exception_details.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.49.0__add_job_exception_details.sql
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+-- Add exception details columns to jobs table
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS exception_message varchar(500);
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS exception_details text;
+

--- a/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.49.0__add_job_exception_details.sql
+++ b/data-index/data-index-storage/data-index-storage-postgresql/src/main/resources/kie-flyway/db/data-index/postgresql/V1.49.0__add_job_exception_details.sql
@@ -18,6 +18,8 @@
  */
 
 -- Add exception details columns to jobs table
-ALTER TABLE jobs ADD COLUMN IF NOT EXISTS exception_message varchar(500);
-ALTER TABLE jobs ADD COLUMN IF NOT EXISTS exception_details text;
+-- exception_message: VARCHAR without length constraint for full flexibility
+-- exception_details: TEXT type for large content without space reservation when NULL
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS exception_message VARCHAR;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS exception_details TEXT;
 

--- a/data-index/data-index-test-utils/src/main/java/org/kie/kogito/index/test/TestUtils.java
+++ b/data-index/data-index-test-utils/src/main/java/org/kie/kogito/index/test/TestUtils.java
@@ -397,14 +397,14 @@ public final class TestUtils {
         job.setRootProcessId(rootProcessId);
         job.setRootProcessInstanceId(rootProcessInstanceId);
         job.setStatus(status);
-        job.setExpirationTime(ZonedDateTime.now());
+        job.setExpirationTime(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS));
         job.setPriority(1);
         job.setCallbackEndpoint("http://service");
         job.setRepeatInterval(0l);
         job.setRepeatLimit(-1);
         job.setScheduledId(UUID.randomUUID().toString());
         job.setRetries(10);
-        job.setLastUpdate(ZonedDateTime.now());
+        job.setLastUpdate(ZonedDateTime.now().truncatedTo(ChronoUnit.MILLIS));
         job.setExecutionCounter(2);
         return job;
     }

--- a/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/adapter/ScheduledJobAdapter.java
+++ b/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/adapter/ScheduledJobAdapter.java
@@ -25,11 +25,7 @@ import java.util.Optional;
 
 import org.kie.kogito.jobs.api.JobBuilder;
 import org.kie.kogito.jobs.service.api.recipient.http.HttpRecipient;
-import org.kie.kogito.jobs.service.model.JobDetails;
-import org.kie.kogito.jobs.service.model.JobDetailsBuilder;
-import org.kie.kogito.jobs.service.model.Recipient;
-import org.kie.kogito.jobs.service.model.RecipientInstance;
-import org.kie.kogito.jobs.service.model.ScheduledJob;
+import org.kie.kogito.jobs.service.model.*;
 import org.kie.kogito.jobs.service.utils.DateUtil;
 import org.kie.kogito.timer.Trigger;
 import org.kie.kogito.timer.impl.IntervalTrigger;
@@ -96,6 +92,8 @@ public class ScheduledJobAdapter {
                 .executionCounter(jobDetails.getExecutionCounter())
                 .retries(jobDetails.getRetries())
                 .lastUpdate(jobDetails.getLastUpdate())
+                .exceptionMessage(jobDetails.getExceptionDetails() != null ? jobDetails.getExceptionDetails().exceptionMessage() : null)
+                .exceptionDetails(jobDetails.getExceptionDetails() != null ? jobDetails.getExceptionDetails().exceptionDetails() : null)
                 .build();
     }
 
@@ -111,6 +109,7 @@ public class ScheduledJobAdapter {
                 .status(scheduledJob.getStatus())
                 .trigger(triggerAdapter(scheduledJob))
                 .priority(scheduledJob.getPriority())
+                .exceptionDetails(new JobExecutionExceptionDetails(scheduledJob.getExceptionMessage(), scheduledJob.getExceptionDetails()))
                 .build();
     }
 

--- a/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobDetails.java
+++ b/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobDetails.java
@@ -44,6 +44,7 @@ public class JobDetails {
     private Long executionTimeout;
     private ChronoUnit executionTimeoutUnit;
     private ZonedDateTime created;
+    private JobExecutionExceptionDetails exceptionDetails;
 
     public JobDetails() {
         // do nothing
@@ -52,7 +53,7 @@ public class JobDetails {
     @SuppressWarnings("java:S107")
     protected JobDetails(String id, String correlationId, JobStatus status, ZonedDateTime lastUpdate, Integer retries,
             Integer executionCounter, String scheduledId, Recipient recipient, Trigger trigger, Integer priority,
-            Long executionTimeout, ChronoUnit executionTimeoutUnit, ZonedDateTime created) {
+            Long executionTimeout, ChronoUnit executionTimeoutUnit, ZonedDateTime created, JobExecutionExceptionDetails exceptionDetails) {
         this.id = id;
         this.correlationId = correlationId;
         this.status = status;
@@ -66,6 +67,7 @@ public class JobDetails {
         this.executionTimeout = executionTimeout;
         this.executionTimeoutUnit = executionTimeoutUnit;
         this.created = created;
+        this.exceptionDetails = exceptionDetails;
     }
 
     public String getId() {
@@ -118,6 +120,10 @@ public class JobDetails {
 
     public ZonedDateTime getCreated() {
         return created;
+    }
+
+    public JobExecutionExceptionDetails getExceptionDetails() {
+        return exceptionDetails;
     }
 
     public static JobDetailsBuilder builder() {
@@ -176,6 +182,10 @@ public class JobDetails {
         this.created = created;
     }
 
+    public void setExceptionDetails(JobExecutionExceptionDetails exceptionDetails) {
+        this.exceptionDetails = exceptionDetails;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -196,14 +206,15 @@ public class JobDetails {
                 && Objects.equals(getTrigger().hasNextFireTime(), that.getTrigger().hasNextFireTime())
                 && Objects.equals(getExecutionTimeout(), that.getExecutionTimeout())
                 && Objects.equals(getExecutionTimeoutUnit(), that.getExecutionTimeoutUnit())
-                && Objects.equals(getCreated(), that.getCreated());
+                && Objects.equals(getCreated(), that.getCreated())
+                && Objects.equals(getExceptionDetails(), that.getExceptionDetails());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getId(), getCorrelationId(), getStatus(), getRetries(), getExecutionCounter(),
                 getScheduledId(), getRecipient(), getTrigger(), getExecutionTimeout(), getExecutionTimeoutUnit(),
-                getCreated());
+                getCreated(), getExceptionDetails());
     }
 
     @Override
@@ -213,6 +224,6 @@ public class JobDetails {
                 .add("retries=" + retries).add("executionCounter=" + executionCounter)
                 .add("scheduledId='" + scheduledId + "'").add("recipient=" + recipient).add("trigger=" + trigger)
                 .add("executionTimeout=" + executionTimeout).add("executionTimeoutUnit=" + executionTimeoutUnit)
-                .add("created=" + created).toString();
+                .add("created=" + created).add("exceptionDetails=" + exceptionDetails).toString();
     }
 }

--- a/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobDetailsBuilder.java
+++ b/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobDetailsBuilder.java
@@ -39,6 +39,7 @@ public class JobDetailsBuilder {
     private Long executionTimeout;
     private ChronoUnit executionTimeoutUnit;
     private ZonedDateTime created;
+    private JobExecutionExceptionDetails exceptionDetails;
 
     public JobDetailsBuilder id(String id) {
         this.id = id;
@@ -105,9 +106,14 @@ public class JobDetailsBuilder {
         return this;
     }
 
+    public JobDetailsBuilder exceptionDetails(JobExecutionExceptionDetails exceptionDetails) {
+        this.exceptionDetails = exceptionDetails;
+        return this;
+    }
+
     public JobDetails build() {
         return new JobDetails(id, correlationId, status, lastUpdate, retries, executionCounter, scheduledId,
-                recipient, trigger, priority, executionTimeout, executionTimeoutUnit, created);
+                recipient, trigger, priority, executionTimeout, executionTimeoutUnit, created, exceptionDetails);
     }
 
     public JobDetailsBuilder of(JobDetails jobDetails) {
@@ -123,7 +129,8 @@ public class JobDetailsBuilder {
                 .priority(jobDetails.getPriority())
                 .executionTimeout(jobDetails.getExecutionTimeout())
                 .executionTimeoutUnit(jobDetails.getExecutionTimeoutUnit())
-                .created(jobDetails.getCreated());
+                .created(jobDetails.getCreated())
+                .exceptionDetails(jobDetails.getExceptionDetails());
     }
 
     public JobDetailsBuilder incrementRetries() {
@@ -148,6 +155,7 @@ public class JobDetailsBuilder {
                 .priority(j.map(JobDetails::getPriority).orElse(priority))
                 .executionCounter(j.map(JobDetails::getExecutionCounter).orElse(executionCounter))
                 .executionTimeout(j.map(JobDetails::getExecutionTimeout).orElse(executionTimeout))
-                .executionTimeoutUnit(j.map(JobDetails::getExecutionTimeoutUnit).orElse(executionTimeoutUnit));
+                .executionTimeoutUnit(j.map(JobDetails::getExecutionTimeoutUnit).orElse(executionTimeoutUnit))
+                .exceptionDetails(j.map(JobDetails::getExceptionDetails).orElse(exceptionDetails));
     }
 }

--- a/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobExecutionErrorDetails.java
+++ b/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobExecutionErrorDetails.java
@@ -1,4 +1,0 @@
-package org.kie.kogito.jobs.service.model;
-
-public record JobExecutionErrorDetails(String message, String details) {
-}

--- a/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobExecutionErrorDetails.java
+++ b/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobExecutionErrorDetails.java
@@ -1,0 +1,4 @@
+package org.kie.kogito.jobs.service.model;
+
+public record JobExecutionErrorDetails(String message, String details) {
+}

--- a/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobExecutionExceptionDetails.java
+++ b/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/JobExecutionExceptionDetails.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.jobs.service.model;
+
+/**
+ * Represents exception details captured during job execution failure.
+ * 
+ * @param exceptionMessage The exception class name or short message
+ * @param exceptionDetails The detailed exception message or stack trace
+ */
+public record JobExecutionExceptionDetails(String exceptionMessage, String exceptionDetails) {
+}

--- a/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/ScheduledJob.java
+++ b/jobs-service/jobs-service-internal-api/src/main/java/org/kie/kogito/jobs/service/model/ScheduledJob.java
@@ -35,6 +35,8 @@ public class ScheduledJob extends Job {
     private ZonedDateTime lastUpdate;
     private Integer executionCounter;
     private JobExecutionResponse executionResponse;
+    private String exceptionMessage;
+    private String exceptionDetails;
 
     public ScheduledJob() {
     }
@@ -70,12 +72,20 @@ public class ScheduledJob extends Job {
         return lastUpdate;
     }
 
+    public Integer getExecutionCounter() {
+        return executionCounter;
+    }
+
     public JobExecutionResponse getExecutionResponse() {
         return executionResponse;
     }
 
-    public Integer getExecutionCounter() {
-        return executionCounter;
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public String getExceptionDetails() {
+        return exceptionDetails;
     }
 
     public Optional<Long> hasInterval() {
@@ -96,6 +106,8 @@ public class ScheduledJob extends Job {
                 .add("lastUpdate=" + lastUpdate)
                 .add("executionResponse=" + executionResponse)
                 .add("executionCounter=" + executionCounter)
+                .add("exceptionMessage=" + exceptionMessage)
+                .add("exceptionDetails=" + exceptionDetails)
                 .add("job=" + super.toString())
                 .toString();
     }
@@ -117,12 +129,15 @@ public class ScheduledJob extends Job {
                 getStatus() == that.getStatus() &&
                 getLastUpdate().equals(that.getLastUpdate()) &&
                 Objects.equals(getExecutionCounter(), that.getExecutionCounter()) &&
-                Objects.equals(getExecutionResponse(), that.getExecutionResponse());
+                Objects.equals(getExecutionResponse(), that.getExecutionResponse()) &&
+                Objects.equals(getExceptionMessage(), that.getExceptionMessage()) &&
+                Objects.equals(getExceptionDetails(), that.getExceptionDetails());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), getScheduledId(), getRetries(), getStatus(), getLastUpdate(), getExecutionCounter(), getExecutionResponse());
+        return Objects.hash(super.hashCode(), getScheduledId(), getRetries(), getStatus(), getLastUpdate(), getExecutionCounter(), getExecutionResponse(), getExceptionMessage(),
+                getExceptionDetails());
     }
 
     public static class ScheduledJobBuilder {
@@ -135,6 +150,8 @@ public class ScheduledJob extends Job {
         private ZonedDateTime expirationTime;
         private JobExecutionResponse executionResponse;
         private Integer executionCounter = 0;
+        private String exceptionMessage;
+        private String exceptionDetails;
 
         public ScheduledJobBuilder job(Job job) {
             this.job = job;
@@ -189,7 +206,9 @@ public class ScheduledJob extends Job {
                     .retries(scheduledJob.getRetries())
                     .status(scheduledJob.getStatus())
                     .executionResponse(scheduledJob.getExecutionResponse())
-                    .executionCounter(scheduledJob.getExecutionCounter());
+                    .executionCounter(scheduledJob.getExecutionCounter())
+                    .exceptionMessage(scheduledJob.getExceptionMessage())
+                    .exceptionDetails(scheduledJob.getExceptionDetails());
         }
 
         public ScheduledJobBuilder merge(ScheduledJob scheduledJob) {
@@ -199,7 +218,9 @@ public class ScheduledJob extends Job {
                     .retries(j.map(ScheduledJob::getRetries).orElse(retries))
                     .status(j.map(ScheduledJob::getStatus).orElse(status))
                     .executionResponse(j.map(ScheduledJob::getExecutionResponse).orElse(executionResponse))
-                    .executionCounter(j.map(ScheduledJob::getExecutionCounter).orElse(executionCounter));
+                    .executionCounter(j.map(ScheduledJob::getExecutionCounter).orElse(executionCounter))
+                    .exceptionMessage(j.map(ScheduledJob::getExceptionMessage).orElse(exceptionMessage))
+                    .exceptionDetails(j.map(ScheduledJob::getExceptionDetails).orElse(exceptionDetails));
         }
 
         public ScheduledJobBuilder status(JobStatus status) {
@@ -222,6 +243,16 @@ public class ScheduledJob extends Job {
             return this;
         }
 
+        public ScheduledJobBuilder exceptionMessage(String exceptionMessage) {
+            this.exceptionMessage = exceptionMessage;
+            return this;
+        }
+
+        public ScheduledJobBuilder exceptionDetails(String exceptionDetails) {
+            this.exceptionDetails = exceptionDetails;
+            return this;
+        }
+
         public static ScheduledJob from(Job job) {
             return builder().job(job).build();
         }
@@ -234,6 +265,8 @@ public class ScheduledJob extends Job {
             instance.lastUpdate = getLastUpdate();
             instance.executionCounter = executionCounter;
             instance.executionResponse = executionResponse;
+            instance.exceptionMessage = exceptionMessage;
+            instance.exceptionDetails = exceptionDetails;
             return instance;
         }
 

--- a/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/runtime/src/test/java/org/kie/kogito/addons/quarkus/jobs/service/embedded/stream/EventPublisherJobStreamsTest.java
+++ b/jobs-service/kogito-addons-jobs-service/kogito-addons-quarkus-jobs-service-embedded/runtime/src/test/java/org/kie/kogito/addons/quarkus/jobs/service/embedded/stream/EventPublisherJobStreamsTest.java
@@ -133,7 +133,7 @@ class EventPublisherJobStreamsTest {
     }
 
     private void assertData(JsonNode jsonNode) {
-        assertThat(jsonNode).hasSize(17);
+        assertThat(jsonNode).hasSize(19);
         assertHasField(jsonNode, "id", JOB_ID);
         assertHasField(jsonNode, "expirationTime", EXPIRATION_TIME.toString());
         assertHasField(jsonNode, "priority", Integer.toString(PRIORITY));
@@ -151,6 +151,8 @@ class EventPublisherJobStreamsTest {
         assertHasField(jsonNode, "lastUpdate", LAST_UPDATE.toString());
         assertHasField(jsonNode, "executionCounter", Integer.toString(EXECUTION_COUNTER));
         assertHasField(jsonNode, "executionResponse", null);
+        assertHasField(jsonNode, "exceptionMessage", null);
+        assertHasField(jsonNode, "exceptionDetails", null);
     }
 
     private JobDetails buildJobDetails() {

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/api/JobSchedulerBuilder.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/api/JobSchedulerBuilder.java
@@ -19,6 +19,7 @@
 package org.kie.kogito.app.jobs.api;
 
 import org.kie.kogito.app.jobs.impl.VertxJobScheduler;
+import org.kie.kogito.app.jobs.integrations.JobExceptionDetailsExtractor;
 import org.kie.kogito.app.jobs.spi.JobContextFactory;
 import org.kie.kogito.app.jobs.spi.JobStore;
 import org.kie.kogito.event.EventPublisher;
@@ -58,4 +59,6 @@ public interface JobSchedulerBuilder {
     JobSchedulerBuilder withJobSynchronization(JobSynchronization jobSynchronization);
 
     JobSchedulerBuilder withJobDescriptorMergers(JobDescriptionMerger... jobDescriptionMergers);
+
+    JobSchedulerBuilder withExceptionDetailsExtractor(JobExceptionDetailsExtractor exceptionDetailsExtractor);
 }

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -23,7 +23,10 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -380,11 +383,6 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
     public void cancel(String jobId) {
         JobContext jobContext = jobContextFactory.newContext();
         JobDetails jobDetails = jobStore.find(jobContext, jobId);
-        if (Set.of(JobStatus.RUNNING, JobStatus.ERROR, JobStatus.EXECUTED).contains(jobDetails.getStatus())) {
-            // Skipping canceling of jobs that are already running, or finished (either executed correctly or ended in error).
-            LOG.debug("Skipping cancelling of job with id {} due to its state being {}.", jobId, jobDetails.getStatus());
-            return;
-        }
         JobDetails cancelledJobDetails = doCancel(jobDetails);
         jobSchedulerListeners.forEach(l -> l.onCancel(cancelledJobDetails));
         reconcileScheduling(null, jobContext, cancelledJobDetails);

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -23,10 +23,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -454,6 +451,11 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
     public void cancel(String jobId) {
         JobContext jobContext = jobContextFactory.newContext();
         JobDetails jobDetails = jobStore.find(jobContext, jobId);
+        if (Set.of(JobStatus.RUNNING, JobStatus.ERROR, JobStatus.EXECUTED).contains(jobDetails.getStatus())) {
+            // Skipping canceling of jobs that are already running, or finished (either executed correctly or ended in error).
+            LOG.debug("Skipping cancelling of job with id {} due to its state being {}.", jobId, jobDetails.getStatus());
+            return;
+        }
         JobDetails cancelledJobDetails = doCancel(jobDetails);
         jobSchedulerListeners.forEach(l -> l.onCancel(cancelledJobDetails));
         reconcileScheduling(null, jobContext, cancelledJobDetails);

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/AbstractJobDescriptionJobInstanceEventAdapter.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/AbstractJobDescriptionJobInstanceEventAdapter.java
@@ -89,6 +89,8 @@ public abstract class AbstractJobDescriptionJobInstanceEventAdapter implements J
                 .executionCounter(jobDetails.getExecutionCounter())
                 .retries(jobDetails.getRetries())
                 .lastUpdate(jobDetails.getLastUpdate())
+                .exceptionMessage(jobDetails.getExceptionDetails() != null ? jobDetails.getExceptionDetails().exceptionMessage() : null)
+                .exceptionDetails(jobDetails.getExceptionDetails() != null ? jobDetails.getExceptionDetails().exceptionDetails() : null)
                 .build();
 
         return scheduledJob;

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/DefaultJobExceptionDetailsExtractor.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/DefaultJobExceptionDetailsExtractor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.integrations;
+
+import org.kie.kogito.jobs.service.model.JobExecutionExceptionDetails;
+
+/**
+ * Default implementation of JobExceptionDetailsExtractor.
+ * Extracts the exception class name and message without any sanitization.
+ */
+public class DefaultJobExceptionDetailsExtractor implements JobExceptionDetailsExtractor {
+
+    @Override
+    public JobExecutionExceptionDetails extractExceptionDetails(Exception exception) {
+        if (exception != null) {
+            String exceptionMessage = exception.getClass().getName();
+            String exceptionDetails = exception.getMessage();
+            return new JobExecutionExceptionDetails(exceptionMessage, exceptionDetails);
+        }
+        return null;
+    }
+}

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/JobExceptionDetailsExtractor.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/JobExceptionDetailsExtractor.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.integrations;
+
+import org.kie.kogito.jobs.service.model.JobExecutionExceptionDetails;
+
+/**
+ * Interface for extracting exception details from an Exception.
+ * Allows custom implementations for sensitive content sanitization or custom formatting.
+ */
+public interface JobExceptionDetailsExtractor {
+
+    /**
+     * Extracts exception details from an Exception.
+     *
+     * @param exception the exception to extract details from
+     * @return JobExecutionExceptionDetails or null if exception is null
+     */
+    JobExecutionExceptionDetails extractExceptionDetails(Exception exception);
+}

--- a/jobs/jobs-common-embedded/src/test/java/org/kie/kogito/app/jobs/impl/TestEventPublisherWithCapture.java
+++ b/jobs/jobs-common-embedded/src/test/java/org/kie/kogito/app/jobs/impl/TestEventPublisherWithCapture.java
@@ -86,4 +86,3 @@ public class TestEventPublisherWithCapture extends TestEventPublisher {
         capturedJobs.clear();
     }
 }
-

--- a/jobs/jobs-common-embedded/src/test/java/org/kie/kogito/app/jobs/impl/TestEventPublisherWithCapture.java
+++ b/jobs/jobs-common-embedded/src/test/java/org/kie/kogito/app/jobs/impl/TestEventPublisherWithCapture.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.kogito.event.DataEvent;
+import org.kie.kogito.event.job.JobInstanceDataEvent;
+import org.kie.kogito.jobs.service.model.ScheduledJob;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Test event publisher that captures published events for validation.
+ * Extends TestEventPublisher to maintain compatibility with existing tests.
+ */
+public class TestEventPublisherWithCapture extends TestEventPublisher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestEventPublisherWithCapture.class);
+
+    private final List<ScheduledJob> capturedJobs = new ArrayList<>();
+    private final ObjectMapper objectMapper;
+
+    public TestEventPublisherWithCapture() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public void publish(DataEvent<?> event) {
+        super.publish(event);
+
+        if (event instanceof JobInstanceDataEvent) {
+            JobInstanceDataEvent jobEvent = (JobInstanceDataEvent) event;
+            try {
+                ScheduledJob scheduledJob = objectMapper.readValue(jobEvent.getData(), ScheduledJob.class);
+                capturedJobs.add(scheduledJob);
+                LOG.info("Captured job event: id={}, status={}, exceptionMessage={}",
+                        scheduledJob.getId(),
+                        scheduledJob.getStatus(),
+                        scheduledJob.getExceptionMessage() != null ? scheduledJob.getExceptionMessage() : "null");
+            } catch (Exception e) {
+                LOG.error("Failed to deserialize job event", e);
+            }
+        }
+    }
+
+    /**
+     * Returns all captured ScheduledJob objects from published events.
+     */
+    public List<ScheduledJob> getCapturedJobs() {
+        return new ArrayList<>(capturedJobs);
+    }
+
+    /**
+     * Returns the most recently captured ScheduledJob, or null if none captured.
+     */
+    public ScheduledJob getLastCapturedJob() {
+        return capturedJobs.isEmpty() ? null : capturedJobs.get(capturedJobs.size() - 1);
+    }
+
+    /**
+     * Clears all captured jobs.
+     */
+    public void clearCapturedJobs() {
+        capturedJobs.clear();
+    }
+}
+

--- a/jobs/jobs-common-embedded/src/test/java/org/kie/kogito/app/jobs/impl/VertxJobSchedulerTest.java
+++ b/jobs/jobs-common-embedded/src/test/java/org/kie/kogito/app/jobs/impl/VertxJobSchedulerTest.java
@@ -22,10 +22,12 @@ package org.kie.kogito.app.jobs.impl;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.kie.kogito.app.jobs.api.JobScheduler;
 import org.kie.kogito.app.jobs.api.JobSchedulerBuilder;
+import org.kie.kogito.app.jobs.integrations.DefaultJobExceptionDetailsExtractor;
 import org.kie.kogito.app.jobs.spi.JobContextFactory;
 import org.kie.kogito.app.jobs.spi.JobStore;
 import org.kie.kogito.app.jobs.spi.memory.MemoryJobContextFactory;
@@ -35,6 +37,7 @@ import org.kie.kogito.jobs.ExactExpirationTime;
 import org.kie.kogito.jobs.ExpirationTime;
 import org.kie.kogito.jobs.service.model.JobDetails;
 import org.kie.kogito.jobs.service.model.JobStatus;
+import org.kie.kogito.jobs.service.model.ScheduledJob;
 import org.kie.kogito.timer.impl.SimpleTimerTrigger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -379,6 +382,91 @@ public class VertxJobSchedulerTest {
         assertThat(latchJobExecutor.getJobsExecuted()).hasSize(1);
         assertThat(memoryJobStore.find(jobContextFactory.newContext(), jobId)).isNull();
         assertThat(latchExecutionJobSchedulerListener.isExecuted()).isTrue();
+        jobScheduler.close();
+    }
+
+    @Test
+    public void testExceptionDetailsPropagationThroughEvents() throws Exception {
+        // Given: A job scheduler configured with event capture and retry
+        final String jobId = "exception-test-1";
+        final int NUMBER_OF_FAILURES = 2; // First execution + 1 retry
+        final int NUMBER_OF_RETRIES = NUMBER_OF_FAILURES - 1;
+
+        JobStore memoryJobStore = new MemoryJobStore();
+        JobContextFactory jobContextFactory = new MemoryJobContextFactory();
+        TestFailureJobExecutor failureExecutor = new TestFailureJobExecutor(NUMBER_OF_FAILURES);
+        TestEventPublisherWithCapture eventPublisher = new TestEventPublisherWithCapture();
+        LatchFailureJobSchedulerListener latchListener = new LatchFailureJobSchedulerListener(NUMBER_OF_FAILURES);
+
+        JobScheduler jobScheduler = JobSchedulerBuilder.newJobSchedulerBuilder()
+                .withMaxNumberOfRetries(NUMBER_OF_RETRIES)
+                .withJobExecutors(failureExecutor)
+                .withRetryInterval(1000L)
+                .withJobEventAdapters(new TestJobDetailsEventAdapter())
+                .withEventPublishers(eventPublisher)
+                .withJobContextFactory(jobContextFactory)
+                .withJobStore(memoryJobStore)
+                .withJobSchedulerListeners(latchListener)
+                .withJobDescriptorMergers(new TestJobDescriptionMerger())
+                .withExceptionDetailsExtractor(new DefaultJobExceptionDetailsExtractor())
+                .build();
+
+        jobScheduler.init();
+
+        // When: Schedule a job that will fail twice (initial + 1 retry)
+        jobScheduler.schedule(new TestJobDescription(jobId, ZonedDateTime.now().plus(Duration.ofSeconds(1))));
+        latchListener.waitForExecution();
+
+        // Then: Verify the job ended in ERROR status
+        JobDetails jobDetails = memoryJobStore.find(jobContextFactory.newContext(), jobId);
+        assertThat(jobDetails).isNotNull();
+        assertThat(jobDetails.getStatus()).isEqualTo(JobStatus.ERROR);
+        assertThat(jobDetails.getExceptionDetails()).isNotNull();
+        assertThat(jobDetails.getExceptionDetails().exceptionMessage()).contains("RuntimeException");
+        assertThat(jobDetails.getExceptionDetails().exceptionDetails()).contains("Failure expected");
+
+        // And: Verify exception details were propagated through events
+        List<ScheduledJob> capturedJobs = eventPublisher.getCapturedJobs();
+        assertThat(capturedJobs).isNotEmpty();
+
+        // Find RETRY status events - should have exception details
+        List<ScheduledJob> retryJobs = capturedJobs.stream()
+                .filter(job -> "RETRY".equals(job.getStatus().name()))
+                .toList();
+
+        assertThat(retryJobs).isNotEmpty()
+                .as("Should have at least one RETRY event");
+
+        for (ScheduledJob retryJob : retryJobs) {
+            assertThat(retryJob.getExceptionDetails())
+                    .as("RETRY status event should contain exception details")
+                    .isNotNull();
+            assertThat(retryJob.getExceptionMessage())
+                    .as("RETRY event exception message should be propagated")
+                    .contains("RuntimeException");
+            assertThat(retryJob.getExceptionDetails())
+                    .as("RETRY event exception details should be propagated")
+                    .contains("Failure expected");
+        }
+
+        // Find the ERROR status event - should have exception details
+        ScheduledJob errorJob = capturedJobs.stream()
+                .filter(job -> "ERROR".equals(job.getStatus().name()))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(errorJob).isNotNull()
+                .as("Should have an ERROR status event");
+        assertThat(errorJob.getExceptionDetails())
+                .as("ERROR status event should contain exception details")
+                .isNotNull();
+        assertThat(errorJob.getExceptionMessage())
+                .as("ERROR event exception message should be propagated")
+                .contains("RuntimeException");
+        assertThat(errorJob.getExceptionDetails())
+                .as("ERROR event exception details should be propagated")
+                .contains("Failure expected");
+
         jobScheduler.close();
     }
 

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/java/org/kie/kogito/app/jobs/jpa/model/JobDetailsEntity.java
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/java/org/kie/kogito/app/jobs/jpa/model/JobDetailsEntity.java
@@ -82,6 +82,12 @@ public class JobDetailsEntity {
     @Temporal(TemporalType.TIMESTAMP)
     private OffsetDateTime created;
 
+    @Column(name = "exception_message", length = 500)
+    private String exceptionMessage;
+
+    @Column(name = "exception_details", length = 4000)
+    private String exceptionDetails;
+
     public String getId() {
         return id;
     }
@@ -192,5 +198,21 @@ public class JobDetailsEntity {
 
     public void setCreated(OffsetDateTime created) {
         this.created = created;
+    }
+
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public void setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public String getExceptionDetails() {
+        return exceptionDetails;
+    }
+
+    public void setExceptionDetails(String exceptionDetails) {
+        this.exceptionDetails = exceptionDetails;
     }
 }

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/java/org/kie/kogito/app/jobs/jpa/model/JobDetailsEntity.java
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/java/org/kie/kogito/app/jobs/jpa/model/JobDetailsEntity.java
@@ -82,10 +82,10 @@ public class JobDetailsEntity {
     @Temporal(TemporalType.TIMESTAMP)
     private OffsetDateTime created;
 
-    @Column(name = "exception_message", length = 500)
+    @Column(name = "exception_message")
     private String exceptionMessage;
 
-    @Column(name = "exception_details", length = 4000)
+    @Column(name = "exception_details", columnDefinition = "TEXT")
     private String exceptionDetails;
 
     public String getId() {

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/resources/kie-flyway/db/jobs/ansi/V3.0.4__Add_Exception_Details.sql
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/resources/kie-flyway/db/jobs/ansi/V3.0.4__Add_Exception_Details.sql
@@ -18,6 +18,8 @@
  */
 
 -- Add exception details columns to job_details table for Embedded Jobs Addon
-ALTER TABLE job_details ADD COLUMN exception_message varchar(500);
-ALTER TABLE job_details ADD COLUMN exception_details varchar(4000);
+-- exception_message: VARCHAR without length constraint for full flexibility
+-- exception_details: TEXT type for large content without space reservation when NULL
+ALTER TABLE job_details ADD COLUMN exception_message VARCHAR;
+ALTER TABLE job_details ADD COLUMN exception_details TEXT;
 

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/resources/kie-flyway/db/jobs/ansi/V3.0.4__Add_Exception_Details.sql
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/resources/kie-flyway/db/jobs/ansi/V3.0.4__Add_Exception_Details.sql
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+-- Add exception details columns to job_details table for Embedded Jobs Addon
+ALTER TABLE job_details ADD COLUMN exception_message varchar(500);
+ALTER TABLE job_details ADD COLUMN exception_details varchar(4000);
+

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/resources/kie-flyway/db/jobs/postgresql/V3.0.4__Add_Exception_Details.sql
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/resources/kie-flyway/db/jobs/postgresql/V3.0.4__Add_Exception_Details.sql
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+-- Add exception details columns to job_details table for Embedded Jobs Addon
+ALTER TABLE job_details ADD COLUMN IF NOT EXISTS exception_message varchar(500);
+ALTER TABLE job_details ADD COLUMN IF NOT EXISTS exception_details varchar(4000);
+

--- a/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/resources/kie-flyway/db/jobs/postgresql/V3.0.4__Add_Exception_Details.sql
+++ b/jobs/kogito-addons-embedded-jobs-jpa/kogito-addons-common-embedded-jobs-jpa/src/main/resources/kie-flyway/db/jobs/postgresql/V3.0.4__Add_Exception_Details.sql
@@ -18,6 +18,8 @@
  */
 
 -- Add exception details columns to job_details table for Embedded Jobs Addon
-ALTER TABLE job_details ADD COLUMN IF NOT EXISTS exception_message varchar(500);
-ALTER TABLE job_details ADD COLUMN IF NOT EXISTS exception_details varchar(4000);
+-- exception_message: VARCHAR without length constraint for full flexibility
+-- exception_details: TEXT type for large content without space reservation when NULL
+ALTER TABLE job_details ADD COLUMN IF NOT EXISTS exception_message VARCHAR;
+ALTER TABLE job_details ADD COLUMN IF NOT EXISTS exception_details TEXT;
 

--- a/jobs/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/QuarkusJobsService.java
+++ b/jobs/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/QuarkusJobsService.java
@@ -91,6 +91,9 @@ public class QuarkusJobsService implements JobsService {
     @Inject
     Instance<ExceptionHandler> exceptionHandlers;
 
+    @Inject
+    WrappingConditionalJobExceptionDetailsExtractor exceptionDetailsExtractor;
+
     @PostConstruct
     public void init() {
         this.jobScheduler = JobSchedulerBuilder.newJobSchedulerBuilder()
@@ -110,6 +113,7 @@ public class QuarkusJobsService implements JobsService {
                 .withTimeoutInterceptor(
                         new TransactionJobTimeoutInterceptor(),
                         new ErrorHandlingJobTimeoutInterceptor(exceptionHandlers.stream().toList()))
+                .withExceptionDetailsExtractor(exceptionDetailsExtractor)
                 .withNumberOfWorkerThreads(numberOfWorkerThreads)
                 .withJobSynchronization(new JobSynchronization() {
 

--- a/jobs/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/WrappingConditionalJobExceptionDetailsExtractor.java
+++ b/jobs/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/WrappingConditionalJobExceptionDetailsExtractor.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.quarkus;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.kie.kogito.app.jobs.integrations.DefaultJobExceptionDetailsExtractor;
+import org.kie.kogito.app.jobs.integrations.JobExceptionDetailsExtractor;
+import org.kie.kogito.jobs.service.model.JobExecutionExceptionDetails;
+
+import io.quarkus.arc.All;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * CDI producer for JobExceptionDetailsExtractor.
+ * This is the ONLY source of JobExceptionDetailsExtractor beans in the application.
+ *
+ * The producer enforces the kogito.jobs-service.exception-details-enabled property:
+ * - When disabled (false, default): Returns null (no exception details extracted)
+ * - When enabled (true): Returns custom implementation if available, otherwise DefaultJobExceptionDetailsExtractor
+ *
+ * This ensures sensitive exception details are never exposed unless explicitly enabled.
+ *
+ * To provide a custom implementation, create an ApplicationScoped bean:
+ *
+ * <pre>
+ * {
+ *     &#64;code
+ *     &#64;ApplicationScoped
+ *     public class MyCustomExtractor implements JobExceptionDetailsExtractor {
+ *         // implementation
+ *     }
+ * }
+ * </pre>
+ *
+ * The producer will automatically detect and use it when the feature is enabled.
+ */
+@ApplicationScoped
+public class WrappingConditionalJobExceptionDetailsExtractor implements JobExceptionDetailsExtractor {
+
+    @Inject
+    @ConfigProperty(name = "kogito.jobs-service.exception-details-enabled", defaultValue = "false")
+    Boolean exceptionDetailsEnabled;
+
+    @Inject
+    @All // Injects all other implementations
+    Instance<JobExceptionDetailsExtractor> allExtractors;
+
+    @Override
+    public JobExecutionExceptionDetails extractExceptionDetails(Exception e) {
+        // Hijack logic: Check the property first
+        if (!exceptionDetailsEnabled) {
+            return null;
+        }
+
+        // Find the 'real' delegate, excluding this specific class
+        return allExtractors.stream()
+                .filter(impl -> !(impl instanceof WrappingConditionalJobExceptionDetailsExtractor))
+                .findFirst()
+                .map(delegate -> delegate.extractExceptionDetails(e))
+                .orElse(new DefaultJobExceptionDetailsExtractor().extractExceptionDetails(e));
+    }
+}

--- a/jobs/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/QuarkusJPAJobStoreExceptionDetailsTest.java
+++ b/jobs/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/QuarkusJPAJobStoreExceptionDetailsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.jpa.quarkus;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.app.jobs.jpa.JPAJobStore;
+import org.kie.kogito.app.jobs.jpa.model.JobDetailsEntity;
+import org.kie.kogito.app.jobs.spi.JobContext;
+import org.kie.kogito.jobs.service.model.JobDetails;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class for verifying exception details persistence in Quarkus JPA Job Store.
+ * Focuses on testing the newly added exceptionMessage and exceptionDetails fields.
+ */
+@QuarkusTest
+public class QuarkusJPAJobStoreExceptionDetailsTest {
+
+    @Inject
+    EntityManager entityManager;
+
+    private JPAJobStore jobStore;
+
+    @BeforeEach
+    public void init() {
+        jobStore = new JPAJobStore();
+    }
+
+    @Test
+    @Transactional
+    public void testJobStoreDirectlyPersistsExceptionDetails() {
+        // Given: A JobDetails with exception details
+        JobDetails jobDetails = createJobDetailsWithException("direct-test-1");
+
+        // When: Persisting through JobStore
+        JobContext jobContext = new JobContext() {
+            @Override
+            public <T> T getContext() {
+                return (T) entityManager;
+            }
+        };
+        jobStore.persist(jobContext, jobDetails);
+        entityManager.flush();
+        entityManager.clear();
+
+        // Then: Exception details are persisted
+        JobDetailsEntity entity = entityManager.find(JobDetailsEntity.class, "direct-test-1");
+        assertThat(entity).isNotNull();
+        assertThat(entity.getExceptionMessage()).isEqualTo("java.lang.RuntimeException");
+        assertThat(entity.getExceptionDetails()).isEqualTo("Test exception details");
+    }
+
+    @Test
+    @Transactional
+    public void testJobStoreUpdateClearsExceptionDetails() {
+        // Given: A job with exception details exists
+        JobDetails jobDetailsWithException = createJobDetailsWithException("direct-test-2");
+        JobContext jobContext = new JobContext() {
+            @Override
+            public <T> T getContext() {
+                return (T) entityManager;
+            }
+        };
+        jobStore.persist(jobContext, jobDetailsWithException);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When: Updating with null exception details
+        JobDetails jobDetailsWithoutException = createJobDetailsWithoutException("direct-test-2");
+        jobStore.update(jobContext, jobDetailsWithoutException);
+        entityManager.flush();
+        entityManager.clear();
+
+        // Then: Exception details are cleared
+        JobDetailsEntity entity = entityManager.find(JobDetailsEntity.class, "direct-test-2");
+        assertThat(entity).isNotNull();
+        assertThat(entity.getExceptionMessage()).isNull();
+        assertThat(entity.getExceptionDetails()).isNull();
+    }
+
+    @Test
+    @Transactional
+    public void testJobStoreFindReturnsExceptionDetails() {
+        // Given: A job with exception details exists
+        JobDetails jobDetails = createJobDetailsWithException("direct-test-3");
+        JobContext jobContext = new JobContext() {
+            @Override
+            public <T> T getContext() {
+                return (T) entityManager;
+            }
+        };
+        jobStore.persist(jobContext, jobDetails);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When: Finding the job
+        JobDetails found = jobStore.find(jobContext, "direct-test-3");
+
+        // Then: Exception details are returned
+        assertThat(found).isNotNull();
+        assertThat(found.getExceptionDetails()).isNotNull();
+        assertThat(found.getExceptionDetails().exceptionMessage()).isEqualTo("java.lang.RuntimeException");
+        assertThat(found.getExceptionDetails().exceptionDetails()).isEqualTo("Test exception details");
+    }
+
+    @Transactional
+    JobDetailsEntity findJobEntity(String jobId) {
+        return entityManager.find(JobDetailsEntity.class, jobId);
+    }
+
+    private JobDetails createJobDetailsWithException(String jobId) {
+        return TestJobDetailsFactory.createJobDetailsWithException(jobId);
+    }
+
+    private JobDetails createJobDetailsWithoutException(String jobId) {
+        return TestJobDetailsFactory.createJobDetailsWithoutException(jobId);
+    }
+}
+

--- a/jobs/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/QuarkusJPAJobStoreExceptionDetailsTest.java
+++ b/jobs/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/QuarkusJPAJobStoreExceptionDetailsTest.java
@@ -140,4 +140,3 @@ public class QuarkusJPAJobStoreExceptionDetailsTest {
         return TestJobDetailsFactory.createJobDetailsWithoutException(jobId);
     }
 }
-

--- a/jobs/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/TestJobDetailsFactory.java
+++ b/jobs/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/TestJobDetailsFactory.java
@@ -66,4 +66,3 @@ public class TestJobDetailsFactory {
                 .build();
     }
 }
-

--- a/jobs/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/TestJobDetailsFactory.java
+++ b/jobs/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/TestJobDetailsFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.jpa.quarkus;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.kie.kogito.app.jobs.impl.InVMRecipient;
+import org.kie.kogito.jobs.service.model.JobDetails;
+import org.kie.kogito.jobs.service.model.JobExecutionExceptionDetails;
+import org.kie.kogito.jobs.service.model.JobStatus;
+import org.kie.kogito.jobs.service.model.RecipientInstance;
+import org.kie.kogito.timer.impl.SimpleTimerTrigger;
+
+/**
+ * Factory class for creating test JobDetails instances.
+ */
+public class TestJobDetailsFactory {
+
+    private TestJobDetailsFactory() {
+        // Utility class
+    }
+
+    public static JobDetails createJobDetailsWithException(String jobId) {
+        JobExecutionExceptionDetails exceptionDetails = new JobExecutionExceptionDetails(
+                "java.lang.RuntimeException",
+                "Test exception details");
+
+        return JobDetails.builder()
+                .id(jobId)
+                .status(JobStatus.RETRY)
+                .retries(1)
+                .lastUpdate(OffsetDateTime.now().toZonedDateTime())
+                .recipient(new RecipientInstance(new InVMRecipient()))
+                .trigger(new SimpleTimerTrigger(new Date(), 0L, ChronoUnit.MILLIS, 0, "UTC"))
+                .exceptionDetails(exceptionDetails)
+                .build();
+    }
+
+    public static JobDetails createJobDetailsWithoutException(String jobId) {
+        return JobDetails.builder()
+                .id(jobId)
+                .status(JobStatus.SCHEDULED)
+                .retries(0)
+                .lastUpdate(OffsetDateTime.now().toZonedDateTime())
+                .recipient(new RecipientInstance(new InVMRecipient()))
+                .trigger(new SimpleTimerTrigger(new Date(), 0L, ChronoUnit.MILLIS, 0, "UTC"))
+                .exceptionDetails(null)
+                .build();
+    }
+}
+

--- a/jobs/kogito-addons-quarkus-embedded-jobs/src/test/resources/application.properties
+++ b/jobs/kogito-addons-quarkus-embedded-jobs/src/test/resources/application.properties
@@ -18,11 +18,14 @@
 #
 
 
-
 quarkus.hibernate-orm.database.generation=none
 quarkus.hibernate-orm.schema-management.strategy=none
 
 quarkus.flyway.enabled=false
 kie.flyway.enabled=true
 quarkus.hibernate-orm.log.sql=false
+
+# Enable exception details capture for tests
+kogito.jobs-service.exception-details-enabled=true
+
 

--- a/jobs/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringbootJobsService.java
+++ b/jobs/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringbootJobsService.java
@@ -90,6 +90,9 @@ public class SpringbootJobsService implements JobsService {
     @Autowired(required = false)
     protected List<ExceptionHandler> exceptionHandlers;
 
+    @Autowired
+    protected WrappingConditionalJobExceptionDetailsExtractor exceptionDetailsExtractor;
+
     @PostConstruct
     public void init() {
         this.jobScheduler = JobSchedulerBuilder.newJobSchedulerBuilder()
@@ -109,6 +112,7 @@ public class SpringbootJobsService implements JobsService {
                 .withTimeoutInterceptor(
                         new TransactionJobTimeoutInterceptor(transactionManager),
                         new ErrorHandlingJobTimeoutInterceptor(ofNullable(exceptionHandlers).stream().toList()))
+                .withExceptionDetailsExtractor(exceptionDetailsExtractor)
                 .withNumberOfWorkerThreads(numberOfWorkerThreads)
                 .withJobSynchronization(new JobSynchronization() {
 

--- a/jobs/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/WrappingConditionalJobExceptionDetailsExtractor.java
+++ b/jobs/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/WrappingConditionalJobExceptionDetailsExtractor.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.springboot;
+
+import java.util.List;
+
+import org.kie.kogito.app.jobs.integrations.DefaultJobExceptionDetailsExtractor;
+import org.kie.kogito.app.jobs.integrations.JobExceptionDetailsExtractor;
+import org.kie.kogito.jobs.service.model.JobExecutionExceptionDetails;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Boot configuration for JobExceptionDetailsExtractor.
+ * This is the ONLY source of JobExceptionDetailsExtractor beans in the application.
+ *
+ * The configuration enforces the kogito.jobs-service.exception-details-enabled property:
+ * - When disabled (false, default): Returns null (no exception details extracted)
+ * - When enabled (true): Returns custom implementation if available, otherwise DefaultJobExceptionDetailsExtractor
+ *
+ * This ensures sensitive exception details are never exposed unless explicitly enabled.
+ *
+ * To provide a custom implementation, create a Component bean:
+ * 
+ * <pre>
+ * {
+ *     &#64;code
+ *     &#64;Component
+ *     public class MyCustomExtractor implements JobExceptionDetailsExtractor {
+ *         // implementation
+ *     }
+ * }
+ * </pre>
+ *
+ * The configuration will automatically detect and use it when the feature is enabled.
+ */
+@Component
+public class WrappingConditionalJobExceptionDetailsExtractor implements JobExceptionDetailsExtractor {
+
+    @Value("${kogito.jobs-service.exception-details-enabled:false}")
+    private Boolean exceptionDetailsEnabled;
+
+    @Autowired(required = false)
+    @Lazy
+    List<JobExceptionDetailsExtractor> allExtractors;
+
+    public JobExecutionExceptionDetails extractExceptionDetails(Exception e) {
+        // If disabled, return null (no exception details will be extracted)
+        if (!exceptionDetailsEnabled) {
+            return null;
+        }
+
+        // Logic to find the "real" delegate while avoiding a loop
+        return allExtractors.stream()
+                .filter(impl -> impl != this) // Break the recursion
+                .findFirst()
+                .map(delegate -> delegate.extractExceptionDetails(e))
+                .orElse(new DefaultJobExceptionDetailsExtractor().extractExceptionDetails(e));
+    }
+}

--- a/jobs/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/SpringbootJPAJobStoreExceptionDetailsTest.java
+++ b/jobs/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/SpringbootJPAJobStoreExceptionDetailsTest.java
@@ -139,4 +139,3 @@ public class SpringbootJPAJobStoreExceptionDetailsTest {
         return TestJobDetailsFactory.createJobDetailsWithoutException(jobId);
     }
 }
-

--- a/jobs/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/SpringbootJPAJobStoreExceptionDetailsTest.java
+++ b/jobs/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/SpringbootJPAJobStoreExceptionDetailsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.springboot;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.app.jobs.jpa.JPAJobStore;
+import org.kie.kogito.app.jobs.jpa.model.JobDetailsEntity;
+import org.kie.kogito.app.jobs.spi.JobContext;
+import org.kie.kogito.jobs.service.model.JobDetails;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class for verifying exception details persistence in Spring Boot JPA Job Store.
+ * Focuses on testing the newly added exceptionMessage and exceptionDetails fields.
+ */
+@SpringBootTest
+public class SpringbootJPAJobStoreExceptionDetailsTest {
+
+    @Autowired
+    EntityManager entityManager;
+
+    private JPAJobStore jobStore;
+
+    @BeforeEach
+    public void init() {
+        jobStore = new JPAJobStore();
+    }
+
+    @Test
+    @Transactional
+    public void testJobStoreDirectlyPersistsExceptionDetails() {
+        // Given: A JobDetails with exception details
+        JobDetails jobDetails = createJobDetailsWithException("spring-direct-test-1");
+
+        // When: Persisting through JobStore
+        JobContext jobContext = new JobContext() {
+            @Override
+            public <T> T getContext() {
+                return (T) entityManager;
+            }
+        };
+        jobStore.persist(jobContext, jobDetails);
+        entityManager.flush();
+        entityManager.clear();
+
+        // Then: Exception details are persisted
+        JobDetailsEntity entity = entityManager.find(JobDetailsEntity.class, "spring-direct-test-1");
+        assertThat(entity).isNotNull();
+        assertThat(entity.getExceptionMessage()).isEqualTo("java.lang.RuntimeException");
+        assertThat(entity.getExceptionDetails()).isEqualTo("Test exception details");
+    }
+
+    @Test
+    @Transactional
+    public void testJobStoreUpdateClearsExceptionDetails() {
+        // Given: A job with exception details exists
+        JobDetails jobDetailsWithException = createJobDetailsWithException("spring-direct-test-2");
+        JobContext jobContext = new JobContext() {
+            @Override
+            public <T> T getContext() {
+                return (T) entityManager;
+            }
+        };
+        jobStore.persist(jobContext, jobDetailsWithException);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When: Updating with null exception details
+        JobDetails jobDetailsWithoutException = createJobDetailsWithoutException("spring-direct-test-2");
+        jobStore.update(jobContext, jobDetailsWithoutException);
+        entityManager.flush();
+        entityManager.clear();
+
+        // Then: Exception details are cleared
+        JobDetailsEntity entity = entityManager.find(JobDetailsEntity.class, "spring-direct-test-2");
+        assertThat(entity).isNotNull();
+        assertThat(entity.getExceptionMessage()).isNull();
+        assertThat(entity.getExceptionDetails()).isNull();
+    }
+
+    @Test
+    @Transactional
+    public void testJobStoreFindReturnsExceptionDetails() {
+        // Given: A job with exception details exists
+        JobDetails jobDetails = createJobDetailsWithException("spring-direct-test-3");
+        JobContext jobContext = new JobContext() {
+            @Override
+            public <T> T getContext() {
+                return (T) entityManager;
+            }
+        };
+        jobStore.persist(jobContext, jobDetails);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When: Finding the job
+        JobDetails found = jobStore.find(jobContext, "spring-direct-test-3");
+
+        // Then: Exception details are returned
+        assertThat(found).isNotNull();
+        assertThat(found.getExceptionDetails()).isNotNull();
+        assertThat(found.getExceptionDetails().exceptionMessage()).isEqualTo("java.lang.RuntimeException");
+        assertThat(found.getExceptionDetails().exceptionDetails()).isEqualTo("Test exception details");
+    }
+
+    @Transactional
+    JobDetailsEntity findJobEntity(String jobId) {
+        return entityManager.find(JobDetailsEntity.class, jobId);
+    }
+
+    private JobDetails createJobDetailsWithException(String jobId) {
+        return TestJobDetailsFactory.createJobDetailsWithException(jobId);
+    }
+
+    private JobDetails createJobDetailsWithoutException(String jobId) {
+        return TestJobDetailsFactory.createJobDetailsWithoutException(jobId);
+    }
+}
+

--- a/jobs/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/TestJobDetailsFactory.java
+++ b/jobs/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/TestJobDetailsFactory.java
@@ -66,4 +66,3 @@ public class TestJobDetailsFactory {
                 .build();
     }
 }
-

--- a/jobs/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/TestJobDetailsFactory.java
+++ b/jobs/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/TestJobDetailsFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.springboot;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.kie.kogito.app.jobs.impl.InVMRecipient;
+import org.kie.kogito.jobs.service.model.JobDetails;
+import org.kie.kogito.jobs.service.model.JobExecutionExceptionDetails;
+import org.kie.kogito.jobs.service.model.JobStatus;
+import org.kie.kogito.jobs.service.model.RecipientInstance;
+import org.kie.kogito.timer.impl.SimpleTimerTrigger;
+
+/**
+ * Factory class for creating test JobDetails instances.
+ */
+public class TestJobDetailsFactory {
+
+    private TestJobDetailsFactory() {
+        // Utility class
+    }
+
+    public static JobDetails createJobDetailsWithException(String jobId) {
+        JobExecutionExceptionDetails exceptionDetails = new JobExecutionExceptionDetails(
+                "java.lang.RuntimeException",
+                "Test exception details");
+
+        return JobDetails.builder()
+                .id(jobId)
+                .status(JobStatus.RETRY)
+                .retries(1)
+                .lastUpdate(OffsetDateTime.now().toZonedDateTime())
+                .recipient(new RecipientInstance(new InVMRecipient()))
+                .trigger(new SimpleTimerTrigger(new Date(), 0L, ChronoUnit.MILLIS, 0, "UTC"))
+                .exceptionDetails(exceptionDetails)
+                .build();
+    }
+
+    public static JobDetails createJobDetailsWithoutException(String jobId) {
+        return JobDetails.builder()
+                .id(jobId)
+                .status(JobStatus.SCHEDULED)
+                .retries(0)
+                .lastUpdate(OffsetDateTime.now().toZonedDateTime())
+                .recipient(new RecipientInstance(new InVMRecipient()))
+                .trigger(new SimpleTimerTrigger(new Date(), 0L, ChronoUnit.MILLIS, 0, "UTC"))
+                .exceptionDetails(null)
+                .build();
+    }
+}
+

--- a/jobs/kogito-addons-springboot-embedded-jobs/src/test/resources/application.properties
+++ b/jobs/kogito-addons-springboot-embedded-jobs/src/test/resources/application.properties
@@ -10,3 +10,6 @@ spring.jpa.hibernate.ddl-auto:none
 spring.flyway.enabled=false
 
 kie.flyway.enabled=true
+
+# Enable exception details capture for tests
+kogito.jobs-service.exception-details-enabled=true


### PR DESCRIPTION
Fixes apache/incubator-kie-issues#2231

Allowing to enable extraction of exception details related to Job execution attempt when using Embedded Jobs Addon.

The change is promoted also to data-index and data-audit.