### PR TITLE
Improve jobs service leader handoff behavior

### DIFF
--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/management/HttpGatekeeperFilter.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/management/HttpGatekeeperFilter.java
@@ -18,6 +18,7 @@
  */
 package org.kie.kogito.jobs.service.management;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -37,13 +38,20 @@ public class HttpGatekeeperFilter {
     @ConfigProperty(name = "quarkus.smallrye-health.root-path", defaultValue = "/q/health")
     private String healthCheckPath;
 
+    @ConfigProperty(name = "kogito.jobs-service.management.http.protected-paths", defaultValue = "/jobs,/v2/jobs")
+    private List<String> protectedPaths;
+
+    @ConfigProperty(name = "kogito.jobs-service.management.http.whitelist", defaultValue = "/management")
+    private List<String> whitelistedPaths;
+
     protected void onMessagingStatusChange(@Observes MessagingChangeEvent event) {
         this.enabled.set(event.isEnabled());
     }
 
     @RouteFilter(100)
     void masterFilter(RoutingContext rc) throws Exception {
-        if (!enabled.get() && !rc.request().path().contains(healthCheckPath)) {
+        String path = rc.request().path();
+        if (!enabled.get() && isProtected(path) && !isWhitelisted(path)) {
             //block
             rc.response().setStatusCode(503);
             rc.response().setStatusMessage(ERROR_MESSAGE);
@@ -52,5 +60,30 @@ public class HttpGatekeeperFilter {
         }
         //continue
         rc.next();
+    }
+
+    private boolean isProtected(String path) {
+        return pathMatchesAny(path, protectedPaths);
+    }
+
+    private boolean isWhitelisted(String path) {
+        return pathMatches(path, healthCheckPath) || pathMatchesAny(path, whitelistedPaths);
+    }
+
+    private boolean pathMatchesAny(String path, List<String> pathPrefixes) {
+        return pathPrefixes != null && pathPrefixes.stream().anyMatch(prefix -> pathMatches(path, prefix));
+    }
+
+    private boolean pathMatches(String path, String pathPrefix) {
+        if (path == null || pathPrefix == null || pathPrefix.isBlank()) {
+            return false;
+        }
+        String normalizedPrefix = normalizePath(pathPrefix);
+        return "/".equals(normalizedPrefix) || path.equals(normalizedPrefix) || path.startsWith(normalizedPrefix + "/");
+    }
+
+    private String normalizePath(String path) {
+        String normalized = path.startsWith("/") ? path : "/" + path;
+        return normalized.length() > 1 && normalized.endsWith("/") ? normalized.substring(0, normalized.length() - 1) : normalized;
     }
 }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/management/JobServiceInstanceManager.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/management/JobServiceInstanceManager.java
@@ -62,6 +62,9 @@ public class JobServiceInstanceManager {
     @ConfigProperty(name = "kogito.jobs-service.management.heartbeat.management-id", defaultValue = "kogito-jobs-service-leader")
     String leaderManagementId;
 
+    @ConfigProperty(name = "kogito.jobs-service.management.resign.pause-heartbeats", defaultValue = "10")
+    long resignPauseHeartbeats;
+
     @Inject
     Instance<MessagingHandler> messagingHandlerInstance;
 
@@ -131,6 +134,10 @@ public class JobServiceInstanceManager {
         shutdown();
     }
 
+    void onResignLeader(@Observes ResignLeaderEvent event) {
+        resign();
+    }
+
     private void shutdown() {
         release(currentInfo.get())
                 .onItem().invoke(i -> checkLeader.cancel())
@@ -183,7 +190,16 @@ public class JobServiceInstanceManager {
 
     protected Uni<JobServiceManagementInfo> heartbeat(JobServiceManagementInfo info) {
         if (isLeader()) {
-            return repository.heartbeat(info);
+            return repository.heartbeat(info)
+                    .onItem().invoke(updated -> {
+                        if (Objects.isNull(updated) && isLeader()) {
+                            LOGGER.warn("Heartbeat failed for token {}, demoting and resuming leader checks", info.getToken());
+                            leader.set(false);
+                            disableCommunication();
+                            heartbeat.pause();
+                            checkLeader.resume();
+                        }
+                    });
         }
         return Uni.createFrom().nullItem();
     }
@@ -207,5 +223,20 @@ public class JobServiceInstanceManager {
 
     protected TimeoutStream getHeartbeat() {
         return heartbeat;
+    }
+
+    private void resign() {
+        leader.set(false);
+        heartbeat.pause();
+        checkLeader.pause();
+        release(currentInfo.get())
+                .subscribe().with(i -> {
+                    long delayMs = TimeUnit.SECONDS.toMillis(heardBeatIntervalInSeconds * resignPauseHeartbeats);
+                    LOGGER.info("Resigned leadership; pausing leader checks for {} heartbeats ({} ms)", resignPauseHeartbeats, delayMs);
+                    vertx.setTimer(delayMs, t -> {
+                        LOGGER.info("Resign pause elapsed; resuming leader checks");
+                        checkLeader.resume();
+                    });
+                }, ex -> LOGGER.error("Error resigning leader", ex));
     }
 }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/management/JobServiceLeaderHealthCheck.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/management/JobServiceLeaderHealthCheck.java
@@ -42,8 +42,13 @@ public class JobServiceLeaderHealthCheck implements HealthCheck {
     public HealthCheckResponse call() {
         final HealthCheckResponseBuilder responseBuilder = HealthCheckResponse.named("Leader Instance");
         if (enabled.get()) {
-            return responseBuilder.up().build();
+            return responseBuilder.up()
+                    .withData("status", "LEADER")
+                    .build();
         }
-        return responseBuilder.down().build();
+        return responseBuilder.up()
+                .withData("status", "WAIT")
+                .withData("message", "Not a leader")
+                .build();
     }
 }

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/management/ResignLeaderEvent.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/management/ResignLeaderEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.jobs.service.management;
+
+public class ResignLeaderEvent {
+}

--- a/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/resource/JobServiceManagementResource.java
+++ b/jobs-service/jobs-service-common/src/main/java/org/kie/kogito/jobs/service/resource/JobServiceManagementResource.java
@@ -19,6 +19,7 @@
 package org.kie.kogito.jobs.service.resource;
 
 import org.kie.kogito.jobs.service.management.ReleaseLeaderEvent;
+import org.kie.kogito.jobs.service.management.ResignLeaderEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,12 +39,24 @@ public class JobServiceManagementResource {
     @Inject
     Event<ReleaseLeaderEvent> releaseLeaderEventEvent;
 
+    @Inject
+    Event<ResignLeaderEvent> resignLeaderEventEvent;
+
     @POST
     @Path("/shutdown")
     public Uni<Response> shutdownHook() {
         return Uni.createFrom().voidItem()
                 .onItem().invoke(i -> LOGGER.info("Job Service is shutting down"))
                 .onItem().invoke(() -> releaseLeaderEventEvent.fire(new ReleaseLeaderEvent()))
+                .onItem().transform(i -> Response.ok().build());
+    }
+
+    @POST
+    @Path("/resign")
+    public Uni<Response> resignLeadership() {
+        return Uni.createFrom().voidItem()
+                .onItem().invoke(i -> LOGGER.info("Job Service is resigning leadership"))
+                .onItem().invoke(() -> resignLeaderEventEvent.fire(new ResignLeaderEvent()))
                 .onItem().transform(i -> Response.ok().build());
     }
 }

--- a/jobs-service/jobs-service-common/src/main/resources/META-INF/microprofile-config.properties
+++ b/jobs-service/jobs-service-common/src/main/resources/META-INF/microprofile-config.properties
@@ -46,6 +46,8 @@ kogito.jobs-service.loadJobIntervalInMinutes=10
 kogito.jobs-service.loadJobFromCurrentTimeIntervalInMinutes=60
 kogito.jobs-service.forceExecuteExpiredJobs=true
 kogito.jobs-service.forceExecuteExpiredJobsOnServiceStart=true
+kogito.jobs-service.management.http.protected-paths=/jobs,/v2/jobs
+kogito.jobs-service.management.http.whitelist=/management
 
 
 quarkus.oidc.enabled=true

--- a/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/management/HttpGatekeeperFilterTest.java
+++ b/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/management/HttpGatekeeperFilterTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.jobs.service.management;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class HttpGatekeeperFilterTest {
+
+    private HttpGatekeeperFilter filter;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        filter = new HttpGatekeeperFilter();
+        setField("healthCheckPath", "/q/health");
+        setField("protectedPaths", List.of("/jobs", "/v2/jobs"));
+        setField("whitelistedPaths", List.of("/management"));
+    }
+
+    @Test
+    void shouldBlockJobsApiWhenInstanceIsNotLeader() throws Exception {
+        RoutingContext routingContext = routingContext("/jobs/my-job");
+
+        filter.masterFilter(routingContext);
+
+        verify(routingContext.response()).setStatusCode(503);
+        verify(routingContext.response()).setStatusMessage(HttpGatekeeperFilter.ERROR_MESSAGE);
+        verify(routingContext).end();
+        verify(routingContext, never()).next();
+    }
+
+    @Test
+    void shouldAllowManagementApiWhenInstanceIsNotLeader() throws Exception {
+        RoutingContext routingContext = routingContext("/management/resign");
+
+        filter.masterFilter(routingContext);
+
+        verify(routingContext).next();
+        verify(routingContext, never()).end();
+    }
+
+    @Test
+    void shouldAllowEmbeddedWorkflowApiWhenInstanceIsNotLeader() throws Exception {
+        RoutingContext routingContext = routingContext("/orders/123");
+
+        filter.masterFilter(routingContext);
+
+        verify(routingContext).next();
+        verify(routingContext, never()).end();
+    }
+
+    @Test
+    void shouldAllowAllPathsWhenInstanceIsLeader() throws Exception {
+        RoutingContext routingContext = routingContext("/jobs/my-job");
+        filter.onMessagingStatusChange(new MessagingChangeEvent(true));
+
+        filter.masterFilter(routingContext);
+
+        verify(routingContext).next();
+        verify(routingContext, never()).end();
+    }
+
+    @Test
+    void shouldSupportStrictModeWithWhitelist() throws Exception {
+        setField("protectedPaths", List.of("/"));
+        setField("whitelistedPaths", List.of("/orders"));
+
+        RoutingContext jobsRoutingContext = routingContext("/jobs/my-job");
+        filter.masterFilter(jobsRoutingContext);
+        verify(jobsRoutingContext.response()).setStatusCode(503);
+        verify(jobsRoutingContext).end();
+
+        RoutingContext workflowRoutingContext = routingContext("/orders/123");
+        filter.masterFilter(workflowRoutingContext);
+        verify(workflowRoutingContext).next();
+
+        RoutingContext healthRoutingContext = routingContext("/q/health/ready");
+        filter.masterFilter(healthRoutingContext);
+        verify(healthRoutingContext).next();
+    }
+
+    private RoutingContext routingContext(String path) {
+        RoutingContext routingContext = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        HttpServerResponse response = mock(HttpServerResponse.class);
+        when(routingContext.request()).thenReturn(request);
+        when(routingContext.response()).thenReturn(response);
+        when(request.path()).thenReturn(path);
+        when(response.setStatusCode(503)).thenReturn(response);
+        when(response.setStatusMessage(HttpGatekeeperFilter.ERROR_MESSAGE)).thenReturn(response);
+        return routingContext;
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field field = HttpGatekeeperFilter.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(filter, value);
+    }
+}

--- a/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/management/JobServiceInstanceManagerTest.java
+++ b/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/management/JobServiceInstanceManagerTest.java
@@ -40,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.TimeoutStream;
 import io.vertx.mutiny.core.Vertx;
 
@@ -51,6 +52,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -92,6 +94,7 @@ class JobServiceInstanceManagerTest {
         tested.heartbeatExpirationInSeconds = 1;
         tested.leaderCheckIntervalInSeconds = 1;
         tested.heardBeatIntervalInSeconds = 1;
+        tested.resignPauseHeartbeats = 1;
         messagingHandler = mock(MessagingHandler.class);
         Stream<MessagingHandler> handlers = Arrays.stream(new MessagingHandler[] { messagingHandler });
         lenient().doReturn(handlers).when(messagingHandlerInstance).stream();
@@ -169,5 +172,38 @@ class JobServiceInstanceManagerTest {
         assertThat(lastHeartbeat.getId()).isEqualTo(tested.getCurrentInfo().getId());
         assertThat(lastHeartbeat.getToken()).isEqualTo(tested.getCurrentInfo().getToken());
         assertThat(lastHeartbeat.getLastHeartbeat()).isNotNull();
+    }
+
+    @Test
+    void heartbeatDemotesLeaderWhenTokenWasLost() {
+        JobServiceManagementInfo info = new JobServiceManagementInfo("id", "token", OffsetDateTime.now());
+        TimeoutStream checkLeader = mock(TimeoutStream.class);
+        TimeoutStream heartbeat = mock(TimeoutStream.class);
+        tested.tryBecomeLeader(info, checkLeader, heartbeat).await().indefinitely();
+        doReturn(Uni.createFrom().nullItem()).when(repository).heartbeat(info);
+
+        tested.heartbeat(info).await().indefinitely();
+
+        assertThat(tested.isLeader()).isFalse();
+        verify(messagingHandler, atLeastOnce()).pause();
+        verify(messagingChangeEventEvent, atLeastOnce()).fire(any());
+        verify(heartbeat).pause();
+        verify(checkLeader).resume();
+    }
+
+    @Test
+    void onResignLeaderReleasesLeadership() {
+        tested.startup(startupEvent);
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(tested.isLeader()).isTrue());
+
+        tested.onResignLeader(new ResignLeaderEvent());
+
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(tested.isLeader()).isFalse();
+                    verify(tested, times(1)).release(infoCaptor.capture());
+                    assertThat(infoCaptor.getValue()).isEqualTo(tested.getCurrentInfo());
+                });
     }
 }

--- a/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/management/JobServiceLeaderHealthCheckTest.java
+++ b/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/management/JobServiceLeaderHealthCheckTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.jobs.service.management;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JobServiceLeaderHealthCheckTest {
+
+    @Test
+    void shouldReportUpWhenWaitingForLeadership() {
+        JobServiceLeaderHealthCheck healthCheck = new JobServiceLeaderHealthCheck();
+
+        HealthCheckResponse response = healthCheck.call();
+
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+        assertThat(response.getData()).hasValueSatisfying(data -> assertThat(data.get("status")).isEqualTo("WAIT"));
+    }
+
+    @Test
+    void shouldReportUpWhenLeader() {
+        JobServiceLeaderHealthCheck healthCheck = new JobServiceLeaderHealthCheck();
+        healthCheck.onMessagingStatusChange(new MessagingChangeEvent(true));
+
+        HealthCheckResponse response = healthCheck.call();
+
+        assertThat(response.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+        assertThat(response.getData()).hasValueSatisfying(data -> assertThat(data.get("status")).isEqualTo("LEADER"));
+    }
+}

--- a/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/resource/JobServiceManagementResourceIT.java
+++ b/jobs-service/jobs-service-common/src/test/java/org/kie/kogito/jobs/service/resource/JobServiceManagementResourceIT.java
@@ -33,6 +33,7 @@ class JobServiceManagementResourceIT {
 
     private static final String HEALTH_ENDPOINT = "/q/health/ready";
     public static final String MANAGEMENT_SHUTDOWN_ENDPOINT = "/management/shutdown";
+    public static final String MANAGEMENT_RESIGN_ENDPOINT = "/management/resign";
 
     @Test
     public void testShutdown() {
@@ -54,6 +55,15 @@ class JobServiceManagementResourceIT {
                 .accept(ContentType.JSON)
                 .get(HEALTH_ENDPOINT)
                 .then()
-                .statusCode(503));
+                .statusCode(200));
+    }
+
+    @Test
+    public void testResign() {
+        given()
+                .when()
+                .post(MANAGEMENT_RESIGN_ENDPOINT)
+                .then()
+                .statusCode(200);
     }
 }


### PR DESCRIPTION
## Summary
This draft PR improves Jobs Service leader/follower behavior in .

## Changes
- limit follower HTTP blocking to configurable protected paths instead of blocking all non-health routes
- allow management and health endpoints while follower instances wait for leadership
- add  to voluntarily resign leadership
- demote the current leader when heartbeat no longer owns the repository token
- keep readiness  with  for follower instances so embedded workflow runtimes remain routable
- add focused unit/integration test coverage for gatekeeper behavior, leader handoff, and readiness

## Why
In embedded Jobs Service deployments, blocking every non-health HTTP route on follower instances can also block unrelated workflow/runtime endpoints served by the same application. This PR narrows that behavior so follower instances reject Jobs Service protected routes while still allowing embedded workflow traffic.

## Notes
- This PR is being shared first for discussion on the KIE Zulip thread.
- Formal KOGITO issue/branch/title alignment can be done afterward if the proposed direction is accepted.
- Local Maven verification from this machine is currently blocked by Apache snapshots certificate resolution for .
