### PR TITLE
[incubator-kie-issues#2382] Handle concurrent duplicate ProcessDefinition insert

### DIFF
--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessDefinitionEntityStorage.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/main/java/org/kie/kogito/index/jpa/storage/ProcessDefinitionEntityStorage.java
@@ -19,18 +19,27 @@
 package org.kie.kogito.index.jpa.storage;
 
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
+import org.hibernate.exception.ConstraintViolationException;
 import org.kie.kogito.index.jpa.mapper.ProcessDefinitionEntityMapper;
 import org.kie.kogito.index.jpa.model.ProcessDefinitionEntity;
 import org.kie.kogito.index.model.ProcessDefinition;
 import org.kie.kogito.index.model.ProcessDefinitionKey;
 import org.kie.kogito.process.Processes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
 
 import jakarta.persistence.EntityManager;
 
 import static org.kie.kogito.index.DependencyInjectionUtils.getInstance;
 
 public class ProcessDefinitionEntityStorage extends AbstractStorage<ProcessDefinitionKey, ProcessDefinitionEntity, ProcessDefinition> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessDefinitionEntityStorage.class);
 
     protected ProcessDefinitionEntityStorage() {
     }
@@ -42,6 +51,24 @@ public class ProcessDefinitionEntityStorage extends AbstractStorage<ProcessDefin
     public ProcessDefinitionEntityStorage(EntityManager em, Iterable<JsonPredicateBuilder> predicateBuilder, ProcessDefinitionEntityMapper mapper, Iterable<Processes> processes) {
         super(em, ProcessDefinition.class, ProcessDefinitionEntity.class, mapper::mapToModel, mapper.INSTANCE::mapToEntity, e -> new ProcessDefinitionKey(e.getId(),
                 e.getVersion()), Optional.ofNullable(getInstance(predicateBuilder)), Optional.ofNullable(getInstance(processes)));
+    }
+
+    protected ProcessDefinition put(ProcessDefinitionKey key, ProcessDefinition value,
+            Function<Supplier<ProcessDefinition>, ProcessDefinition> isolatedTransaction) {
+        try {
+            return isolatedTransaction.apply(() -> {
+                super.put(key, value);
+                em.flush();
+                return value;
+            });
+        } catch (RuntimeException e) {
+            if (Throwables.getCausalChain(e).stream().noneMatch(ConstraintViolationException.class::isInstance)) {
+                throw e;
+            }
+            LOGGER.info("ProcessDefinition with id '{}' and version '{}' is already present, skipping insert.", key.getId(), key.getVersion());
+            LOGGER.debug("Duplicate ProcessDefinition insert suppressed", e);
+            return get(key);
+        }
     }
 
 }

