### PR TITLE
[Incubator-kie-issues#2269] Fix embedded addon timer repeatLimit signal

### DIFF
--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/ProcessInstanceJobExecutor.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/ProcessInstanceJobExecutor.java
@@ -26,6 +26,7 @@ import org.kie.kogito.process.Processes;
 import org.kie.kogito.process.SignalFactory;
 import org.kie.kogito.services.uow.UnitOfWorkExecutor;
 import org.kie.kogito.timer.TimerInstance;
+import org.kie.kogito.timer.impl.SimpleTimerTrigger;
 import org.kie.kogito.uow.UnitOfWorkManager;
 
 public class ProcessInstanceJobExecutor implements JobExecutor {
@@ -52,7 +53,9 @@ public class ProcessInstanceJobExecutor implements JobExecutor {
         UnitOfWorkExecutor.executeInUnitOfWork(uom, () -> {
             processes.processByProcessInstanceId(processJobDescription.processInstanceId()).ifPresent(processes -> {
                 processes.instances().findById(processJobDescription.processInstanceId()).ifPresent(pi -> {
-                    pi.send(SignalFactory.of(SIGNAL, TimerInstance.with(jobDetails.getId(), processJobDescription.timerId(), jobDetails.getRetries())));
+                    SimpleTimerTrigger timerTrigger = (SimpleTimerTrigger) jobDetails.getTrigger();
+                    int remaining = timerTrigger.getRemainingRepetitions();
+                    pi.send(SignalFactory.of(SIGNAL, TimerInstance.with(jobDetails.getId(), processJobDescription.timerId(), remaining == -1 ? Integer.MAX_VALUE : remaining)));
                 });
             });
             return null;

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/ProcessInstanceJobExecutor.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/ProcessInstanceJobExecutor.java
@@ -54,7 +54,7 @@ public class ProcessInstanceJobExecutor implements JobExecutor {
             processes.processByProcessInstanceId(processJobDescription.processInstanceId()).ifPresent(processes -> {
                 processes.instances().findById(processJobDescription.processInstanceId()).ifPresent(pi -> {
                     SimpleTimerTrigger timerTrigger = (SimpleTimerTrigger) jobDetails.getTrigger();
-                    int remaining = timerTrigger.getRemainingRepetitions();
+                    int remaining = timerTrigger.computeRemainingRepetitions();
                     pi.send(SignalFactory.of(SIGNAL, TimerInstance.with(jobDetails.getId(), processJobDescription.timerId(), remaining == -1 ? Integer.MAX_VALUE : remaining)));
                 });
             });


### PR DESCRIPTION
ProcessInstanceJobExecutor was using jobDetails.getRetries() (error retry count) as the repeatLimit sent to TimerNodeInstance. It should be the remaining timer repetitions. Fixed by using SimpleTimerTrigger.getRemainingRepetitions() instead.

Closes: https://github.com/apache/incubator-kie-issues/issues/2269
Associated PR: https://github.com/apache/incubator-kie-kogito-runtimes/pull/4248
