### PR TITLE
[incubator-kie-issues#2350] QuarkusJobsService / SpringbootJobsService throw IllegalStateException when transaction is not active

### DIFF
--- a/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/QuarkusJobsService.java
+++ b/kogito-apps-quarkus/jobs-quarkus/kogito-addons-quarkus-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/quarkus/QuarkusJobsService.java
@@ -119,6 +119,9 @@ public class QuarkusJobsService implements JobsService {
 
                     @Override
                     public void synchronize(Runnable action) {
+                        if (registry.getTransactionStatus() != Status.STATUS_ACTIVE) {
+                            return;
+                        }
                         registry.registerInterposedSynchronization(new Synchronization() {
 
                             @Override

--- a/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringbootJobsService.java
+++ b/kogito-apps-springboot/jobs-springboot/kogito-addons-springboot-embedded-jobs/src/main/java/org/kie/kogito/app/jobs/springboot/SpringbootJobsService.java
@@ -118,6 +118,9 @@ public class SpringbootJobsService implements JobsService {
 
                     @Override
                     public void synchronize(Runnable action) {
+                        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+                            return;
+                        }
                         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                             @Override
                             public void afterCommit() {


### PR DESCRIPTION

`QuarkusJobsService.synchronize()` and `SpringbootJobsService.synchronize()` register a transaction synchronization unconditionally. If the transaction is no longer active, this throws:
` java.lang.IllegalStateException: Syncs are not allowed to be registered when the transaction is in state 1`


Added guard for both. Skip's registration when the transaction is not active. The action only runs on commit, so a rolled-back transaction would never execute it, skipping is safe.

Closes: https://github.com/apache/incubator-kie-issues/issues/2350