--- a/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractConcurrentProcessDefinitionStorageIT.java
+++ b/data-index/data-index-storage/data-index-storage-jpa-common/src/test/java/org/kie/kogito/index/jpa/storage/AbstractConcurrentProcessDefinitionStorageIT.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.index.jpa.storage;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.sql.DataSource;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.kie.kogito.index.model.ProcessDefinition;
+import org.kie.kogito.index.model.ProcessDefinitionKey;
+import org.kie.kogito.index.test.TestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * A competing replica is simulated with a plain JDBC connection that inserts the same definition and commits
+ * only once the insert of the storage is queued behind it on the primary key index, which is what PostgreSQL
+ * does and what makes that insert fail with a duplicate key.
+ */
+public abstract class AbstractConcurrentProcessDefinitionStorageIT {
+
+    private static final String INSERT_DEFINITION = "insert into definitions (id, version, name, type) values (?, ?, ?, ?)";
+    private static final String COUNT_PENDING_LOCKS = "select count(*) from pg_locks where not granted and pid <> pg_backend_pid()";
+    private static final long LOCK_POLL_TIMEOUT_MILLIS = 15_000;
+    private static final long LOCK_POLL_INTERVAL_MILLIS = 100;
+
+    private final ProcessDefinitionEntityStorage storage;
+    private final DataSource dataSource;
+
+    protected AbstractConcurrentProcessDefinitionStorageIT(ProcessDefinitionEntityStorage storage, DataSource dataSource) {
+        this.storage = storage;
+        this.dataSource = dataSource;
+    }
+
+    protected abstract void executeInTransaction(Runnable operation);
+
+    @Test
+    void testConcurrentRegistrationOfTheSameProcessDefinition() throws Exception {
+        String processId = RandomStringUtils.randomAlphabetic(10);
+        String version = "2.0";
+        ProcessDefinitionKey key = new ProcessDefinitionKey(processId, version);
+        ProcessDefinition definition = TestUtils.createProcessDefinition(processId, version, Set.of("admin", "kogito"));
+
+        AtomicReference<ProcessDefinition> indexed = new AtomicReference<>();
+        AtomicBoolean indexingInsertBlocked = new AtomicBoolean();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CountDownLatch indexingStarted = new CountDownLatch(1);
+        try (Connection otherReplica = dataSource.getConnection()) {
+            otherReplica.setAutoCommit(false);
+            insertDefinition(otherReplica, processId, version);
+
+            Future<?> commitOfTheOtherReplica = executor.submit(() -> {
+                try {
+                    indexingStarted.await();
+                    indexingInsertBlocked.set(waitForTheIndexingInsertToBlock(otherReplica));
+                } finally {
+                    otherReplica.commit();
+                }
+                return null;
+            });
+
+            indexingStarted.countDown();
+            assertThatCode(() -> executeInTransaction(() -> indexed.set(storage.put(key, definition)))).doesNotThrowAnyException();
+
+            commitOfTheOtherReplica.get(1, TimeUnit.MINUTES);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(indexingInsertBlocked).as("the storage never queued its insert behind the other replica, the race was not reproduced").isTrue();
+        assertThat(indexed.get()).isNotNull().extracting(ProcessDefinition::getId, ProcessDefinition::getVersion, ProcessDefinition::getName)
+                .containsExactly(processId, version, processId);
+        assertThat(storage.get(key)).isEqualTo(indexed.get());
+    }
+
+    private void insertDefinition(Connection connection, String processId, String version) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(INSERT_DEFINITION)) {
+            statement.setString(1, processId);
+            statement.setString(2, version);
+            statement.setString(3, processId);
+            statement.setString(4, "PROCESS");
+            statement.executeUpdate();
+        }
+    }
+
+    private boolean waitForTheIndexingInsertToBlock(Connection connection) throws Exception {
+        long deadline = System.currentTimeMillis() + LOCK_POLL_TIMEOUT_MILLIS;
+        while (System.currentTimeMillis() < deadline) {
+            Thread.sleep(LOCK_POLL_INTERVAL_MILLIS);
+            try (PreparedStatement statement = connection.prepareStatement(COUNT_PENDING_LOCKS);
+                    ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next() && resultSet.getInt(1) > 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-jpa-quarkus/src/main/java/org/kie/kogito/index/jpa/quarkus/QuarkusProcessDefinitionEntityStorage.java
+++ b/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-jpa-quarkus/src/main/java/org/kie/kogito/index/jpa/quarkus/QuarkusProcessDefinitionEntityStorage.java
@@ -19,16 +19,20 @@
 package org.kie.kogito.index.jpa.quarkus;
 
 import java.util.Collections;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.kie.kogito.index.jpa.storage.JsonPredicateBuilder;
 import org.kie.kogito.index.jpa.storage.ProcessDefinitionEntityStorage;
+import org.kie.kogito.index.model.ProcessDefinition;
+import org.kie.kogito.index.model.ProcessDefinitionKey;
 import org.kie.kogito.process.Processes;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 
 @ApplicationScoped
 public class QuarkusProcessDefinitionEntityStorage extends ProcessDefinitionEntityStorage {
@@ -37,6 +41,16 @@ public class QuarkusProcessDefinitionEntityStorage extends ProcessDefinitionEnti
     public QuarkusProcessDefinitionEntityStorage(EntityManager em, Instance<JsonPredicateBuilder> predicateBuilder, Instance<Processes> processesInstance,
             @ConfigProperty(name = "kogito.persistence.data-isolation.enabled", defaultValue = "false") Boolean dataIsolationEnabled) {
         super(em, predicateBuilder, dataIsolationEnabled ? processesInstance : Collections.emptyList());
+    }
+
+    @Override
+    public ProcessDefinition put(ProcessDefinitionKey key, ProcessDefinition value) {
+        return put(key, value, this::insertInNewTransaction);
+    }
+
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    protected ProcessDefinition insertInNewTransaction(Supplier<ProcessDefinition> insert) {
+        return insert.get();
     }
 
 }

--- a/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-jpa-quarkus/src/test/java/org/kie/kogito/index/jpa/quarkus/storage/PostgreSQLConcurrentProcessDefinitionStorageIT.java
+++ b/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-jpa-quarkus/src/test/java/org/kie/kogito/index/jpa/quarkus/storage/PostgreSQLConcurrentProcessDefinitionStorageIT.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.index.jpa.quarkus.storage;
+
+import javax.sql.DataSource;
+
+import org.kie.kogito.index.jpa.quarkus.PostgreSQLQuarkusTestProfile;
+import org.kie.kogito.index.jpa.storage.AbstractConcurrentProcessDefinitionStorageIT;
+import org.kie.kogito.index.jpa.storage.ProcessDefinitionEntityStorage;
+import org.kie.kogito.testcontainers.quarkus.PostgreSqlQuarkusTestResource;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+import jakarta.inject.Inject;
+
+@QuarkusTest
+@QuarkusTestResource(value = PostgreSqlQuarkusTestResource.class, restrictToAnnotatedClass = true)
+@TestProfile(PostgreSQLQuarkusTestProfile.class)
+class PostgreSQLConcurrentProcessDefinitionStorageIT extends AbstractConcurrentProcessDefinitionStorageIT {
+
+    @Inject
+    public PostgreSQLConcurrentProcessDefinitionStorageIT(ProcessDefinitionEntityStorage storage, DataSource dataSource) {
+        super(storage, dataSource);
+    }
+
+    @Override
+    protected void executeInTransaction(Runnable operation) {
+        QuarkusTransaction.requiringNew().run(operation);
+    }
+}

--- a/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-postgresql/src/main/java/org/kie/kogito/index/postgresql/QuarkusProcessDefinitionEntityStorage.java
+++ b/kogito-apps-quarkus/data-index-storage-quarkus/data-index-storage-postgresql/src/main/java/org/kie/kogito/index/postgresql/QuarkusProcessDefinitionEntityStorage.java
@@ -19,16 +19,20 @@
 package org.kie.kogito.index.postgresql;
 
 import java.util.Collections;
+import java.util.function.Supplier;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.kie.kogito.index.jpa.storage.JsonPredicateBuilder;
 import org.kie.kogito.index.jpa.storage.ProcessDefinitionEntityStorage;
+import org.kie.kogito.index.model.ProcessDefinition;
+import org.kie.kogito.index.model.ProcessDefinitionKey;
 import org.kie.kogito.process.Processes;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 
 @ApplicationScoped
 public class QuarkusProcessDefinitionEntityStorage extends ProcessDefinitionEntityStorage {
@@ -37,6 +41,16 @@ public class QuarkusProcessDefinitionEntityStorage extends ProcessDefinitionEnti
     public QuarkusProcessDefinitionEntityStorage(EntityManager em, Instance<JsonPredicateBuilder> predicateBuilder, Instance<Processes> processesInstance,
             @ConfigProperty(name = "kogito.persistence.data-isolation.enabled", defaultValue = "false") Boolean dataIsolationEnabled) {
         super(em, predicateBuilder, dataIsolationEnabled ? processesInstance : Collections.emptyList());
+    }
+
+    @Override
+    public ProcessDefinition put(ProcessDefinitionKey key, ProcessDefinition value) {
+        return put(key, value, this::insertInNewTransaction);
+    }
+
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    protected ProcessDefinition insertInNewTransaction(Supplier<ProcessDefinition> insert) {
+        return insert.get();
     }
 
 }

--- a/kogito-apps-springboot/data-index-springboot/data-index-storage-jpa-springboot/src/main/java/org/kie/kogito/index/jpa/springboot/storage/DataIndexStorageProducer.java
+++ b/kogito-apps-springboot/data-index-springboot/data-index-storage-jpa-springboot/src/main/java/org/kie/kogito/index/jpa/springboot/storage/DataIndexStorageProducer.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.kie.kogito.index.api.DateTimeCoercing;
-import org.kie.kogito.index.jpa.mapper.ProcessDefinitionEntityMapper;
 import org.kie.kogito.index.jpa.mapper.ProcessInstanceEntityMapper;
 import org.kie.kogito.index.jpa.storage.*;
 import org.kie.kogito.index.storage.DataIndexStorageService;
@@ -43,16 +42,6 @@ public class DataIndexStorageProducer {
     @Bean
     public JobEntityStorage jobEntityStorage(EntityManager entityManager, @Autowired(required = false) List<Processes> processes) {
         return new JobEntityStorage(entityManager, dataIsolationEnabled ? processes : Collections.emptyList());
-    }
-
-    @Bean
-    public ProcessDefinitionEntityStorage processDefinitionEntityStorage(EntityManager entityManager,
-            @Autowired(required = false) List<JsonPredicateBuilder> jsonPredicateBuilders,
-            @Autowired(required = false) List<Processes> processes) {
-        return new ProcessDefinitionEntityStorage(entityManager,
-                jsonPredicateBuilders != null ? jsonPredicateBuilders : Collections.emptyList(),
-                ProcessDefinitionEntityMapper.INSTANCE,
-                dataIsolationEnabled ? processes : Collections.emptyList());
     }
 
     @Bean

--- a/kogito-apps-springboot/data-index-springboot/data-index-storage-jpa-springboot/src/main/java/org/kie/kogito/index/jpa/springboot/storage/SpringBootProcessDefinitionEntityStorage.java
+++ b/kogito-apps-springboot/data-index-springboot/data-index-storage-jpa-springboot/src/main/java/org/kie/kogito/index/jpa/springboot/storage/SpringBootProcessDefinitionEntityStorage.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.kie.kogito.index.jpa.springboot.storage;
+
+import java.util.Collections;
+
+import org.kie.kogito.index.jpa.mapper.ProcessDefinitionEntityMapper;
+import org.kie.kogito.index.jpa.storage.JsonPredicateBuilder;
+import org.kie.kogito.index.jpa.storage.ProcessDefinitionEntityStorage;
+import org.kie.kogito.index.model.ProcessDefinition;
+import org.kie.kogito.index.model.ProcessDefinitionKey;
+import org.kie.kogito.process.Processes;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import jakarta.persistence.EntityManager;
+
+@Component
+public class SpringBootProcessDefinitionEntityStorage extends ProcessDefinitionEntityStorage {
+
+    private final TransactionTemplate isolatedTransaction;
+
+    public SpringBootProcessDefinitionEntityStorage(EntityManager entityManager, ObjectProvider<JsonPredicateBuilder> jsonPredicateBuilders,
+            ObjectProvider<Processes> processes, PlatformTransactionManager transactionManager,
+            @Value("${kogito.persistence.data-isolation.enabled:false}") Boolean dataIsolationEnabled) {
+        super(entityManager, jsonPredicateBuilders, ProcessDefinitionEntityMapper.INSTANCE,
+                dataIsolationEnabled ? processes : Collections.emptyList());
+        this.isolatedTransaction = new TransactionTemplate(transactionManager);
+        this.isolatedTransaction.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+    @Override
+    public ProcessDefinition put(ProcessDefinitionKey key, ProcessDefinition value) {
+        return put(key, value, insert -> isolatedTransaction.execute(status -> insert.get()));
+    }
+
+}

--- a/kogito-apps-springboot/data-index-springboot/data-index-storage-jpa-springboot/src/test/java/org/kie/kogito/index/jpa/springboot/storage/PostgreSQLConcurrentProcessDefinitionStorageIT.java
+++ b/kogito-apps-springboot/data-index-springboot/data-index-storage-jpa-springboot/src/test/java/org/kie/kogito/index/jpa/springboot/storage/PostgreSQLConcurrentProcessDefinitionStorageIT.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.kie.kogito.index.jpa.springboot.storage;
+
+import javax.sql.DataSource;
+
+import org.kie.kogito.index.jpa.springboot.KogitoSpringBootApplication;
+import org.kie.kogito.index.jpa.storage.AbstractConcurrentProcessDefinitionStorageIT;
+import org.kie.kogito.index.jpa.storage.ProcessDefinitionEntityStorage;
+import org.kie.kogito.testcontainers.springboot.PostgreSqlSpringBootTestResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = KogitoSpringBootApplication.class)
+@ContextConfiguration(initializers = PostgreSqlSpringBootTestResource.class)
+@ActiveProfiles("postgresql")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class PostgreSQLConcurrentProcessDefinitionStorageIT extends AbstractConcurrentProcessDefinitionStorageIT {
+
+    private final TransactionTemplate transactionTemplate;
+
+    @Autowired
+    public PostgreSQLConcurrentProcessDefinitionStorageIT(ProcessDefinitionEntityStorage storage, DataSource dataSource,
+            PlatformTransactionManager transactionManager) {
+        super(storage, dataSource);
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+        this.transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+    @Override
+    protected void executeInTransaction(Runnable operation) {
+        transactionTemplate.executeWithoutResult(status -> operation.run());
+    }
+}


### PR DESCRIPTION
When a few replicas of the same app start together, they all see an empty state and insert the same `(id, version)` rows into `definitions`. All but the first hit a primary key violation and the replica dies on startup. 

The reason is  `em.merge()` only queues the INSERT, and `put` joins the transaction that indexing already runs in, so the INSERT is only sent when that outer transaction commits - after any `try`/`catch` around `put` has returned.

**Changes**

- **`ProcessDefinitionEntityStorage`** - new `put` overload with the actual fix: flush the insert right away so the failure happens where we can catch it, run it in a separate transaction so the rollback doesn't kill the caller's work, and on a duplicate just return the definition that's already stored.

- **`QuarkusProcessDefinitionEntityStorage`** (jpa-quarkus *and* postgresql) - overrides `put` to run the insert in a `@Transactional(REQUIRES_NEW)` method. Two copies of the same class, both used by an embedded add-on, so both need it.

- **`SpringBootProcessDefinitionEntityStorage`** (new, springboot) - same thing with a`TransactionTemplate`. `@Transactional` doesn't work here: Spring ignores it when a class calls its own method, so the insert would just run in the caller's transaction.

This is also why the catch sits *outside* the transaction, not inside, here a failed flush marks the transaction as rollback only, so the commit still fails after the `catch` has run. The exception is different too, Quarkus throws `ConstraintViolationException`, Spring Boot throws `DataIntegrityViolationException`.

- **`DataIndexStorageProducer`** (springboot) - removed the `processDefinitionEntityStorage` bean, otherwise there'd be two beans of the same type now that the class above provides it.

**Tests**

`AbstractConcurrentProcessDefinitionStorageIT` plus a PostgreSQL subclass per runtime. A plain JDBC connection acts as the competing replica, it inserts the row and holds it uncommitted, so the storage still sees nothing and queues its own insert, which blocks on the primary key index. The commit is triggered from `pg_locks` once that insert is actually waiting, so there are no sleeps.

Closes: https://github.com/apache/incubator-kie-issues/issues/2382
