### PR TITLE
[incubator-kie-issues#2311] Handle reconciliation of RETRY or ERROR jobs in a new transaction

### DIFF
--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/api/JobSchedulerBuilder.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/api/JobSchedulerBuilder.java
@@ -22,6 +22,7 @@ import org.kie.kogito.app.jobs.impl.VertxJobScheduler;
 import org.kie.kogito.app.jobs.integrations.JobExceptionDetailsExtractor;
 import org.kie.kogito.app.jobs.spi.JobContextFactory;
 import org.kie.kogito.app.jobs.spi.JobStore;
+import org.kie.kogito.app.jobs.spi.TransactionRollbackMarker;
 import org.kie.kogito.event.EventPublisher;
 
 public interface JobSchedulerBuilder {
@@ -61,4 +62,6 @@ public interface JobSchedulerBuilder {
     JobSchedulerBuilder withJobDescriptorMergers(JobDescriptionMerger... jobDescriptionMergers);
 
     JobSchedulerBuilder withExceptionDetailsExtractor(JobExceptionDetailsExtractor exceptionDetailsExtractor);
+
+    JobSchedulerBuilder withTransactionRollbackMarker(TransactionRollbackMarker transactionRollbackMarker);
 }

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -47,6 +47,8 @@ import org.kie.kogito.app.jobs.integrations.UserTaskInstanceJobDescriptorMerger;
 import org.kie.kogito.app.jobs.spi.JobContext;
 import org.kie.kogito.app.jobs.spi.JobContextFactory;
 import org.kie.kogito.app.jobs.spi.JobStore;
+import org.kie.kogito.app.jobs.spi.NoOpTransactionRollbackMarker;
+import org.kie.kogito.app.jobs.spi.TransactionRollbackMarker;
 import org.kie.kogito.app.jobs.spi.memory.MemoryJobContextFactory;
 import org.kie.kogito.app.jobs.spi.memory.MemoryJobStore;
 import org.kie.kogito.event.DataEvent;
@@ -114,6 +116,8 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
     private JobSynchronization jobSynchronization;
 
     private JobExceptionDetailsExtractor exceptionDetailsExtractor;
+
+    private TransactionRollbackMarker transactionRollbackMarker;
 
     public class VertxJobSchedulerBuilder implements JobSchedulerBuilder {
 
@@ -213,6 +217,12 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             return this;
         }
 
+        @Override
+        public JobSchedulerBuilder withTransactionRollbackMarker(TransactionRollbackMarker transactionRollbackMarker) {
+            VertxJobScheduler.this.transactionRollbackMarker = transactionRollbackMarker;
+            return this;
+        }
+
     }
 
     public VertxJobScheduler() {
@@ -242,6 +252,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
         this.refreshJobsInterval = 1000L;
         this.retryInterval = 10 * 1000L; // ten seconds
         this.maxRefreshJobsIntervalWindow = 5 * 60 * 1000L; // every 5 minute
+        this.transactionRollbackMarker = new NoOpTransactionRollbackMarker();
     }
 
     @Override
@@ -422,22 +433,23 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                 } catch (Exception exception) {
                     LOG.trace("Timeout {} with jobId {} will be retried if possible", timerId, jobId, exception);
 
-                    // CRITICAL: Mark the current transaction for rollback FIRST
-                    // This ensures user task JPA changes are rolled back
+                    // Mark the current transaction for rollback
                     markTransactionForRollback();
 
                     JobDetails nextJobDetails = doRetryOrError(jobDetails, exception);
 
-                    // For RETRY and ERROR status, we need to reconcile in a NEW transaction
-                    // because the current transaction is now marked for rollback.
-                    if (nextJobDetails.getStatus() == JobStatus.RETRY || nextJobDetails.getStatus() == JobStatus.ERROR) {
+                    // For RETRY and ERROR status, check if we need to reconcile in a NEW transaction
+                    // Only do this if there's an active transaction that was marked for rollback
+                    if ((nextJobDetails.getStatus() == JobStatus.RETRY || nextJobDetails.getStatus() == JobStatus.ERROR)
+                            && transactionRollbackMarker != null && transactionRollbackMarker.isTransactionActive()) {
                         scheduleReconciliationInNewTransaction(timerId, nextJobDetails);
                     } else {
-                        // For other statuses, reconcile normally
+                        // For other statuses or when no transaction is active, reconcile normally
                         reconcileScheduling(timerId, jobContext, nextJobDetails);
                     }
 
                     jobSchedulerListeners.forEach(l -> l.onFailure(jobDetails));
+
                     return new JobTimeoutExecution(nextJobDetails, exception);
                 }
 
@@ -457,13 +469,10 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
         String jobId = jobDetails.getId();
 
         // Schedule the reconciliation to run asynchronously in a new transaction
-        // Use vertx executeBlocking to run in a worker thread with a new transaction context
         vertx.executeBlocking(promise -> {
             try {
-                // Create a new job context for the new transaction
                 JobContext newJobContext = jobContextFactory.newContext();
 
-                // Create a callable that will be wrapped by transaction interceptors
                 Callable<Void> reconciliationTask = () -> {
                     reconcileScheduling(timerId, newJobContext, jobDetails);
                     return null;
@@ -474,7 +483,6 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                 for (JobTimeoutInterceptor interceptor : interceptors) {
                     final Callable<Void> currentTask = wrappedTask;
                     wrappedTask = () -> {
-                        // Wrap in a callable that returns Void instead of JobTimeoutExecution
                         interceptor.chainIntercept(() -> {
                             currentTask.call();
                             return new JobTimeoutExecution(jobDetails);
@@ -483,7 +491,6 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                     };
                 }
 
-                // Execute the wrapped task
                 wrappedTask.call();
 
                 promise.complete();
@@ -713,45 +720,13 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
     }
 
     /**
-     * Marks the current transaction for rollback using reflection to support both Quarkus and Spring Boot.
-     * This ensures that any changes made in the current transaction (like user task JPA operations)
-     * are rolled back, while allowing retry logic to execute in a new transaction.
+     * Marks the current transaction for rollback using the injected TransactionRollbackMarker.
      */
     private void markTransactionForRollback() {
-        try {
-            // Try Quarkus/Narayana first (com.arjuna.ats.jta.TransactionManager)
-            Class<?> tmClass = Class.forName("com.arjuna.ats.jta.TransactionManager");
-            java.lang.reflect.Method getTransactionManagerMethod = tmClass.getMethod("transactionManager");
-            Object tm = getTransactionManagerMethod.invoke(null);
-
-            if (tm != null) {
-                java.lang.reflect.Method getTransactionMethod = tm.getClass().getMethod("getTransaction");
-                Object transaction = getTransactionMethod.invoke(tm);
-
-                if (transaction != null) {
-                    java.lang.reflect.Method setRollbackOnlyMethod = tm.getClass().getMethod("setRollbackOnly");
-                    setRollbackOnlyMethod.invoke(tm);
-                    LOG.debug("Marked transaction for rollback due to exception in job execution (Quarkus/Narayana)");
-                    return;
-                }
-            }
-        } catch (ClassNotFoundException e) {
-            // Narayana not available, try Spring Boot
-            LOG.trace("Narayana TransactionManager not found, trying Spring Boot");
-        } catch (Exception e) {
-            LOG.warn("Failed to mark transaction for rollback using Narayana", e);
-        }
-
-        try {
-            // Try Spring Boot (org.springframework.transaction.support.TransactionSynchronizationManager)
-            Class<?> tsmClass = Class.forName("org.springframework.transaction.support.TransactionSynchronizationManager");
-            java.lang.reflect.Method setRollbackOnlyMethod = tsmClass.getMethod("setRollbackOnly");
-            setRollbackOnlyMethod.invoke(null);
-            LOG.debug("Marked transaction for rollback due to exception in job execution (Spring Boot)");
-        } catch (ClassNotFoundException e) {
-            LOG.trace("Spring TransactionSynchronizationManager not found");
-        } catch (Exception e) {
-            LOG.warn("Failed to mark transaction for rollback using Spring Boot", e);
+        if (transactionRollbackMarker != null) {
+            transactionRollbackMarker.markForRollback();
+        } else {
+            LOG.warn("No TransactionRollbackMarker configured. Transaction rollback marking is not supported.");
         }
     }
 

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -437,11 +437,8 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                     markTransactionForRollbackWhenEnabled();
 
                     JobDetails nextJobDetails = doRetryOrError(jobDetails, exception);
-
                     reconcileScheduling(timerId, jobContext, nextJobDetails);
-
                     jobSchedulerListeners.forEach(l -> l.onFailure(jobDetails));
-
                     return new JobTimeoutExecution(nextJobDetails, exception);
                 }
 
@@ -467,63 +464,38 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             // Current transaction will be rolled back, so schedule retry in a new transaction
             LOG.trace("Job {} with status {} will be scheduled in new transaction", jobId, status);
 
-            vertx.executeBlocking(promise -> {
-                try {
-                    JobContext newJobContext = jobContextFactory.newContext();
+            JobContext newJobContext = jobContextFactory.newContext();
 
-                    Callable<Void> newTransactionTask = () -> {
-                        jobStore.update(newJobContext, jobDetails);
-                        fireEvents(jobDetails); // Fire events after rollback
-                        // Schedule timer in new transaction after persistence
-                        if (status == JobStatus.RETRY) {
-                            addOrUpdateTxTimer(jobDetails);
-                        } else {
-                            removeTxTimer(jobDetails);
-                        }
-                        return null;
-                    };
-
-                    // Apply transaction interceptors to ensure this runs in a new transaction
-                    Callable<Void> wrappedTask = newTransactionTask;
-                    for (JobTimeoutInterceptor interceptor : interceptors) {
-                        final Callable<Void> currentTask = wrappedTask;
-                        wrappedTask = () -> {
-                            interceptor.chainIntercept(() -> {
-                                currentTask.call();
-                                return new JobTimeoutExecution(jobDetails);
-                            }).call();
-                            return null;
-                        };
-                    }
-
-                    wrappedTask.call();
-                    promise.complete();
-                } catch (Exception e) {
-                    LOG.error("Failed to schedule retry for job {} in new transaction", jobId, e);
-                    promise.fail(e);
+            Callable<JobTimeoutExecution> newTransactionTask = () -> {
+                jobStore.update(newJobContext, jobDetails);
+                fireEvents(jobDetails); // Fire events after rollback
+                // Schedule timer in new transaction after persistence
+                if (status == JobStatus.RETRY) {
+                    addOrUpdateTxTimer(jobDetails);
+                } else {
+                    removeTxTimer(jobDetails);
                 }
-            }, false, result -> {
-                if (result.failed()) {
-                    LOG.error("Async retry scheduling failed for job {}", jobId, result.cause());
-                }
-            });
+                return new JobTimeoutExecution(jobDetails);
+            };
+
+            // Apply transaction interceptors to ensure this runs in a new transaction
+            for (JobTimeoutInterceptor interceptor : interceptors) {
+                newTransactionTask = interceptor.chainIntercept(newTransactionTask);
+            }
+
+            vertx.executeBlocking(newTransactionTask, false)
+                    .onFailure(e -> LOG.error("Async retry scheduling failed for job {}", jobId, e));
         } else {
             // No active transaction or transaction not marked for rollback
             LOG.trace("Job {} with status {} will be scheduled", jobId, status);
 
             try {
                 jobStore.update(jobContext, jobDetails);
-                // Fire events AFTER persistence to ensure Data Index can query the updated job
                 fireEvents(jobDetails);
-                // Schedule timer AFTER persistence (no transaction synchronization needed)
                 if (status == JobStatus.RETRY) {
-                    addTimerInfo(jobDetails);
+                    addOrUpdateTxTimer(jobDetails);
                 } else {
-                    String mapKey = getMapKey(jobDetails);
-                    TimerInfo timerInfo = jobsScheduled.remove(mapKey);
-                    if (timerInfo != null) {
-                        removeTimerInfo(timerInfo);
-                    }
+                    removeTxTimer(jobDetails);
                 }
             } catch (Exception e) {
                 LOG.error("Failed to schedule retry for job {}", jobId, e);

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -422,7 +422,16 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                 } catch (Exception exception) {
                     LOG.trace("Timeout {} with jobId {} will be retried if possible", timerId, jobId, exception);
                     JobDetails nextJobDetails = doRetryOrError(jobDetails, exception);
-                    reconcileScheduling(timerId, jobContext, nextJobDetails);
+
+                    // For RETRY and ERROR status, we need to reconcile in a NEW transaction
+                    // because the current transaction may be marked for rollback due to the exception.
+                    if (nextJobDetails.getStatus() == JobStatus.RETRY || nextJobDetails.getStatus() == JobStatus.ERROR) {
+                        scheduleReconciliationInNewTransaction(timerId, nextJobDetails);
+                    } else {
+                        // For other statuses, reconcile normally
+                        reconcileScheduling(timerId, jobContext, nextJobDetails);
+                    }
+
                     jobSchedulerListeners.forEach(l -> l.onFailure(jobDetails));
                     return new JobTimeoutExecution(nextJobDetails, exception);
                 }
@@ -433,6 +442,55 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             current = interceptor.chainIntercept(current);
         }
         return current;
+    }
+
+    /**
+     * Schedules reconciliation to happen in a new transaction after the current one completes.
+     * This is necessary when the current transaction is marked for rollback due to an exception.
+     */
+    private void scheduleReconciliationInNewTransaction(Long timerId, JobDetails jobDetails) {
+        String jobId = jobDetails.getId();
+
+        // Schedule the reconciliation to run asynchronously in a new transaction
+        // Use vertx executeBlocking to run in a worker thread with a new transaction context
+        vertx.executeBlocking(promise -> {
+            try {
+                // Create a new job context for the new transaction
+                JobContext newJobContext = jobContextFactory.newContext();
+
+                // Create a callable that will be wrapped by transaction interceptors
+                Callable<Void> reconciliationTask = () -> {
+                    reconcileScheduling(timerId, newJobContext, jobDetails);
+                    return null;
+                };
+
+                // Apply transaction interceptors to ensure this runs in a new transaction
+                Callable<Void> wrappedTask = reconciliationTask;
+                for (JobTimeoutInterceptor interceptor : interceptors) {
+                    final Callable<Void> currentTask = wrappedTask;
+                    wrappedTask = () -> {
+                        // Wrap in a callable that returns Void instead of JobTimeoutExecution
+                        interceptor.chainIntercept(() -> {
+                            currentTask.call();
+                            return new JobTimeoutExecution(jobDetails);
+                        }).call();
+                        return null;
+                    };
+                }
+
+                // Execute the wrapped task
+                wrappedTask.call();
+
+                promise.complete();
+            } catch (Exception e) {
+                LOG.error("Failed to reconcile job {} in new transaction", jobId, e);
+                promise.fail(e);
+            }
+        }, false, result -> {
+            if (result.failed()) {
+                LOG.error("Async reconciliation failed for job {}", jobId, result.cause());
+            }
+        });
     }
 
     private void reconcileScheduling(Long timerId, JobContext jobContext, JobDetails nextJobDetails) {

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -466,17 +466,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
 
             JobContext newJobContext = jobContextFactory.newContext();
 
-            Callable<JobTimeoutExecution> newTransactionTask = () -> {
-                jobStore.update(newJobContext, jobDetails);
-                fireEvents(jobDetails); // Fire events after rollback
-                // Schedule timer in new transaction after persistence
-                if (status == JobStatus.RETRY) {
-                    addOrUpdateTxTimer(jobDetails);
-                } else {
-                    removeTxTimer(jobDetails);
-                }
-                return new JobTimeoutExecution(jobDetails);
-            };
+            Callable<JobTimeoutExecution> newTransactionTask = () -> persistAndSchedule(newJobContext, jobDetails, status);
 
             // Apply transaction interceptors to ensure this runs in a new transaction
             for (JobTimeoutInterceptor interceptor : interceptors) {
@@ -490,17 +480,23 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             LOG.trace("Job {} with status {} will be scheduled", jobId, status);
 
             try {
-                jobStore.update(jobContext, jobDetails);
-                fireEvents(jobDetails);
-                if (status == JobStatus.RETRY) {
-                    addOrUpdateTxTimer(jobDetails);
-                } else {
-                    removeTxTimer(jobDetails);
-                }
+                persistAndSchedule(jobContext, jobDetails, status);
             } catch (Exception e) {
                 LOG.error("Failed to schedule retry for job {}", jobId, e);
             }
         }
+    }
+
+    private JobTimeoutExecution persistAndSchedule(JobContext jobContext, JobDetails jobDetails, JobStatus status) throws Exception {
+        jobStore.update(jobContext, jobDetails);
+        fireEvents(jobDetails);
+        // Schedule timer after persistence
+        if (status == JobStatus.RETRY) {
+            addOrUpdateTxTimer(jobDetails);
+        } else {
+            removeTxTimer(jobDetails);
+        }
+        return new JobTimeoutExecution(jobDetails);
     }
 
     private void reconcileScheduling(Long timerId, JobContext jobContext, JobDetails nextJobDetails) {

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -434,17 +434,13 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                     LOG.trace("Timeout {} with jobId {} will be retried if possible", timerId, jobId, exception);
 
                     // Mark the current transaction for rollback
-                    markTransactionForRollback();
+                    markTransactionForRollbackWhenEnabled();
 
                     JobDetails nextJobDetails = doRetryOrError(jobDetails, exception);
 
-                    // For RETRY and ERROR status, check if we need to reconcile in a NEW transaction
-                    // Only do this if there's an active transaction that was marked for rollback
-                    if ((nextJobDetails.getStatus() == JobStatus.RETRY || nextJobDetails.getStatus() == JobStatus.ERROR)
-                            && transactionRollbackMarker != null && transactionRollbackMarker.isTransactionActive()) {
+                    if (shouldReconcileInNewTransaction(nextJobDetails)) {
                         scheduleReconciliationInNewTransaction(timerId, nextJobDetails);
                     } else {
-                        // For other statuses or when no transaction is active, reconcile normally
                         reconcileScheduling(timerId, jobContext, nextJobDetails, false);
                     }
 
@@ -459,6 +455,14 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             current = interceptor.chainIntercept(current);
         }
         return current;
+    }
+
+    private boolean shouldReconcileInNewTransaction(JobDetails jobDetails) {
+        // For RETRY and ERROR status, check if we need to reconcile in a NEW transaction
+        // Only do this if there's an active transaction that was marked for rollback
+        return (jobDetails.getStatus() == JobStatus.RETRY || jobDetails.getStatus() == JobStatus.ERROR)
+                && transactionRollbackMarker != null
+                && transactionRollbackMarker.isTransactionActive();
     }
 
     /**
@@ -519,14 +523,8 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             case RETRY:
                 LOG.trace("Timeout {} with jobId {} will be updated and scheduled", timerId, jobId);
                 addOrUpdateTxTimer(nextJobDetails);
-                // Use persist instead of update to handle case where transaction was rolled back
-                // and job record no longer exists in database
-                JobDetails existing = jobStore.find(jobContext, jobId);
-                if (existing != null) {
-                    jobStore.update(jobContext, nextJobDetails);
-                } else {
-                    jobStore.persist(jobContext, nextJobDetails);
-                }
+                // EntityManager.merge() handles both insert and update automatically
+                jobStore.update(jobContext, nextJobDetails);
                 // Fire events only if we're reconciling after a rollback
                 // (events from original transaction were lost)
                 if (afterRollback) {
@@ -536,14 +534,8 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             case ERROR:
                 LOG.trace("Timeout {} with jobId {} will be set to error", timerId, jobId);
                 removeTxTimer(nextJobDetails);
-                // Use persist instead of update to handle case where transaction was rolled back
-                // and job record no longer exists in database
-                JobDetails existingError = jobStore.find(jobContext, jobId);
-                if (existingError != null) {
-                    jobStore.update(jobContext, nextJobDetails);
-                } else {
-                    jobStore.persist(jobContext, nextJobDetails);
-                }
+                // EntityManager.merge() handles both insert and update automatically
+                jobStore.update(jobContext, nextJobDetails);
                 // Fire events only if we're reconciling after a rollback
                 // (events from original transaction were lost)
                 if (afterRollback) {
@@ -747,7 +739,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
     /**
      * Marks the current transaction for rollback using the injected TransactionRollbackMarker.
      */
-    private void markTransactionForRollback() {
+    private void markTransactionForRollbackWhenEnabled() {
         if (transactionRollbackMarker != null) {
             transactionRollbackMarker.markForRollback();
         } else {

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -421,10 +421,15 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                     return new JobTimeoutExecution(nextJobDetails);
                 } catch (Exception exception) {
                     LOG.trace("Timeout {} with jobId {} will be retried if possible", timerId, jobId, exception);
+
+                    // CRITICAL: Mark the current transaction for rollback FIRST
+                    // This ensures user task JPA changes are rolled back
+                    markTransactionForRollback();
+
                     JobDetails nextJobDetails = doRetryOrError(jobDetails, exception);
 
                     // For RETRY and ERROR status, we need to reconcile in a NEW transaction
-                    // because the current transaction may be marked for rollback due to the exception.
+                    // because the current transaction is now marked for rollback.
                     if (nextJobDetails.getStatus() == JobStatus.RETRY || nextJobDetails.getStatus() == JobStatus.ERROR) {
                         scheduleReconciliationInNewTransaction(timerId, nextJobDetails);
                     } else {
@@ -704,6 +709,49 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
         List<DataEvent<byte[]>> jobInstanceEvents = jobEventAdapters.stream().filter(e -> e.accept(jobDetails)).map(e -> e.adapt(jobDetails)).toList();
         for (DataEvent<byte[]> jobEvent : jobInstanceEvents) {
             eventPublishers.forEach(e -> e.publish(jobEvent));
+        }
+    }
+
+    /**
+     * Marks the current transaction for rollback using reflection to support both Quarkus and Spring Boot.
+     * This ensures that any changes made in the current transaction (like user task JPA operations)
+     * are rolled back, while allowing retry logic to execute in a new transaction.
+     */
+    private void markTransactionForRollback() {
+        try {
+            // Try Quarkus/Narayana first (com.arjuna.ats.jta.TransactionManager)
+            Class<?> tmClass = Class.forName("com.arjuna.ats.jta.TransactionManager");
+            java.lang.reflect.Method getTransactionManagerMethod = tmClass.getMethod("transactionManager");
+            Object tm = getTransactionManagerMethod.invoke(null);
+
+            if (tm != null) {
+                java.lang.reflect.Method getTransactionMethod = tm.getClass().getMethod("getTransaction");
+                Object transaction = getTransactionMethod.invoke(tm);
+
+                if (transaction != null) {
+                    java.lang.reflect.Method setRollbackOnlyMethod = tm.getClass().getMethod("setRollbackOnly");
+                    setRollbackOnlyMethod.invoke(tm);
+                    LOG.debug("Marked transaction for rollback due to exception in job execution (Quarkus/Narayana)");
+                    return;
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            // Narayana not available, try Spring Boot
+            LOG.trace("Narayana TransactionManager not found, trying Spring Boot");
+        } catch (Exception e) {
+            LOG.warn("Failed to mark transaction for rollback using Narayana", e);
+        }
+
+        try {
+            // Try Spring Boot (org.springframework.transaction.support.TransactionSynchronizationManager)
+            Class<?> tsmClass = Class.forName("org.springframework.transaction.support.TransactionSynchronizationManager");
+            java.lang.reflect.Method setRollbackOnlyMethod = tsmClass.getMethod("setRollbackOnly");
+            setRollbackOnlyMethod.invoke(null);
+            LOG.debug("Marked transaction for rollback due to exception in job execution (Spring Boot)");
+        } catch (ClassNotFoundException e) {
+            LOG.trace("Spring TransactionSynchronizationManager not found");
+        } catch (Exception e) {
+            LOG.warn("Failed to mark transaction for rollback using Spring Boot", e);
         }
     }
 

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -401,7 +401,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
 
     private void timeout(Long timerId, String jobId) {
         LOG.debug("Executing timeout with timer Id {} and jobId {}", timerId, jobId);
-        workerExecutor.executeBlocking(newTimeoutTask(timerId, jobId));
+        workerExecutor.executeBlocking(newTimeoutTask(timerId, jobId), false);
     }
 
     private Callable<JobTimeoutExecution> newTimeoutTask(Long timerId, String jobId) {

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -396,7 +396,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
         JobDetails jobDetails = jobStore.find(jobContext, jobId);
         JobDetails cancelledJobDetails = doCancel(jobDetails);
         jobSchedulerListeners.forEach(l -> l.onCancel(cancelledJobDetails));
-        reconcileScheduling(null, jobContext, cancelledJobDetails);
+        reconcileScheduling(null, jobContext, cancelledJobDetails, false);
     }
 
     private void timeout(Long timerId, String jobId) {
@@ -427,7 +427,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                     JobDetails executeJobDetails = doExecute(runningJobDetails);
                     LOG.trace("Timeout {} with jobId {} will be rescheduled if required", timerId, jobId);
                     JobDetails nextJobDetails = computeAndScheduleNextJobIfAny(executeJobDetails);
-                    reconcileScheduling(timerId, jobContext, nextJobDetails);
+                    reconcileScheduling(timerId, jobContext, nextJobDetails, false);
                     jobSchedulerListeners.forEach(l -> l.onExecution(jobDetails));
                     return new JobTimeoutExecution(nextJobDetails);
                 } catch (Exception exception) {
@@ -445,7 +445,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                         scheduleReconciliationInNewTransaction(timerId, nextJobDetails);
                     } else {
                         // For other statuses or when no transaction is active, reconcile normally
-                        reconcileScheduling(timerId, jobContext, nextJobDetails);
+                        reconcileScheduling(timerId, jobContext, nextJobDetails, false);
                     }
 
                     jobSchedulerListeners.forEach(l -> l.onFailure(jobDetails));
@@ -469,12 +469,13 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
         String jobId = jobDetails.getId();
 
         // Schedule the reconciliation to run asynchronously in a new transaction
+        // This must be async to avoid deadlock with the current transaction
         vertx.executeBlocking(promise -> {
             try {
                 JobContext newJobContext = jobContextFactory.newContext();
 
                 Callable<Void> reconciliationTask = () -> {
-                    reconcileScheduling(timerId, newJobContext, jobDetails);
+                    reconcileScheduling(timerId, newJobContext, jobDetails, true);
                     return null;
                 };
 
@@ -505,7 +506,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
         });
     }
 
-    private void reconcileScheduling(Long timerId, JobContext jobContext, JobDetails nextJobDetails) {
+    private void reconcileScheduling(Long timerId, JobContext jobContext, JobDetails nextJobDetails, boolean afterRollback) {
         String jobId = nextJobDetails.getId();
         switch (nextJobDetails.getStatus()) {
             case EXECUTED:
@@ -518,12 +519,36 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             case RETRY:
                 LOG.trace("Timeout {} with jobId {} will be updated and scheduled", timerId, jobId);
                 addOrUpdateTxTimer(nextJobDetails);
-                jobStore.update(jobContext, nextJobDetails);
+                // Use persist instead of update to handle case where transaction was rolled back
+                // and job record no longer exists in database
+                JobDetails existing = jobStore.find(jobContext, jobId);
+                if (existing != null) {
+                    jobStore.update(jobContext, nextJobDetails);
+                } else {
+                    jobStore.persist(jobContext, nextJobDetails);
+                }
+                // Fire events only if we're reconciling after a rollback
+                // (events from original transaction were lost)
+                if (afterRollback) {
+                    fireEvents(nextJobDetails);
+                }
                 break;
             case ERROR:
                 LOG.trace("Timeout {} with jobId {} will be set to error", timerId, jobId);
                 removeTxTimer(nextJobDetails);
-                jobStore.update(jobContext, nextJobDetails);
+                // Use persist instead of update to handle case where transaction was rolled back
+                // and job record no longer exists in database
+                JobDetails existingError = jobStore.find(jobContext, jobId);
+                if (existingError != null) {
+                    jobStore.update(jobContext, nextJobDetails);
+                } else {
+                    jobStore.persist(jobContext, nextJobDetails);
+                }
+                // Fire events only if we're reconciling after a rollback
+                // (events from original transaction were lost)
+                if (afterRollback) {
+                    fireEvents(nextJobDetails);
+                }
                 break;
             default:
                 LOG.trace("Timeout {} with jobId {} is RUNNING and should not happen", timerId, jobId);

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/impl/VertxJobScheduler.java
@@ -396,7 +396,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
         JobDetails jobDetails = jobStore.find(jobContext, jobId);
         JobDetails cancelledJobDetails = doCancel(jobDetails);
         jobSchedulerListeners.forEach(l -> l.onCancel(cancelledJobDetails));
-        reconcileScheduling(null, jobContext, cancelledJobDetails, false);
+        reconcileScheduling(null, jobContext, cancelledJobDetails);
     }
 
     private void timeout(Long timerId, String jobId) {
@@ -427,7 +427,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                     JobDetails executeJobDetails = doExecute(runningJobDetails);
                     LOG.trace("Timeout {} with jobId {} will be rescheduled if required", timerId, jobId);
                     JobDetails nextJobDetails = computeAndScheduleNextJobIfAny(executeJobDetails);
-                    reconcileScheduling(timerId, jobContext, nextJobDetails, false);
+                    reconcileScheduling(timerId, jobContext, nextJobDetails);
                     jobSchedulerListeners.forEach(l -> l.onExecution(jobDetails));
                     return new JobTimeoutExecution(nextJobDetails);
                 } catch (Exception exception) {
@@ -438,11 +438,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
 
                     JobDetails nextJobDetails = doRetryOrError(jobDetails, exception);
 
-                    if (shouldReconcileInNewTransaction(nextJobDetails)) {
-                        scheduleReconciliationInNewTransaction(timerId, nextJobDetails);
-                    } else {
-                        reconcileScheduling(timerId, jobContext, nextJobDetails, false);
-                    }
+                    reconcileScheduling(timerId, jobContext, nextJobDetails);
 
                     jobSchedulerListeners.forEach(l -> l.onFailure(jobDetails));
 
@@ -457,60 +453,85 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
         return current;
     }
 
-    private boolean shouldReconcileInNewTransaction(JobDetails jobDetails) {
-        // For RETRY and ERROR status, check if we need to reconcile in a NEW transaction
-        // Only do this if there's an active transaction that was marked for rollback
-        return (jobDetails.getStatus() == JobStatus.RETRY || jobDetails.getStatus() == JobStatus.ERROR)
-                && transactionRollbackMarker != null
-                && transactionRollbackMarker.isTransactionActive();
-    }
-
     /**
-     * Schedules reconciliation to happen in a new transaction after the current one completes.
-     * This is necessary when the current transaction is marked for rollback due to an exception.
+     * Handles retry scheduling for RETRY and ERROR job statuses.
+     * If there's an active transaction that was marked for rollback, schedules the retry
+     * in a new transaction. Otherwise, persists the job immediately.
      */
-    private void scheduleReconciliationInNewTransaction(Long timerId, JobDetails jobDetails) {
+    private void scheduleRetry(JobContext jobContext, JobDetails jobDetails) {
         String jobId = jobDetails.getId();
+        JobStatus status = jobDetails.getStatus();
 
-        // Schedule the reconciliation to run asynchronously in a new transaction
-        // This must be async to avoid deadlock with the current transaction
-        vertx.executeBlocking(promise -> {
-            try {
-                JobContext newJobContext = jobContextFactory.newContext();
+        // Check if we need to execute in a new transaction
+        if (transactionRollbackMarker != null && transactionRollbackMarker.isTransactionActive()) {
+            // Current transaction will be rolled back, so schedule retry in a new transaction
+            LOG.trace("Job {} with status {} will be scheduled in new transaction", jobId, status);
 
-                Callable<Void> reconciliationTask = () -> {
-                    reconcileScheduling(timerId, newJobContext, jobDetails, true);
-                    return null;
-                };
+            vertx.executeBlocking(promise -> {
+                try {
+                    JobContext newJobContext = jobContextFactory.newContext();
 
-                // Apply transaction interceptors to ensure this runs in a new transaction
-                Callable<Void> wrappedTask = reconciliationTask;
-                for (JobTimeoutInterceptor interceptor : interceptors) {
-                    final Callable<Void> currentTask = wrappedTask;
-                    wrappedTask = () -> {
-                        interceptor.chainIntercept(() -> {
-                            currentTask.call();
-                            return new JobTimeoutExecution(jobDetails);
-                        }).call();
+                    Callable<Void> newTransactionTask = () -> {
+                        jobStore.update(newJobContext, jobDetails);
+                        fireEvents(jobDetails); // Fire events after rollback
+                        // Schedule timer in new transaction after persistence
+                        if (status == JobStatus.RETRY) {
+                            addOrUpdateTxTimer(jobDetails);
+                        } else {
+                            removeTxTimer(jobDetails);
+                        }
                         return null;
                     };
+
+                    // Apply transaction interceptors to ensure this runs in a new transaction
+                    Callable<Void> wrappedTask = newTransactionTask;
+                    for (JobTimeoutInterceptor interceptor : interceptors) {
+                        final Callable<Void> currentTask = wrappedTask;
+                        wrappedTask = () -> {
+                            interceptor.chainIntercept(() -> {
+                                currentTask.call();
+                                return new JobTimeoutExecution(jobDetails);
+                            }).call();
+                            return null;
+                        };
+                    }
+
+                    wrappedTask.call();
+                    promise.complete();
+                } catch (Exception e) {
+                    LOG.error("Failed to schedule retry for job {} in new transaction", jobId, e);
+                    promise.fail(e);
                 }
+            }, false, result -> {
+                if (result.failed()) {
+                    LOG.error("Async retry scheduling failed for job {}", jobId, result.cause());
+                }
+            });
+        } else {
+            // No active transaction or transaction not marked for rollback
+            LOG.trace("Job {} with status {} will be scheduled", jobId, status);
 
-                wrappedTask.call();
-
-                promise.complete();
+            try {
+                jobStore.update(jobContext, jobDetails);
+                // Fire events AFTER persistence to ensure Data Index can query the updated job
+                fireEvents(jobDetails);
+                // Schedule timer AFTER persistence (no transaction synchronization needed)
+                if (status == JobStatus.RETRY) {
+                    addTimerInfo(jobDetails);
+                } else {
+                    String mapKey = getMapKey(jobDetails);
+                    TimerInfo timerInfo = jobsScheduled.remove(mapKey);
+                    if (timerInfo != null) {
+                        removeTimerInfo(timerInfo);
+                    }
+                }
             } catch (Exception e) {
-                LOG.error("Failed to reconcile job {} in new transaction", jobId, e);
-                promise.fail(e);
+                LOG.error("Failed to schedule retry for job {}", jobId, e);
             }
-        }, false, result -> {
-            if (result.failed()) {
-                LOG.error("Async reconciliation failed for job {}", jobId, result.cause());
-            }
-        });
+        }
     }
 
-    private void reconcileScheduling(Long timerId, JobContext jobContext, JobDetails nextJobDetails, boolean afterRollback) {
+    private void reconcileScheduling(Long timerId, JobContext jobContext, JobDetails nextJobDetails) {
         String jobId = nextJobDetails.getId();
         switch (nextJobDetails.getStatus()) {
             case EXECUTED:
@@ -520,27 +541,13 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
                 jobStore.remove(jobContext, jobId);
                 break;
             case SCHEDULED:
-            case RETRY:
                 LOG.trace("Timeout {} with jobId {} will be updated and scheduled", timerId, jobId);
                 addOrUpdateTxTimer(nextJobDetails);
-                // EntityManager.merge() handles both insert and update automatically
                 jobStore.update(jobContext, nextJobDetails);
-                // Fire events only if we're reconciling after a rollback
-                // (events from original transaction were lost)
-                if (afterRollback) {
-                    fireEvents(nextJobDetails);
-                }
                 break;
+            case RETRY:
             case ERROR:
-                LOG.trace("Timeout {} with jobId {} will be set to error", timerId, jobId);
-                removeTxTimer(nextJobDetails);
-                // EntityManager.merge() handles both insert and update automatically
-                jobStore.update(jobContext, nextJobDetails);
-                // Fire events only if we're reconciling after a rollback
-                // (events from original transaction were lost)
-                if (afterRollback) {
-                    fireEvents(nextJobDetails);
-                }
+                scheduleRetry(jobContext, nextJobDetails);
                 break;
             default:
                 LOG.trace("Timeout {} with jobId {} is RUNNING and should not happen", timerId, jobId);
@@ -640,7 +647,7 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
 
     private JobDetails doRetryOrError(JobDetails jobDetails, Exception exception) {
         Integer retryCounter = jobDetails.getRetries();
-        // First, create the next JobDetails (RETRY or ERROR) without firing events
+        // Create the next JobDetails (RETRY or ERROR)
         JobDetails nextJobDetails;
         if (retryCounter < this.maxNumberOfRetries) {
             LOG.trace("doRetryOrError: Job {} will be retried (retry {} of {})", jobDetails.getId(), retryCounter + 1, maxNumberOfRetries);
@@ -649,11 +656,10 @@ public class VertxJobScheduler implements JobScheduler, Handler<Long> {
             LOG.trace("doRetryOrError: Job {} exceeded max retries ({}) and will transition to ERROR", jobDetails.getId(), maxNumberOfRetries);
             nextJobDetails = createErrorJobDetails(jobDetails);
         }
-        // Then extract and set exception details BEFORE firing events
+        // Extract and set exception details
         extractAndSetExceptionDetails(nextJobDetails, exception);
         LOG.trace("doRetryOrError: Created {} with exception details: {}", nextJobDetails.getStatus(), nextJobDetails);
-        // Finally fire events with exception details already set
-        fireEvents(nextJobDetails);
+        // Events will be fired in scheduleRetry() after persistence
         return nextJobDetails;
     }
 

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/ErrorHandlingJobTimeoutInterceptor.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/integrations/ErrorHandlingJobTimeoutInterceptor.java
@@ -41,7 +41,9 @@ public class ErrorHandlingJobTimeoutInterceptor implements JobTimeoutInterceptor
 
     @Override
     public Integer priority() {
-        return 50;
+        // Priority 5 ensures this runs OUTSIDE the transaction interceptor (priority 10)
+        // This allows error handling to occur after transaction rollback
+        return 5;
     }
 
     @Override

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/spi/NoOpTransactionRollbackMarker.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/spi/NoOpTransactionRollbackMarker.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.spi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * No-op implementation of TransactionRollbackMarker that does nothing.
+ */
+public class NoOpTransactionRollbackMarker implements TransactionRollbackMarker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NoOpTransactionRollbackMarker.class);
+
+    @Override
+    public void markForRollback() {
+        LOG.warn("No platform-specific TransactionRollbackMarker implementation found. " +
+                "Transaction rollback marking is not supported. " +
+                "Please ensure a Quarkus or Spring Boot specific implementation is available.");
+    }
+
+    @Override
+    public boolean isTransactionActive() {
+        return false;
+    }
+}

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/spi/TransactionRollbackMarker.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/spi/TransactionRollbackMarker.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.spi;
+
+/**
+ * Interface for marking the current transaction for rollback.
+ * This is used when a job execution fails and needs to be retried, ensuring that
+ * any changes made during the failed execution are rolled back before the retry attempt.
+ */
+public interface TransactionRollbackMarker {
+
+    /**
+     * Marks the current transaction for rollback. 
+     * If no transaction is active, this method should do nothing.
+     */
+    void markForRollback();
+
+    /**
+     * Checks if a transaction is currently active.
+     * 
+     * @return true if a transaction is active, false otherwise
+     */
+    boolean isTransactionActive();
+}
+

--- a/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/spi/TransactionRollbackMarker.java
+++ b/jobs/jobs-common-embedded/src/main/java/org/kie/kogito/app/jobs/spi/TransactionRollbackMarker.java
@@ -26,7 +26,7 @@ package org.kie.kogito.app.jobs.spi;
 public interface TransactionRollbackMarker {
 
     /**
-     * Marks the current transaction for rollback. 
+     * Marks the current transaction for rollback.
      * If no transaction is active, this method should do nothing.
      */
     void markForRollback();
@@ -38,4 +38,3 @@ public interface TransactionRollbackMarker {
      */
     boolean isTransactionActive();
 }
-

--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/QuarkusJobsService.java
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/QuarkusJobsService.java
@@ -31,6 +31,7 @@ import org.kie.kogito.app.jobs.integrations.UserTaskInstanceJobDescriptionJobIns
 import org.kie.kogito.app.jobs.quarkus.resource.RestApiConstants;
 import org.kie.kogito.app.jobs.spi.JobContextFactory;
 import org.kie.kogito.app.jobs.spi.JobStore;
+import org.kie.kogito.app.jobs.spi.TransactionRollbackMarker;
 import org.kie.kogito.event.EventPublisher;
 import org.kie.kogito.handler.ExceptionHandler;
 import org.kie.kogito.jobs.JobDescription;
@@ -94,6 +95,9 @@ public class QuarkusJobsService implements JobsService {
     @Inject
     WrappingConditionalJobExceptionDetailsExtractor exceptionDetailsExtractor;
 
+    @Inject
+    TransactionRollbackMarker transactionRollbackMarker;
+
     @PostConstruct
     public void init() {
         this.jobScheduler = JobSchedulerBuilder.newJobSchedulerBuilder()
@@ -114,6 +118,7 @@ public class QuarkusJobsService implements JobsService {
                         new TransactionJobTimeoutInterceptor(),
                         new ErrorHandlingJobTimeoutInterceptor(exceptionHandlers.stream().toList()))
                 .withExceptionDetailsExtractor(exceptionDetailsExtractor)
+                .withTransactionRollbackMarker(transactionRollbackMarker)
                 .withNumberOfWorkerThreads(numberOfWorkerThreads)
                 .withJobSynchronization(new JobSynchronization() {
 

--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/QuarkusTransactionRollbackMarker.java
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/QuarkusTransactionRollbackMarker.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.quarkus;
+
+import org.kie.kogito.app.jobs.spi.TransactionRollbackMarker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+
+@ApplicationScoped
+public class QuarkusTransactionRollbackMarker implements TransactionRollbackMarker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QuarkusTransactionRollbackMarker.class);
+
+    private final TransactionManager transactionManager;
+
+    public QuarkusTransactionRollbackMarker(TransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
+
+    @Override
+    public void markForRollback() {
+        try {
+            if (transactionManager != null && isTransactionActive()) {
+                transactionManager.setRollbackOnly();
+                LOG.debug("Marked transaction for rollback due to exception in job execution (Quarkus/Narayana)");
+            } else {
+                LOG.trace("No active transaction to mark for rollback");
+            }
+        } catch (SystemException e) {
+            LOG.warn("Failed to mark transaction for rollback", e);
+        }
+    }
+
+    @Override
+    public boolean isTransactionActive() {
+        try {
+            if (transactionManager != null) {
+                int status = transactionManager.getStatus();
+                return status == Status.STATUS_ACTIVE || status == Status.STATUS_MARKED_ROLLBACK;
+            }
+        } catch (SystemException e) {
+            LOG.trace("Failed to check transaction status", e);
+        }
+        return false;
+    }
+}

--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/MockDataRepository.java
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/MockDataRepository.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.jpa.quarkus;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionManager;
+
+/**
+ * Mock repository that tracks data persistence attempts and simulates
+ * transactional behavior to verify that rollbacks prevent duplicate data.
+ */
+@ApplicationScoped
+public class MockDataRepository {
+
+    private final ConcurrentHashMap<String, AtomicInteger> committedData = new ConcurrentHashMap<>();
+    private final AtomicInteger totalPersistenceAttempts = new AtomicInteger(0);
+    private final AtomicInteger successfulCommits = new AtomicInteger(0);
+    private final AtomicInteger rolledBackAttempts = new AtomicInteger(0);
+
+    private TransactionManager transactionManager;
+
+    public void setTransactionManager(TransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
+    }
+
+    /**
+     * Simulates persisting data within a transaction.
+     * If the transaction is rolled back, the data should not be committed.
+     */
+    public void persistData(String key, String value) {
+        totalPersistenceAttempts.incrementAndGet();
+
+        // Register a transaction synchronization to track commit/rollback
+        if (transactionManager != null) {
+            try {
+                if (transactionManager.getStatus() == Status.STATUS_ACTIVE) {
+                    transactionManager.getTransaction().registerSynchronization(new Synchronization() {
+                        @Override
+                        public void beforeCompletion() {
+                            // Nothing to do before completion
+                        }
+
+                        @Override
+                        public void afterCompletion(int status) {
+                            if (status == Status.STATUS_COMMITTED) {
+                                // Only commit the data if transaction succeeds
+                                committedData.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+                                successfulCommits.incrementAndGet();
+                            } else if (status == Status.STATUS_ROLLEDBACK) {
+                                rolledBackAttempts.incrementAndGet();
+                            }
+                        }
+                    });
+                } else {
+                    // No active transaction - commit immediately (shouldn't happen in our tests)
+                    committedData.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+                    successfulCommits.incrementAndGet();
+                }
+            } catch (Exception e) {
+                // If we can't register synchronization, commit immediately
+                committedData.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+                successfulCommits.incrementAndGet();
+            }
+        } else {
+            // No transaction manager - commit immediately
+            committedData.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+            successfulCommits.incrementAndGet();
+        }
+    }
+
+    public int getCommittedCount(String key) {
+        AtomicInteger count = committedData.get(key);
+        return count != null ? count.get() : 0;
+    }
+
+    public int getTotalPersistenceAttempts() {
+        return totalPersistenceAttempts.get();
+    }
+
+    public int getSuccessfulCommits() {
+        return successfulCommits.get();
+    }
+
+    public int getRolledBackAttempts() {
+        return rolledBackAttempts.get();
+    }
+
+    public void reset() {
+        committedData.clear();
+        totalPersistenceAttempts.set(0);
+        successfulCommits.set(0);
+        rolledBackAttempts.set(0);
+    }
+}
+

--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/MockDataRepository.java
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/MockDataRepository.java
@@ -113,4 +113,3 @@ public class MockDataRepository {
         rolledBackAttempts.set(0);
     }
 }
-

--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/QuarkusTransactionRollbackTest.java
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/QuarkusTransactionRollbackTest.java
@@ -155,4 +155,3 @@ public class QuarkusTransactionRollbackTest {
     }
 
 }
-

--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/QuarkusTransactionRollbackTest.java
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/QuarkusTransactionRollbackTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.jpa.quarkus;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.app.jobs.quarkus.QuarkusJobsService;
+import org.kie.kogito.app.jobs.quarkus.QuarkusTransactionRollbackMarker;
+import org.kie.kogito.jobs.ExactExpirationTime;
+import org.kie.kogito.jobs.JobsService;
+import org.kie.kogito.jobs.descriptors.ProcessInstanceJobDescription;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.Status;
+import jakarta.transaction.TransactionManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+public class QuarkusTransactionRollbackTest {
+
+    @Inject
+    JobsService jobsService;
+
+    @Inject
+    TestJobSchedulerListener listener;
+
+    @Inject
+    TestJobExecutor testJobExecutor;
+
+    @Inject
+    TestExceptionHandler exceptionHandler;
+
+    @Inject
+    QuarkusTransactionRollbackMarker transactionRollbackMarker;
+
+    @Inject
+    TransactionManager transactionManager;
+
+    @Inject
+    MockDataRepository mockDataRepository;
+
+    @BeforeEach
+    public void init() {
+        ((QuarkusJobsService) jobsService).init();
+        testJobExecutor.reset();
+        exceptionHandler.reset();
+        mockDataRepository.reset();
+        mockDataRepository.setTransactionManager(transactionManager);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        ((QuarkusJobsService) jobsService).destroy();
+    }
+
+    @Test
+    public void testTransactionRollbackMarkerInjected() {
+        assertThat(transactionRollbackMarker).isNotNull();
+        assertThat(transactionRollbackMarker.isTransactionActive()).isFalse();
+    }
+
+    @Test
+    public void testTransactionRollbackOnJobFailure() throws Exception {
+        // Configure the test executor to fail 4 times (initial + 3 retries)
+        testJobExecutor.setNumberOfFailures(4);
+
+        ProcessInstanceJobDescription jobDescription = new ProcessInstanceJobDescription(
+                "rollback-test-job",
+                "-1",
+                ExactExpirationTime.of(Instant.now().plus(Duration.ofSeconds(2)).atZone(ZoneId.of("UTC"))),
+                5,
+                "test-process-instance",
+                null,
+                "test-process",
+                null,
+                "test-node-instance");
+
+        listener.setCount(4);
+        jobsService.scheduleJob(jobDescription);
+
+        // Wait for all retries to complete and error handler to be invoked
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10L))
+                .untilAsserted(() -> {
+                    assertThat(exceptionHandler.isError())
+                            .as("Error handler should be invoked after max retries")
+                            .isTrue();
+                });
+
+        assertThat(listener.await(1, java.util.concurrent.TimeUnit.SECONDS))
+                .as("All job executions should have been attempted")
+                .isTrue();
+
+        assertThat(mockDataRepository.getTotalPersistenceAttempts())
+                .as("Should have 4 persistence attempts (initial + 3 retries)")
+                .isEqualTo(4);
+
+        assertThat(mockDataRepository.getRolledBackAttempts())
+                .as("All failed attempts should have been rolled back")
+                .isEqualTo(4);
+
+        assertThat(mockDataRepository.getSuccessfulCommits())
+                .as("No data should be committed when all attempts fail")
+                .isEqualTo(0);
+
+        assertThat(mockDataRepository.getCommittedCount("rollback-test-job"))
+                .as("No duplicate data should be persisted due to rollback")
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void testTransactionRollbackMarkerFunctionality() throws Exception {
+        assertThat(transactionRollbackMarker.isTransactionActive()).isFalse();
+
+        transactionManager.begin();
+        try {
+            assertThat(transactionRollbackMarker.isTransactionActive()).isTrue();
+
+            transactionRollbackMarker.markForRollback();
+
+            // Verify the transaction is marked for rollback
+            assertThat(transactionManager.getStatus())
+                    .as("Transaction should be marked for rollback")
+                    .isEqualTo(Status.STATUS_MARKED_ROLLBACK);
+        } finally {
+            transactionManager.rollback();
+        }
+
+        assertThat(transactionRollbackMarker.isTransactionActive()).isFalse();
+    }
+
+}
+

--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/TestJobExecutor.java
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/jpa/quarkus/TestJobExecutor.java
@@ -23,6 +23,7 @@ import org.kie.kogito.jobs.service.model.JobDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 @Singleton
@@ -30,6 +31,9 @@ public class TestJobExecutor implements JobExecutor {
 
     private Logger LOG = LoggerFactory.getLogger(TestJobExecutor.class);
     private int numberOfFailures;
+
+    @Inject
+    MockDataRepository mockDataRepository;
 
     @Override
     public boolean accept(JobDetails jobDescription) {
@@ -39,6 +43,12 @@ public class TestJobExecutor implements JobExecutor {
     @Override
     public void execute(JobDetails jobDescription) {
         LOG.info("executing {}", jobDescription);
+
+        // Simulate data persistence (e.g., creating a user task)
+        if (mockDataRepository != null) {
+            mockDataRepository.persistData(jobDescription.getId(), "execution-data");
+        }
+
         if (numberOfFailures > 0) {
             --numberOfFailures;
             throw new RuntimeException();

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringBootTransactionRollbackMarker.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringBootTransactionRollbackMarker.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.springboot;
+
+import org.kie.kogito.app.jobs.spi.TransactionRollbackMarker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Component
+public class SpringBootTransactionRollbackMarker implements TransactionRollbackMarker {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpringBootTransactionRollbackMarker.class);
+
+    @Override
+    public void markForRollback() {
+        try {
+            if (isTransactionActive()) {
+                TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+                LOG.debug("Marked transaction for rollback due to exception in job execution (Spring Boot)");
+            } else {
+                LOG.trace("No active transaction to mark for rollback");
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to mark transaction for rollback", e);
+        }
+    }
+
+    @Override
+    public boolean isTransactionActive() {
+        return TransactionSynchronizationManager.isActualTransactionActive();
+    }
+}

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringBootTransactionRollbackMarker.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringBootTransactionRollbackMarker.java
@@ -22,7 +22,7 @@ import org.kie.kogito.app.jobs.spi.TransactionRollbackMarker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.interceptor.TransactionAspectSupport;
+import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
@@ -30,17 +30,27 @@ public class SpringBootTransactionRollbackMarker implements TransactionRollbackM
 
     private static final Logger LOG = LoggerFactory.getLogger(SpringBootTransactionRollbackMarker.class);
 
+    // Thread-local to store the current TransactionStatus for TransactionTemplate usage
+    private static final ThreadLocal<TransactionStatus> CURRENT_TRANSACTION_STATUS = new ThreadLocal<>();
+
+    public static void setCurrentTransactionStatus(TransactionStatus status) {
+        CURRENT_TRANSACTION_STATUS.set(status);
+    }
+
+    public static void clearCurrentTransactionStatus() {
+        CURRENT_TRANSACTION_STATUS.remove();
+    }
+
     @Override
     public void markForRollback() {
-        try {
-            if (isTransactionActive()) {
-                TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
-                LOG.debug("Marked transaction for rollback due to exception in job execution (Spring Boot)");
+        if (isTransactionActive()) {
+            TransactionStatus status = CURRENT_TRANSACTION_STATUS.get();
+            if (status != null) {
+                status.setRollbackOnly();
+                LOG.debug("Transaction marked for rollback using TransactionStatus");
             } else {
-                LOG.trace("No active transaction to mark for rollback");
+                LOG.warn("No TransactionStatus available to mark for rollback");
             }
-        } catch (Exception e) {
-            LOG.warn("Failed to mark transaction for rollback", e);
         }
     }
 

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringbootJobsService.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringbootJobsService.java
@@ -32,6 +32,7 @@ import org.kie.kogito.app.jobs.integrations.ProcessJobDescriptionJobInstanceEven
 import org.kie.kogito.app.jobs.integrations.UserTaskInstanceJobDescriptionJobInstanceEventAdapter;
 import org.kie.kogito.app.jobs.spi.JobContextFactory;
 import org.kie.kogito.app.jobs.spi.JobStore;
+import org.kie.kogito.app.jobs.spi.TransactionRollbackMarker;
 import org.kie.kogito.app.jobs.springboot.resource.RestApiConstants;
 import org.kie.kogito.event.EventPublisher;
 import org.kie.kogito.handler.ExceptionHandler;
@@ -93,6 +94,9 @@ public class SpringbootJobsService implements JobsService {
     @Autowired
     protected WrappingConditionalJobExceptionDetailsExtractor exceptionDetailsExtractor;
 
+    @Autowired
+    protected TransactionRollbackMarker transactionRollbackMarker;
+
     @PostConstruct
     public void init() {
         this.jobScheduler = JobSchedulerBuilder.newJobSchedulerBuilder()
@@ -113,6 +117,7 @@ public class SpringbootJobsService implements JobsService {
                         new TransactionJobTimeoutInterceptor(transactionManager),
                         new ErrorHandlingJobTimeoutInterceptor(ofNullable(exceptionHandlers).stream().toList()))
                 .withExceptionDetailsExtractor(exceptionDetailsExtractor)
+                .withTransactionRollbackMarker(transactionRollbackMarker)
                 .withNumberOfWorkerThreads(numberOfWorkerThreads)
                 .withJobSynchronization(new JobSynchronization() {
 

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringbootJobsService.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringbootJobsService.java
@@ -114,8 +114,8 @@ public class SpringbootJobsService implements JobsService {
                 .withMaxNumberOfRetries(maxNumberOfRetries)
                 .withRefreshJobsInterval(maxRefreshJobsIntervalWindow * 60 * 1000L)
                 .withTimeoutInterceptor(
-                        new TransactionJobTimeoutInterceptor(transactionManager),
-                        new ErrorHandlingJobTimeoutInterceptor(ofNullable(exceptionHandlers).stream().toList()))
+                        new ErrorHandlingJobTimeoutInterceptor(ofNullable(exceptionHandlers).stream().toList()),
+                        new TransactionJobTimeoutInterceptor(transactionManager))
                 .withExceptionDetailsExtractor(exceptionDetailsExtractor)
                 .withTransactionRollbackMarker(transactionRollbackMarker)
                 .withNumberOfWorkerThreads(numberOfWorkerThreads)

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/TransactionJobTimeoutInterceptor.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/TransactionJobTimeoutInterceptor.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Callable;
 import org.kie.kogito.app.jobs.api.JobTimeoutExecution;
 import org.kie.kogito.app.jobs.api.JobTimeoutInterceptor;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 public class TransactionJobTimeoutInterceptor implements JobTimeoutInterceptor {
@@ -41,9 +42,25 @@ public class TransactionJobTimeoutInterceptor implements JobTimeoutInterceptor {
             public JobTimeoutExecution call() throws Exception {
                 return transactionTemplate.execute(status -> {
                     try {
+                        // Initialize transaction synchronization if not already active
+                        // This is needed for TransactionSynchronizationManager callbacks to work
+                        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+                            TransactionSynchronizationManager.initSynchronization();
+                        }
+
+                        // Store the transaction status in thread-local for SpringBootTransactionRollbackMarker
+                        SpringBootTransactionRollbackMarker.setCurrentTransactionStatus(status);
+
                         return callable.call();
+                    } catch (RuntimeException e) {
+                        // Re-throw RuntimeException to trigger rollback
+                        throw e;
                     } catch (Exception e) {
+                        // Wrap checked exceptions in RuntimeException to trigger rollback
                         throw new RuntimeException(e);
+                    } finally {
+                        // Clear the transaction status from thread-local
+                        SpringBootTransactionRollbackMarker.clearCurrentTransactionStatus();
                     }
                 });
             }

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/MockDataRepository.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/MockDataRepository.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.springboot;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * Mock repository that tracks data persistence attempts and simulates
+ * transactional behavior to verify that rollbacks prevent duplicate data.
+ */
+@Component
+public class MockDataRepository {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MockDataRepository.class);
+
+    private final ConcurrentHashMap<String, AtomicInteger> committedData = new ConcurrentHashMap<>();
+    private final AtomicInteger totalPersistenceAttempts = new AtomicInteger(0);
+    private final AtomicInteger successfulCommits = new AtomicInteger(0);
+    private final AtomicInteger rolledBackAttempts = new AtomicInteger(0);
+
+    /**
+     * Simulates persisting data within a transaction.
+     * If the transaction is rolled back, the data should not be committed.
+     */
+    public void persistData(String key, String value) {
+        totalPersistenceAttempts.incrementAndGet();
+
+        // Register a transaction synchronization to track commit/rollback
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    // Only commit the data if transaction succeeds
+                    committedData.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+                    successfulCommits.incrementAndGet();
+                }
+
+                @Override
+                public void afterCompletion(int status) {
+                    if (status == STATUS_ROLLED_BACK) {
+                        rolledBackAttempts.incrementAndGet();
+                    }
+                }
+            });
+        } else {
+            // No transaction active - commit immediately (shouldn't happen in our tests)
+            committedData.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+            successfulCommits.incrementAndGet();
+        }
+    }
+
+    public int getCommittedCount(String key) {
+        AtomicInteger count = committedData.get(key);
+        return count != null ? count.get() : 0;
+    }
+
+    public int getTotalPersistenceAttempts() {
+        return totalPersistenceAttempts.get();
+    }
+
+    public int getSuccessfulCommits() {
+        return successfulCommits.get();
+    }
+
+    public int getRolledBackAttempts() {
+        return rolledBackAttempts.get();
+    }
+
+    public void reset() {
+        committedData.clear();
+        totalPersistenceAttempts.set(0);
+        successfulCommits.set(0);
+        rolledBackAttempts.set(0);
+    }
+}

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/SpringBootTransactionRollbackTest.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/SpringBootTransactionRollbackTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.app.jobs.springboot;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.jobs.ExactExpirationTime;
+import org.kie.kogito.jobs.JobsService;
+import org.kie.kogito.jobs.descriptors.ProcessInstanceJobDescription;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class SpringBootTransactionRollbackTest {
+
+    @Autowired
+    JobsService jobsService;
+
+    @Autowired
+    TestJobSchedulerListener listener;
+
+    @Autowired
+    TestJobExecutor testJobExecutor;
+
+    @Autowired
+    TestExceptionHandler exceptionHandler;
+
+    @Autowired
+    SpringBootTransactionRollbackMarker transactionRollbackMarker;
+
+    @Autowired
+    PlatformTransactionManager transactionManager;
+
+    @Autowired
+    MockDataRepository mockDataRepository;
+
+    @BeforeEach
+    public void init() {
+        testJobExecutor.reset();
+        exceptionHandler.reset();
+        mockDataRepository.reset();
+    }
+
+    @Test
+    public void testTransactionRollbackMarkerInjected() {
+        assertThat(transactionRollbackMarker).isNotNull();
+        assertThat(transactionRollbackMarker.isTransactionActive()).isFalse();
+    }
+
+    @Test
+    public void testTransactionRollbackOnJobFailure() throws Exception {
+        // Configure the test executor to fail 4 times (initial + 3 retries)
+        testJobExecutor.setNumberOfFailures(4);
+
+        ProcessInstanceJobDescription jobDescription = new ProcessInstanceJobDescription(
+                "rollback-test-job",
+                "-1",
+                ExactExpirationTime.of(Instant.now().plus(Duration.ofSeconds(2)).atZone(ZoneId.of("UTC"))),
+                5,
+                "test-process-instance",
+                null,
+                "test-process",
+                null,
+                "test-node-instance");
+
+        listener.setCount(4);
+        jobsService.scheduleJob(jobDescription);
+
+        // Wait for all retries to complete and error handler to be invoked
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10L))
+                .untilAsserted(() -> {
+                    assertThat(exceptionHandler.isError())
+                            .as("Error handler should be invoked after max retries")
+                            .isTrue();
+                });
+
+        assertThat(listener.await(1, java.util.concurrent.TimeUnit.SECONDS))
+                .as("All job executions should have been attempted")
+                .isTrue();
+
+        assertThat(mockDataRepository.getTotalPersistenceAttempts())
+                .as("Should have 4 persistence attempts (initial + 3 retries)")
+                .isEqualTo(4);
+
+        assertThat(mockDataRepository.getRolledBackAttempts())
+                .as("All failed attempts should have been rolled back by Spring")
+                .isEqualTo(4);
+
+        assertThat(mockDataRepository.getSuccessfulCommits())
+                .as("No data should be committed when all attempts fail")
+                .isEqualTo(0);
+
+        assertThat(mockDataRepository.getCommittedCount("rollback-test-job"))
+                .as("No duplicate data should be persisted due to automatic rollback")
+                .isEqualTo(0);
+    }
+}

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/TestJobExecutor.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/test/java/org/kie/kogito/app/jobs/springboot/TestJobExecutor.java
@@ -22,6 +22,7 @@ import org.kie.kogito.app.jobs.api.JobExecutor;
 import org.kie.kogito.jobs.service.model.JobDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,9 @@ public class TestJobExecutor implements JobExecutor {
     private Logger LOG = LoggerFactory.getLogger(TestJobExecutor.class);
     private int numberOfFailures;
 
+    @Autowired(required = false)
+    private MockDataRepository mockDataRepository;
+
     @Override
     public boolean accept(JobDetails jobDescription) {
         return true;
@@ -41,6 +45,12 @@ public class TestJobExecutor implements JobExecutor {
     @Override
     public void execute(JobDetails jobDescription) {
         LOG.info("executing {}", jobDescription);
+
+        // Simulate data persistence (e.g., creating a user task)
+        if (mockDataRepository != null) {
+            mockDataRepository.persistData(jobDescription.getId(), "execution-data");
+        }
+
         if (numberOfFailures > 0) {
             --numberOfFailures;
             throw new RuntimeException();


### PR DESCRIPTION
Closes https://github.com/apache/incubator-kie-issues/issues/2311

Note that the PR does not attempt to resolve the duplicate key constraint violation reported in the issue. Instead, it improves the error handling if one of the job execution threads encounters an issue (which could also be caused by parallel updates of the same process instance). The solution here is to allow the failing transaction to be rolled back, while executing the retry logic in a new transaction.