### PR TITLE
Fix CVE-2024-6763, CVE-2025-11143, CVE-2026-2332: Replace wiremock with wiremock-jetty12

### DIFF
--- a/kogito-apps-quarkus/data-index-quarkus/data-index-service-mongodb/pom.xml
+++ b/kogito-apps-quarkus/data-index-quarkus/data-index-service-mongodb/pom.xml
@@ -130,7 +130,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-common-quarkus/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-common-quarkus/pom.xml
@@ -83,7 +83,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-embedded/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
     <!--  keep build order in place -->

--- a/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-knative-eventing/pom.xml
@@ -77,7 +77,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-management/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-management/pom.xml
@@ -101,7 +101,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-messaging/pom.xml
+++ b/kogito-apps-quarkus/integration-tests-jobs-service-quarkus/integration-tests-jobs-service-quarkus-messaging/pom.xml
@@ -101,7 +101,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-recipients/job-http-recipient/deployment/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-recipients/job-http-recipient/deployment/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-common/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-common/pom.xml
@@ -185,7 +185,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-infinispan/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-infinispan/pom.xml
@@ -119,7 +119,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jetty12</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-inmemory/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-inmemory/pom.xml
@@ -109,7 +109,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jetty12</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-mongodb/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-mongodb/pom.xml
@@ -106,7 +106,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jetty12</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-postgresql-common/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-postgresql-common/pom.xml
@@ -102,7 +102,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jetty12</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-storage-jpa/pom.xml
+++ b/kogito-apps-quarkus/jobs-service-quarkus/jobs-service-storage-jpa/pom.xml
@@ -123,7 +123,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jetty12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This PR replaces the `wiremock` artifact with `wiremock-jetty12` in test dependencies to resolve four Jetty CVEs.

**Background**
This change is part of a coordinated fix across multiple repositories to upgrade Jetty from 11.0.24 to 12.0.33. The parent repository (Drools kie-parent) has been updated to manage Jetty 12.0.33 and WireMock 3.13.2.

**Changes Made**
Replaced `wiremock` with `wiremock-jetty12` in 13 pom.xml files:

**Impact
- All test dependencies now use `wiremock-jetty12` which pulls Jetty 12.0.33
- Inherits Jetty version management from Drools kie-parent
- No functional changes to tests

**CVEs Resolved**
- CVE-2024-6763 (Critical)
- CVE-2025-11143 (Critical)
- CVE-2026-2332 (High)
- CVE-2025-5115

**Dependencies**
- Requires Drools kie-parent PR to be merged first